### PR TITLE
fix: 긴 메시지 전송으로 인한 sse 응답이 늦어지면서 hikari pool 커넥션 점유 및 쓰레드 풀 자원 고갈

### DIFF
--- a/src/main/java/com/melissa/diary/domain/DailyChatLog.java
+++ b/src/main/java/com/melissa/diary/domain/DailyChatLog.java
@@ -23,7 +23,7 @@ public class DailyChatLog {
     @Column(nullable = false)
     private Role role;
 
-    @Column(nullable = false) // 단순 채팅밖에 안됨
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     @CreatedDate

--- a/src/main/java/com/melissa/diary/domain/Thread.java
+++ b/src/main/java/com/melissa/diary/domain/Thread.java
@@ -55,7 +55,7 @@ public class Thread {
     private AiProfile aiProfile;
 
     // 아래부턴 요약필요라서 null 가능
-    @Column(nullable = true, length = 30)
+    @Column(nullable = true, length = 50)
     private String summaryTitle;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/melissa/diary/repository/ThreadRepository.java
+++ b/src/main/java/com/melissa/diary/repository/ThreadRepository.java
@@ -2,14 +2,25 @@ package com.melissa.diary.repository;
 
 import com.melissa.diary.domain.Thread;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ThreadRepository extends JpaRepository<Thread,Long> {
-    Optional<Thread> findByUserIdAndYearAndMonthAndDay(Long userId, int year, int month, int day);
+    @Query("SELECT DISTINCT t FROM Thread t LEFT JOIN FETCH t.dailyChatLogs " +
+            "WHERE t.user.id = :userId AND t.year = :year AND t.month = :month AND t.day = :day")
+    Optional<Thread> findByUserIdAndYearAndMonthAndDay(@Param("userId") Long userId,
+                                                       @Param("year") int year,
+                                                       @Param("month") int month,
+                                                       @Param("day") int day);
 
-    List<Thread> findByUserIdAndYearAndMonth(Long userId, int year, int month);
+    @Query("SELECT DISTINCT t FROM Thread t LEFT JOIN FETCH t.dailyChatLogs " +
+            "WHERE t.user.id = :userId AND t.year = :year AND t.month = :month")
+    List<Thread> findByUserIdAndYearAndMonth(@Param("userId") Long userId,
+                                             @Param("year") int year,
+                                             @Param("month") int month);
 
     void deleteAllByUserId(Long userId);
 

--- a/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
@@ -12,6 +12,7 @@ import com.melissa.diary.domain.enums.Role;
 import com.melissa.diary.repository.ThreadRepository;
 import com.melissa.diary.repository.UserRepository;
 import com.melissa.diary.repository.UserSettingRepository;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
@@ -23,6 +24,7 @@ import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
@@ -41,8 +43,13 @@ public class ThreadSummaryService {
     private final ChatClient summaryClient;
     private final ImageGenerator imageGenerator;
 
-    public ThreadSummaryService(UserRepository userRepository, ThreadRepository threadRepository, UserSettingRepository userSettingRepository,
-                                @Qualifier("summaryClient") ChatClient summaryClient, ImageGenerator imageGenerator) {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    public ThreadSummaryService(UserRepository userRepository,
+                                ThreadRepository threadRepository,
+                                UserSettingRepository userSettingRepository,
+                                @Qualifier("summaryClient")
+                                ChatClient summaryClient,
+                                ImageGenerator imageGenerator) {
         this.userRepository = userRepository;
         this.threadRepository = threadRepository;
         this.userSettingRepository = userSettingRepository;
@@ -50,31 +57,19 @@ public class ThreadSummaryService {
         this.imageGenerator = imageGenerator;
     }
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     /**
-     * 1시간마다 실행! -> 사용자 설정의 시간과 일치한 사용자들만 실행
+     * 매 정각 실행 – 사용자가 설정한 시간과 현재 시각의 시(hour)가 동일한 경우에만 요약 생성
      */
-    @Scheduled(cron = "0 0 * * * *") // 매 정각(00분)이 될 때마다 실행
-    @Transactional
+    @Scheduled(cron = "0 0 * * * *")
     public void generateDailySummaryForAllUsers() {
         LocalTime currentTime = LocalTime.now();
-
-        // 모든 유저 조회
         List<User> users = userRepository.findAll();
-
-        // 각 유저별 요약 스케줄 확인 및 요약 생성
         for (User user : users) {
-            // userSetting 가져오기
             UserSetting userSetting = userSettingRepository.findByUserId(user.getId())
                     .orElseThrow(() -> new ErrorHandler(ErrorStatus.SETTING_NOT_FOUND));
-
             LocalTime userSummaryTime = userSetting.getSleepTime().toLocalTime();
-
-            // 사용자가 설정한 요약 시간과 "현재 시간의 시"가 동일하다면 요약 진행
             if (currentTime.getHour() == userSummaryTime.getHour()) {
                 try {
-                    // 예: 오늘 날짜의 thread를 찾아서, ChatLog 요약
                     generateDailySummaryForUser(user.getId());
                 } catch (Exception e) {
                     log.error("[ThreadSummary] 요약 생성 실패. userId=" + user.getId(), e);
@@ -85,60 +80,68 @@ public class ThreadSummaryService {
 
     /**
      * 특정 유저의 오늘(또는 원하는 날짜)의 Thread에 대해 요약을 생성한다.
+     *
+     * → DB 조회/데이터 초기화는 짧은 트랜잭션(read-only)으로 처리한 후,
+     *    외부 API 호출(LLM, 이미지 생성)은 트랜잭션 외부에서 실행하고,
+     *    최종 업데이트는 별도의 신규 트랜잭션(REQUIRES_NEW)에서 처리한다.
      */
-    @Transactional
     public void generateDailySummaryForUser(Long userId) {
         LocalDateTime now = LocalDateTime.now();
         int year = now.getYear();
         int month = now.getMonthValue();
         int day = now.getDayOfMonth();
         int hour = now.getHour();
-
-        // 오전 8시 이전은 전날로
+        // 오전 8시 이전이면 전날로 처리
         if (hour < 8) {
             day -= 1;
         }
 
-        // Thread 조회
-        Thread thread = threadRepository.findByUserIdAndYearAndMonthAndDay(userId, year, month, day)
-                .orElse(null);
-
-        if (thread == null) {
+        // DB에서 스레드와 채팅 로그 초기화 (read-only 트랜잭션로 분리)
+        ThreadSummaryData summaryData = fetchThreadSummaryData(userId, year, month, day);
+        if (summaryData == null) {
             log.warn("[ThreadSummary] 해당 날짜 스레드가 없습니다. userId={}, {}-{}-{}", userId, year, month, day);
             return;
         }
-
-        // dailyChatLogs를 기반으로 프롬프트 생성
-        List<DailyChatLog> logs = thread.getDailyChatLogs();
-        
-        // 채팅 내용이 없다면 요약 불필요 (AI 비용 절약)
+        List<DailyChatLog> logs = summaryData.getLogs();
         if (logs == null || logs.isEmpty()) {
             log.warn("[ThreadSummary] 채팅 로그가 없어 요약 불필요. userId={}, {}-{}-{}", userId, year, month, day);
             return;
         }
-        // 실제 채팅 기록으로 요약 프롬프트 생성
         String chatLogsForPrompt = buildChatLogsPrompt(logs);
-
-        // 3) 프롬프트 생성
         String prompt = buildSummaryPrompt(chatLogsForPrompt);
 
-        // 4) LLM 호출
+        // 외부 LLM 호출 및 이미지 생성 (트랜잭션 외부)
         String llmResponse = callLLMForSummary(prompt);
-
-        // 5) 파싱해서 thread에 업데이트
-        parseAndUpdateThread(thread, llmResponse);
-
-        // 6) 이미지 프롬프트 생성
-        String imagePrompt = buildImagePrompt(thread);
-
-        // 7) 목업 ImageGenerator 로 이미지 url 생성
+        String imagePrompt = buildImagePrompt(summaryData.getThread());
         String imageUrl = imageGenerator.genProfileImage(imagePrompt);
-        thread.setImageUrl(imageUrl);
 
-        // 8) DB 저장
+        // 신규 트랜잭션에서 스레드 업데이트 (요약 결과 및 이미지 URL 반영)
+        updateThreadSummary(summaryData.getThread().getId(), llmResponse, imageUrl);
+    }
+
+    // 스레드 조회로직 트랜잭션 분리
+    @Transactional(readOnly = true)
+    public ThreadSummaryData fetchThreadSummaryData(Long userId, int year, int month, int day) {
+        Thread thread = threadRepository.findByUserIdAndYearAndMonthAndDay(userId, year, month, day)
+                .orElse(null);
+        if (thread == null) return null;
+        // lazy 연관관계 초기화: DailyChatLog 목록 조회
+        List<DailyChatLog> logs = thread.getDailyChatLogs();
+        return new ThreadSummaryData(thread, logs);
+    }
+
+    // 스레드 업데이트해서 저장하는 로직 트랜잭션 분리
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateThreadSummary(Long threadId, String llmResponse, String imageUrl) {
+        Thread thread = threadRepository.findById(threadId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.CALENDAR_NOT_FOUND));
+        // LLM 응답을 파싱하여 스레드 요약 정보 업데이트
+        parseAndUpdateThread(thread, llmResponse);
+        thread.setImageUrl(imageUrl);
         threadRepository.save(thread);
     }
 
+    // 채팅로그를 프롬프트에 넣도록 변환
     private String buildChatLogsPrompt(List<DailyChatLog> logs) {
         return logs.stream()
                 .map(log -> {
@@ -151,14 +154,14 @@ public class ThreadSummaryService {
                 .collect(Collectors.joining("\n"));
     }
 
+    // 요약 프롬프트 생성
     private String buildSummaryPrompt(String chatLogs) {
         return """
                 오늘의 채팅 로그입니다: %s
 
                 위 대화를 오늘의 채팅로그를 기반으로 그림일기 형식으로 요약해 주세요.
                 - mood(HAPPY, SAD, TIRED, ANGRY, RELAX 중 하나)
-                - title(30자 이하, 평범한 제목이 아니라 유쾌하고 흥미로운 표현을 사용, 이모티콘 안 쓰도록)
-                   * 예시: "김치전엔 소주지! 수원에서 한 잔", "전주 가려다 수원행, "전이냐 감자탕이냐, 그것이 문제로다"
+                - title(30자 이하, 유쾌하고 흥미로운 표현, 이모티콘 미사용)
                 - story(300자 이하, 일기 형식)
                 - hashTag1, hashTag2(주제 연관 해시태그)
                                 
@@ -174,15 +177,13 @@ public class ThreadSummaryService {
                 """.formatted(chatLogs);
     }
 
-    //LLM 호출 (ChatModel 이용) -> 결과를 문자열로 반환
+    // llm 호출 분리
     private String callLLMForSummary(String prompt) {
         return summaryClient.prompt().user(prompt).call().content();
     }
 
-
-    //LLM 응답(JSON)을 파싱하여 Thread에 summaryTitle, mood, summaryContent 등 업데이트 후 저장
+    // LLM 응답(JSON)을 파싱하여 스레드 요약 정보를 업데이트
     private void parseAndUpdateThread(Thread thread, String llmResponse) {
-        // 1. JSON 파싱
         try {
             int startIndex = llmResponse.indexOf("{");
             int endIndex = llmResponse.lastIndexOf("}");
@@ -198,43 +199,33 @@ public class ThreadSummaryService {
             String hashTag1 = node.has("hashTag1") ? node.get("hashTag1").asText() : null;
             String hashTag2 = node.has("hashTag2") ? node.get("hashTag2").asText() : null;
 
-            // 2. Mood enum 매핑
-            Mood moodEnum = null;
+            // Mood enum 매핑 (정상 값이 아니면 기본값 HAPPY)
+            Mood moodEnum = Mood.HAPPY;
             if (moodStr != null) {
                 try {
-                    moodEnum = Mood.valueOf(moodStr.toUpperCase().trim()); // HAPPY, SAD 등
+                    moodEnum = Mood.valueOf(moodStr.toUpperCase().trim());
                 } catch (IllegalArgumentException e) {
-                    // 만약 enum에 없는 값이면 해피로 기본설정
                     moodEnum = Mood.HAPPY;
                 }
             }
 
-            log.info(moodStr);
-
-            // 3. Thread 업데이트
             thread.setSummaryTitle(summaryTitle);
             thread.setMood(moodEnum);
             thread.setSummaryContent(summaryContent);
             thread.setHashtag1(hashTag1);
             thread.setHashtag2(hashTag2);
             thread.setSummaryCreatedAt(LocalDateTime.now());
-
-            threadRepository.save(thread);
-
         } catch (IOException e) {
             throw new ErrorHandler(ErrorStatus.CALENDAR_PROCESSING_FAILED);
         }
     }
 
-
-    // 이미지 생성용 프롬프트 - Thread 객체를 활용해 프롬프트 생성
+    // 이미지 생성 프롬프트
     private String buildImagePrompt(Thread thread) {
-        // "제목 + 무드 + 해시태그 + 요약내용"을 바탕으로 이미지를 프롬프팅
         String moodText = thread.getMood() == null ? "HAPPY" : thread.getMood().name();
         String hashtagPart = String.format("#%s #%s",
                 thread.getHashtag1() == null ? "" : thread.getHashtag1(),
                 thread.getHashtag2() == null ? "" : thread.getHashtag2());
-
         return """
                 그림일기에 들어갈 그림을 그려줘
                 NO TEXT!!!
@@ -248,5 +239,19 @@ public class ThreadSummaryService {
                 thread.getSummaryContent() == null ? "" : thread.getSummaryContent(),
                 hashtagPart
         );
+    }
+
+    /**
+     * 내부 DTO 클래스 – DB에서 조회한 Thread와 채팅 로그를 담기 위함
+     */
+    @Getter
+    protected static class ThreadSummaryData {
+        private final Thread thread;
+        private final List<DailyChatLog> logs;
+
+        public ThreadSummaryData(Thread thread, List<DailyChatLog> logs) {
+            this.thread = thread;
+            this.logs = logs;
+        }
     }
 }

--- a/src/main/java/com/melissa/diary/service/UserSettingService.java
+++ b/src/main/java/com/melissa/diary/service/UserSettingService.java
@@ -12,6 +12,7 @@ import com.melissa.diary.web.dto.UserSettingRequestDTO;
 import com.melissa.diary.web.dto.UserSettingResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Time;
 import java.util.Optional;
@@ -24,6 +25,7 @@ public class UserSettingService {
 
 
     // 조회
+    @Transactional(readOnly = true)
     public UserSettingResponseDTO.UserSettingResponse getUserSettings(Long userId) {
         UserSetting userSetting = userSettingRepository.findByUserId(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.SETTING_NOT_FOUND));
@@ -31,7 +33,9 @@ public class UserSettingService {
         return UserSettingConverter.toResponse(userSetting);
     }
 
+
     // 수정
+    @Transactional
     public UserSettingResponseDTO.UserSettingResponse updateUserSettings(Long userId, UserSettingRequestDTO.UserSettingRequest request) {
         UserSetting existingSetting = userSettingRepository.findByUserId(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.SETTING_NOT_FOUND));
@@ -42,6 +46,7 @@ public class UserSettingService {
         return UserSettingConverter.toResponse(updated);
     }
 
+    @Transactional
     public void createDefaultSetting(Long userId) {
         // 이미 존재하면 등록하지 않음
         Optional<UserSetting> optional = userSettingRepository.findByUserId(userId);
@@ -71,6 +76,7 @@ public class UserSettingService {
         }
     }
 
+    @Transactional(readOnly = true)
     public boolean isNewUser(Long userId) {
         // 설정값이 있으면 신규가입이 아님 (기본값이라도 있으면, 기존유저)
         return !userSettingRepository.existsByUserId(userId);

--- a/src/main/java/com/melissa/diary/web/controller/ThreadController.java
+++ b/src/main/java/com/melissa/diary/web/controller/ThreadController.java
@@ -2,6 +2,7 @@ package com.melissa.diary.web.controller;
 
 import com.melissa.diary.apiPayload.ApiResponse;
 import com.melissa.diary.service.ThreadService;
+import com.melissa.diary.web.dto.ThreadRequestDTO;
 import com.melissa.diary.web.dto.ThreadResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -70,14 +71,11 @@ public class ThreadController {
     @Operation(description = "AI에게 채팅 메시지를 전송하고, SSE로 실시간 응답을 받습니다.")
     @PostMapping(value = "/message", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<String>> messageToAi(
-            @RequestParam(name = "content") String userMessage,
-            @RequestParam(name = "year") int year,
-            @RequestParam(name = "month") int month,
-            @RequestParam(name = "day") int day,
+            @RequestBody ThreadRequestDTO.AiChatRequest request,
             Principal principal
     ) {
         Long userId = Long.parseLong(principal.getName());
-        return threadService.messageToAi(userId, year, month, day, userMessage);
+        return threadService.messageToAi(userId, request.getYear(), request.getMonth(), request.getDay(), request.getContent());
     }
 
     // 해당 날짜(Thread)의 채팅메시지 조회

--- a/src/main/java/com/melissa/diary/web/dto/ThreadRequestDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/ThreadRequestDTO.java
@@ -1,4 +1,19 @@
 package com.melissa.diary.web.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class ThreadRequestDTO {
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AiChatRequest {
+        private String content;
+        private int year;
+        private int month;
+        private int day;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,10 +17,13 @@ spring:
     username: ${AWS_DB_USERNAME} #root #
     password: ${AWS_DB_PASSWORD} #12341234 #
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 50 # 풀 크기 늘리기
   sql:
     init:
       mode: never
   jpa:
+    open-in-view: false # 요청 전/후로 EntityManager를 물고 있지 않도록
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,9 +13,9 @@ spring:
           quality: standard
           response_format: b64_json
   datasource:
-    url: jdbc:mysql://${AWS_DB_URL}:3306/melissa_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=true&requireSSL=true #jdbc:mysql://127.0.0.1:3306/melissa_db  #
-    username: ${AWS_DB_USERNAME} #root #
-    password: ${AWS_DB_PASSWORD} #12341234 #
+    url: jdbc:mysql://127.0.0.1:3306/melissa_db  #jdbc:mysql://${AWS_DB_URL}:3306/melissa_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=true&requireSSL=true #
+    username: root #${AWS_DB_USERNAME} #
+    password: 12341234 #${AWS_DB_PASSWORD} #
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       maximum-pool-size: 50 # 풀 크기 늘리기

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,12 +13,12 @@ spring:
           quality: standard
           response_format: b64_json
   datasource:
-    url: jdbc:mysql://127.0.0.1:3306/melissa_db  #jdbc:mysql://${AWS_DB_URL}:3306/melissa_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=true&requireSSL=true #
-    username: root #${AWS_DB_USERNAME} #
-    password: 12341234 #${AWS_DB_PASSWORD} #
+    url: jdbc:mysql://${AWS_DB_URL}:3306/melissa_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=true&requireSSL=true #jdbc:mysql://127.0.0.1:3306/melissa_db  #
+    username: ${AWS_DB_USERNAME} #root #
+    password: ${AWS_DB_PASSWORD} #12341234 #
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
-      maximum-pool-size: 50 # 풀 크기 늘리기
+      maximum-pool-size: 20 # 풀 크기 늘리기
   sql:
     init:
       mode: never
@@ -31,7 +31,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: update
+          auto: create
         default_batch_fetch_size: 1000
   servlet:
     multipart:


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- openInView 설정 비활성화
- hikari pool max size 증가 (10 -> 20)
- 각 서비스 트랜잭션 로직 함수로 추출하여 db 접근시 자원할당 최소화(빠른 반납)
- Ai 메시지 전송 api의 컨트롤러 부분 중 reqParam에서 reqBody로 변경

## 📋 변경 사항
- 긴 문자열을 저장하기 위한 ChatLog의 TEXT형식으로의 변환을 위해 yml create

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
![image](https://github.com/user-attachments/assets/f6c3b605-8b8d-48e0-9b87-913e16fa717b)
이제 긴 문자열도 처리가 가능해졌다. 프론트 단에서 적절히 잘라주면 될듯

## 😄 문제점 파악과 4시간 장정의 후기
> 트랜잭션 속 큰 기능을 담는 것이 패착이었다.
- 프론트 측에서 테스트 용도로 엄청 긴 문자열을 전송했지만, 이는 서비스상 언제든 일어날 수 있던 일이었다.
- 이 때문에 Hikari Pool 커넥션 점유율이 증가했고, 덩달아 쓰레드풀 자원도 부족해지면서 문제가 생기고 말았다.
- 이것이 일어나게 된 근본적인 이유는 "JPA에서 영속성 컨텍스트가 데이터베이스 커넥션을 DB에 언제 돌려주냐" 에 관한 개념이 전혀 없이 openInView에 대한 설정을 기본값으로 가져갔기 때문이다.
- openInView를 통해 세션이 유지되며, Ai가 긴 대답에 대한 답변을 주는 그 과정에서조차 데이터베이스 커넥션을 점유하고 있었다. 
- 그래서 클라이언트에게 응답이 모두 끝나고 난 뒤에 안전하게 반납하기에, 그 이전에는 계속 점유하고 있는 것이다.
- 이 과정에서 점유율 문제가 발생한 것이기에, 내가 추측한  hikari pool max size 자체에는 문제가 없었다. 그래도 불안하니 10 증가시켰다.
- 다음부터는 서비스 로직 중에서 시간이 오래 걸리는 로직 (Ai 응답 등)이 포함된다면, 저 설정부터 건들 것이다... 😮‍💨 
