### PR TITLE
fix: 유저의 스레드(대화기록)이 없는 경우, 최근 생성한 Ai Profile을 리턴하도록 수정

### DIFF
--- a/src/main/java/com/melissa/diary/repository/AiProfileRepository.java
+++ b/src/main/java/com/melissa/diary/repository/AiProfileRepository.java
@@ -15,6 +15,8 @@ public interface AiProfileRepository extends JpaRepository<AiProfile, Long> {
     // ID, active 둘 다 만족하는 프로필 조회 -> 단건 조회
     Optional<AiProfile> findByIdAndActiveIsTrue(Long id);
 
+    // 가장 최근에 생성된 AiProfile (active 상태) 하나 조회
+    Optional<AiProfile> findFirstByUserIdAndActiveIsTrueOrderByCreatedAtDesc(Long userId);
 
     boolean existsByUserId(Long userId);
     void deleteAllByUserId(Long userId);

--- a/src/main/java/com/melissa/diary/service/AiProfileService.java
+++ b/src/main/java/com/melissa/diary/service/AiProfileService.java
@@ -283,12 +283,19 @@ public class AiProfileService {
                 );
     }
 
-    public AiProfileResponseDTO.AiProfileResponse getRecentAiProfileId(Long userId){
+    public AiProfileResponseDTO.AiProfileResponse getRecentAiProfileId(Long userId) {
         // 유저마다의 최근 스레드를 찾기
-        Thread thread = threadRepository.findFirstByUserIdOrderByYearDescMonthDescDayDesc(userId)
-                .orElseThrow(() -> new ErrorHandler(ErrorStatus.THREAD_LATEST_NOT_FOUND));
+        Optional<Thread> optionalThread = threadRepository.findFirstByUserIdOrderByYearDescMonthDescDayDesc(userId);
 
-        // 최근 스레드에서 ai 프로필 id를 리턴
-        return AiProfileConverter.toResponse(thread.getAiProfile());
+        if (optionalThread.isPresent()) {
+            // 최근 스레드에서 ai 프로필 id를 리턴
+            return AiProfileConverter.toResponse(optionalThread.get().getAiProfile());
+        } else {
+            // 대체제인 유저의 최근 AiProfile을 createdAt 기준으로 찾음
+            AiProfile aiProfile = aiProfileRepository.findFirstByUserIdAndActiveIsTrueOrderByCreatedAtDesc(userId)
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.PROFILE_NOT_FOUND));
+
+            return AiProfileConverter.toResponse(aiProfile);
+        }
     }
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
유저의 스레드(대화기록)이 없는 경우, 최근 생성한 Ai Profile을 리턴하도록 수정

기존 방식에서는 최근 생성한 Ai Profile을 리턴하는 것이 아닌, 에러코드를 리턴하는 방식으로 구현되어 있었음.
이에 따라 프론트엔드 측에서 예외 처리 및 대체 데이터를 처리해야 하는 로직이 추가로 필요했음.

이번 수정으로, 스레드가 존재하지 않는 경우에도 백엔드에서 자동으로 유저의 가장 최근 Ai Profile을 반환하도록 하여 프론트엔드 수정 없이도 대응 가능하도록 변경함.

## 📋 변경 사항

ThreadRepository.findFirstByUserIdOrderByYearDescMonthDescDayDesc()로 스레드를 조회하고
→ 존재하지 않으면

AiProfileRepository.findFirstByUserIdAndActiveIsTrueOrderByCreatedAtDesc()로 최근 Ai Profile 조회

예외(ErrorHandler) 발생 대신 fallback 처리를 통해 정상 응답 반환

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
