### PR TITLE
feat: 일일요약 프롬프트 수정 및 ai 채팅 flux 리턴값 뒤에 null 제거해서 저장

### DIFF
--- a/src/main/java/com/melissa/diary/config/AiConfig.java
+++ b/src/main/java/com/melissa/diary/config/AiConfig.java
@@ -60,4 +60,25 @@ public class AiConfig {
                 .defaultSystem("사용자와 채팅을 나누면서, 일기를 작성할 정보를 추출하거나 공감해줘. 대답에서 해시태그는 사용하지마. {system}")
                 .build();
     }
+
+    @Bean(name = "summaryClient")
+    ChatClient summaryClient(){
+        OpenAiApi api = new OpenAiApi(apiKey);
+        OpenAiChatOptions options = OpenAiChatOptions.builder()
+                .model(OpenAiApi.ChatModel.GPT_4_O_MINI)
+                .temperature(0.5)
+                .build();
+
+        String system = """
+                당신은 사용자와의 대화를 통해 그림일기를 작성하는 전문 에이전트입니다.
+                - 대화에서 중요한 사건, 감정, 생각을 파악하여 그림일기 형식으로 정리합니다.
+                - 시간 순서와 인과관계를 고려하여 자연스럽게 이야기를 구성합니다.
+                - 사용자의 감정 변화를 섬세하게 반영하여 적절한 mood를 설정합니다.
+                - 그림일기에 어울리는 제목과 내용을 작성하고, 그림을 상상할 수 있도록 상세한 묘사를 포함합니다.
+                - 주제에 맞는 해시태그를 추가하여 일기의 특징을 강조합니다.""";
+
+        return ChatClient.builder(new OpenAiChatModel(api, options))
+                .defaultSystem(system)
+                .build();
+    }
 }

--- a/src/main/java/com/melissa/diary/service/ThreadService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadService.java
@@ -203,10 +203,13 @@ public class ThreadService {
                 })
                 .doOnError(e -> log.error("AI 응답 스트리밍 중 에러 발생", e))
                 .doOnComplete(() -> {
+
+                    String answer = aiAnswerBuilder.toString().replace("null", "").trim();
+
                     // 모든 응답이 완료되면 최종 AI 응답을 DB에 저장
                     DailyChatLog aiChat = DailyChatLog.builder()
                             .role(Role.AI)
-                            .content(aiAnswerBuilder.toString())
+                            .content(answer)
                             .thread(thread)
                             .aiProfile(aiProfile)
                             .createdAt(LocalDateTime.now())
@@ -214,7 +217,7 @@ public class ThreadService {
                     dailyChatLogRepository.save(aiChat);
                 });
 
-        // finish 이벤트를 내보내는 Flux (단일 이벤트)
+        // finish 이벤트를 내보내는 Flux (단일 이벤트) : 현성이 요청
         Flux<ServerSentEvent<String>> finishEventFlux = Flux.just(
                 ServerSentEvent.<String>builder()
                         .id(String.valueOf(System.currentTimeMillis()))


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- 일일요약 프롬프트 수정 (줄글요약, 이미지 생성)
- ai 채팅 flux 리턴값 뒤에 null 제거해서 저장 (flux의 끝에 null이 항상 붙는 문제 수정)

## 📋 변경 사항
- 요약된 String 저장시, replace를 활용해 뒤에 붙은 null 제거해서 저장
- 프론트에서는 flux를 streaming으로 보여준 이후, db에 저장된 값을 불러옴.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot (추억돋는 테스트 결과)

![image](https://github.com/user-attachments/assets/25b776d6-6694-4a82-87d3-1b4b7d6cdd59)
![image](https://github.com/user-attachments/assets/b646ca2e-3389-4a03-8ab5-af94a2d84b34)
