### PR TITLE
fix: 서비스 유지 위해 헤더검증 적용 해제

### DIFF
--- a/src/main/java/com/melissa/diary/web/controller/ThreadController.java
+++ b/src/main/java/com/melissa/diary/web/controller/ThreadController.java
@@ -75,23 +75,8 @@ public class ThreadController {
     @PostMapping(value = "/message", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<String>> messageToAi(
             @RequestBody ThreadRequestDTO.AiChatRequest request,
-            Principal principal,
-            ServerHttpRequest httpRequest
-    ) {
+            Principal principal) {
         Long userId = Long.parseLong(principal.getName());
-
-        // Accept 헤더가 text/event-stream 인지 검증
-        boolean acceptHeaderValid = httpRequest.getHeaders().getAccept().stream()
-                .anyMatch(mt -> mt.isCompatibleWith(MediaType.TEXT_EVENT_STREAM));
-
-        if (!acceptHeaderValid) {
-            // 만약 올바르지 않다면, SSE 에러 이벤트 한 번 전송하고 종료
-            log.warn("클라이언트가 Accept 헤더를 누락했거나 잘못 보냄: {}", httpRequest.getHeaders().getAccept());
-            return Flux.just(ServerSentEvent.<String>builder()
-                    .event("error")
-                    .data("잘못된 요청입니다. Accept: text/event-stream 헤더가 필요합니다.")
-                    .build());
-        }
 
         return threadService.messageToAi(userId, request.getYear(), request.getMonth(), request.getDay(), request.getContent());
     }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
서비스 유지 및 띄어쓰기 검증을 위해 무중단 서버를 유지할 필요 생김
- 프론트 측에서 파라미터의 변경으로 인해, 현재 어플리케이션 단에서 요청이 정상적으로 수행되지 않음.
- 헤더검증을 해제하여 정상적으로 수행하도록 변경

## 📋 변경 사항
변경 사항이나 추가 사항을 작성해주세요.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
