### PR TITLE
fix : ​OpenAiImageApi 생성자는 버전 1.0.0-M6부터 사용 중단으로 공식문서의 새로운 빌더패턴으로 변경

### DIFF
--- a/src/main/java/com/melissa/diary/config/AiConfig.java
+++ b/src/main/java/com/melissa/diary/config/AiConfig.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
 
 @Configuration
 public class AiConfig {
@@ -19,7 +20,10 @@ public class AiConfig {
     @Value("${spring.ai.openai.api-key}") String apiKey;
     @Bean
     ImageModel imageModel() {
-        return new OpenAiImageModel(new OpenAiImageApi(apiKey));
+        OpenAiImageApi api = OpenAiImageApi.builder()
+                .apiKey(apiKey)
+                .build();
+        return new OpenAiImageModel(api);
     }
 
     @Bean


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
OpenAiImageApi 생성자는 버전 1.0.0-M6부터 사용 중단으로 공식문서의 새로운 빌더패턴으로 변경

## 📋 변경 사항
ImageModel의 생성자 변경

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
