### PR TITLE
feat: 최근 사용한 ai 프로필 정보 리턴하는 api 구현

### DIFF
--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -36,6 +36,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CALENDAR_INVALID_DATE(HttpStatus.BAD_REQUEST, "CALENDAR4003", "유효하지 않은 날짜입니다."),
     CALENDAR_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CALENDAR5001", "캘린더 데이터를 처리하는 중 오류가 발생했습니다."),
     THREAD_ALREADY_ENROLL(HttpStatus.BAD_REQUEST, "THREAD4001", "해당 날짜의 스레드가 이미 존재합니다."),
+    THREAD_LATEST_NOT_FOUND(HttpStatus.NOT_FOUND, "THREAD4002", "최근 스레드를 찾을 수 없습니다."),
 
     // CHAT
     CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4001", "해당 날짜의 채팅로그를 찾을 수 없습니다."),

--- a/src/main/java/com/melissa/diary/domain/Thread.java
+++ b/src/main/java/com/melissa/diary/domain/Thread.java
@@ -1,5 +1,6 @@
 package com.melissa.diary.domain;
 
+import com.melissa.diary.domain.common.BaseEntity;
 import com.melissa.diary.domain.enums.Mood;
 import jakarta.persistence.*;
 import lombok.*;
@@ -24,7 +25,7 @@ import java.util.List;
                 @UniqueConstraint(columnNames = {"user_id", "year", "month", "day"}) // 유저별 날짜 유니크 조건 추가
         }
 )
-public class Thread {
+public class Thread extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/melissa/diary/repository/ThreadRepository.java
+++ b/src/main/java/com/melissa/diary/repository/ThreadRepository.java
@@ -24,4 +24,11 @@ public interface ThreadRepository extends JpaRepository<Thread,Long> {
 
     void deleteAllByUserId(Long userId);
 
+    // userId 기준 가장 최근 createdAt 레코드 하나 조회
+    /**
+     * userId 기준으로 year -> month -> day 내림차순 정렬,
+     * 가장 첫 번째(최신) Thread를 가져오는 메서드
+     */
+    Optional<Thread> findFirstByUserIdOrderByYearDescMonthDescDayDesc(Long userId);
+
 }

--- a/src/main/java/com/melissa/diary/service/AiProfileService.java
+++ b/src/main/java/com/melissa/diary/service/AiProfileService.java
@@ -8,9 +8,11 @@ import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
 import com.melissa.diary.aws.s3.AmazonS3Manager;
 import com.melissa.diary.converter.AiProfileConverter;
 import com.melissa.diary.domain.AiProfile;
+import com.melissa.diary.domain.Thread;
 import com.melissa.diary.domain.User;
 import com.melissa.diary.domain.Uuid;
 import com.melissa.diary.repository.AiProfileRepository;
+import com.melissa.diary.repository.ThreadRepository;
 import com.melissa.diary.repository.UserRepository;
 import com.melissa.diary.repository.UuidRepository;
 import com.melissa.diary.web.dto.AiProfileRequestDTO;
@@ -35,14 +37,16 @@ import java.util.UUID;
 public class AiProfileService {
 
     private final AiProfileRepository aiProfileRepository;
+    private final ThreadRepository threadRepository;
     private final UserRepository userRepository;
     private final ChatClient chatClient;
     private final ImageGenerator imageGenerator;
     // Jackson : json 맵핑 도와주는 객체
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public AiProfileService(AiProfileRepository aiProfileRepository, UserRepository userRepository, @Qualifier("profileClient") ChatClient chatClient, ImageGenerator imageGenerator) {
+    public AiProfileService(AiProfileRepository aiProfileRepository, ThreadRepository threadRepository,UserRepository userRepository, @Qualifier("profileClient") ChatClient chatClient, ImageGenerator imageGenerator) {
         this.aiProfileRepository = aiProfileRepository;
+        this.threadRepository = threadRepository;
         this.userRepository = userRepository;
         this.chatClient = chatClient;
         this.imageGenerator = imageGenerator;
@@ -279,4 +283,12 @@ public class AiProfileService {
                 );
     }
 
+    public AiProfileResponseDTO.AiProfileResponse getRecentAiProfileId(Long userId){
+        // 유저마다의 최근 스레드를 찾기
+        Thread thread = threadRepository.findFirstByUserIdOrderByYearDescMonthDescDayDesc(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.THREAD_LATEST_NOT_FOUND));
+
+        // 최근 스레드에서 ai 프로필 id를 리턴
+        return AiProfileConverter.toResponse(thread.getAiProfile());
+    }
 }

--- a/src/main/java/com/melissa/diary/web/controller/AiProfileController.java
+++ b/src/main/java/com/melissa/diary/web/controller/AiProfileController.java
@@ -44,6 +44,18 @@ public class AiProfileController {
         return ApiResponse.onSuccess(response);
     }
 
+    @Operation(description = "최근 사용한 AI 프로필 ID를 조회합니다.")
+    @GetMapping("/recent")
+    public ApiResponse<AiProfileResponseDTO.AiProfileResponse> getAiProfileIdRecent(Principal principal) {
+
+        Long userId = Long.parseLong(principal.getName());
+
+        // 서비스 로직 호출
+        AiProfileResponseDTO.AiProfileResponse response = aiProfileService.getRecentAiProfileId(userId);
+
+        return ApiResponse.onSuccess(response);
+    }
+
     @Operation(description = "특정 AI 프로필을 만들 당시의 질문을 조회합니다.")
     @GetMapping("/{aiProfileId}/question")
     public ApiResponse<AiProfileResponseDTO.AiProfileQuestionResponse> getAiQuestionProfile(


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
최근 사용한 ai 프로필 정보 리턴하는 api 구현

- 프론트 측의 요청 (재로그인 시, 최근 사용한 ai 프로필 정보가 날아가서 사용성 측면 업그레이드 위함)

## 📋 변경 사항
Thread에 연, 월, 일로 최근 사용한 Thread 객체를 찾아서 해당 Thread가 보유한 aiProfile에 대한 정보를 넘겨줌.
그래도 createAt과 updateAt을 추가해 이후 업데이트에서 정확한 최신 정보를 업데이트하도록 수정 예정

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
