### PR TITLE
fix: SSE Accept 헤더 검증 추가 및 스트리밍 도중 에러발생 fall back 처리

### DIFF
--- a/src/main/java/com/melissa/diary/service/ThreadService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadService.java
@@ -199,10 +199,17 @@ public class ThreadService {
                             .data(partialMessage)
                             .build();
                 })
-                .doOnError(e -> log.error("AI 응답 스트리밍 중 에러 발생", e))
                 .doOnComplete(() -> {
                     String answer = aiAnswerBuilder.toString().replace("null", "").trim();
                     saveAiMessage(answer, threadData);
+                })
+                .onErrorResume(e -> {
+                    // 클라이언트가 끊었거나, AI 응답 중 오류가 발생시 여기서 캐치
+                    // SSE로 에러 이벤트를 전송 후 스트림 종료
+                    return Flux.just(ServerSentEvent.<String>builder()
+                            .event("error")
+                            .data("SSE 스트리밍 도중 오류가 발생했습니다: " + e.getMessage())
+                            .build());
                 });
 
         // finish 이벤트를 내보내는 Flux (단일 이벤트) : 현성이 요청
@@ -215,7 +222,15 @@ public class ThreadService {
         );
 
         // 두 Flux를 순차적으로 연결하여, aiMessageFlux가 완료된 뒤 finish 이벤트를 발행
-        return Flux.concat(aiMessageFlux, finishEventFlux);
+        return Flux.concat(aiMessageFlux, finishEventFlux)
+                .onErrorResume(e -> {
+            // SSE 에러 이벤트로 마무리
+            log.error("전체 SSE 스트리밍 도중 오류가 발생했습니다: ", e);
+            return Flux.just(ServerSentEvent.<String>builder()
+                    .event("error")
+                    .data("스트리밍 도중 서버 오류가 발생했습니다: " + e.getMessage())
+                    .build());
+        });
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/melissa/diary/web/controller/ThreadController.java
+++ b/src/main/java/com/melissa/diary/web/controller/ThreadController.java
@@ -7,8 +7,10 @@ import com.melissa.diary.web.dto.ThreadResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 
@@ -18,6 +20,7 @@ import java.security.Principal;
 @Tag(name = "Thread&ChatsAPI", description = "Thread&Chats 관련 API")
 @RequestMapping("/api/v1/chats")
 @RequiredArgsConstructor
+@Slf4j
 public class ThreadController {
 
     private final ThreadService threadService;
@@ -72,9 +75,24 @@ public class ThreadController {
     @PostMapping(value = "/message", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<String>> messageToAi(
             @RequestBody ThreadRequestDTO.AiChatRequest request,
-            Principal principal
+            Principal principal,
+            ServerHttpRequest httpRequest
     ) {
         Long userId = Long.parseLong(principal.getName());
+
+        // Accept 헤더가 text/event-stream 인지 검증
+        boolean acceptHeaderValid = httpRequest.getHeaders().getAccept().stream()
+                .anyMatch(mt -> mt.isCompatibleWith(MediaType.TEXT_EVENT_STREAM));
+
+        if (!acceptHeaderValid) {
+            // 만약 올바르지 않다면, SSE 에러 이벤트 한 번 전송하고 종료
+            log.warn("클라이언트가 Accept 헤더를 누락했거나 잘못 보냄: {}", httpRequest.getHeaders().getAccept());
+            return Flux.just(ServerSentEvent.<String>builder()
+                    .event("error")
+                    .data("잘못된 요청입니다. Accept: text/event-stream 헤더가 필요합니다.")
+                    .build());
+        }
+
         return threadService.messageToAi(userId, request.getYear(), request.getMonth(), request.getDay(), request.getContent());
     }
 


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- SSE 기반 AI 응답 스트리밍 API에서 `Accept: text/event-stream` 헤더 누락 시 에러 처리 추가
- 클라이언트 측 스트리밍 중단 및 네트워크 예외 대응을 위한 `.onErrorResume()` 기반 에러 fallback 처리 추가
- 전체 Flux 스트림 종료 예외도 안전하게 처리

## 📋 변경 사항
- `ThreadController.messageToAi()`에서 `ServerHttpRequest`를 통해 `Accept` 헤더 검증 추가
- `ThreadService.messageToAi()` 내부에 스트리밍 처리 중 `.onErrorResume()` 및 `.doOnError()` 적용
- `Flux.concat(...).onErrorResume(...)`로 전체 스트림 오류 처리
- 예외 발생 시 `event: error` 형식의 SSE 메시지 전송

## 🔍 Code Review

## 📸 ScreenShot
