### PR TITLE
fix: 프롬프트에서 내용 희석 우려로 핵심 제목, 해시태그만 남기도록 수정

### DIFF
--- a/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
@@ -280,17 +280,15 @@ public class ThreadSummaryService {
                 thread.getHashtag1() == null ? "" : thread.getHashtag1(),
                 thread.getHashtag2() == null ? "" : thread.getHashtag2());
         return """
-                주제에 집중된 일러스트를 그려줘
+                해시태그에 집중된 일러스트를 그려
                 NO TEXT!!!
                 디즈니, 픽사, 애니메이션 스타일
                 분위기: %s
                 요약 제목: %s
-                요약 내용: %s
                 해시태그: %s
                 """.formatted(
                 moodText,
                 thread.getSummaryTitle() == null ? "Untitled" : thread.getSummaryTitle(),
-                thread.getSummaryContent() == null ? "" : thread.getSummaryContent(),
                 hashtagPart
         );
     }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
프롬프트에서 내용 희석 우려로 핵심 제목, 해시태그만 남기도록 수정

현재 프롬프트에서, 요약 내용 전문에 해당하는 것을 프롬프트문에 담고 있어, 주제가 희석된다고 판단해서 제거

## 📋 변경 사항
변경 사항이나 추가 사항을 작성해주세요.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
