### PR TITLE
fix: DB와 Service 계층 둘 모두에서 중복입력방지처리 추가

### DIFF
--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -32,6 +32,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CALENDAR_FORBIDDEN(HttpStatus.FORBIDDEN, "CALENDAR4002", "해당 캘린더 데이터를 조회할 권한이 없습니다."),
     CALENDAR_INVALID_DATE(HttpStatus.BAD_REQUEST, "CALENDAR4003", "유효하지 않은 날짜입니다."),
     CALENDAR_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CALENDAR5001", "캘린더 데이터를 처리하는 중 오류가 발생했습니다."),
+    THREAD_ALREADY_ENROLL(HttpStatus.BAD_REQUEST, "THREAD4001", "해당 날짜의 스레드가 이미 존재합니다."),
 
 
     // Auth

--- a/src/main/java/com/melissa/diary/domain/Thread.java
+++ b/src/main/java/com/melissa/diary/domain/Thread.java
@@ -18,7 +18,12 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "`thread`")
+@Table(
+        name = "thread",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "year", "month", "day"}) // 유저별 날짜 유니크 조건 추가
+        }
+)
 public class Thread {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/melissa/diary/domain/UserSetting.java
+++ b/src/main/java/com/melissa/diary/domain/UserSetting.java
@@ -11,6 +11,9 @@ import java.sql.Time;
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
+@Table(name = "user_setting", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id"}) // 유저당 하나만 존재하도록 유니크 제약 조건 추가
+})
 public class UserSetting {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/melissa/diary/service/ThreadService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadService.java
@@ -69,7 +69,7 @@ public class ThreadService {
                 .build();
     }
     private Thread createNewThread(User user, AiProfile aiProfile, int year, int month, int day) {
-        // 스레드 생성 및 저장
+        // 스레드 생성
         Thread newThread = Thread.builder()
                 .user(user)
                 .aiProfile(aiProfile)
@@ -77,9 +77,16 @@ public class ThreadService {
                 .month(month)
                 .day(day)
                 .build();
-        threadRepository.save(newThread);
 
-        // AI 프로필의 첫 채팅 내용을 DailyChatLog로 저장
+        // ====== 유니크 예외 방지를 위한 try-catch ======
+        try {
+            threadRepository.save(newThread);
+        } catch (org.springframework.dao.DataIntegrityViolationException e) {
+            // 이미 같은 (user, year, month, day)로 insert가 들어갔을 경우
+            throw new ErrorHandler(ErrorStatus.THREAD_ALREADY_ENROLL);
+        }
+
+        // AI 프로필의 첫 채팅 저장
         DailyChatLog firstChat = DailyChatLog.builder()
                 .role(Role.AI)
                 .content(aiProfile.getFirstChat())


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
DB와 Service 계층 둘 모두에서 중복입력방지처리 추가

- DB -> 키 값으로 유니크 설정
- Service -> db의 유니크 조건으로 터져도, try catch로 서비스 유지

## 📋 변경 사항
변경 사항이나 추가 사항을 작성해주세요.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
