### PR TITLE
fix: Add swap memory config to support low-memory EB instances

### DIFF
--- a/.ebextensions_dev/02-setup-swap.config
+++ b/.ebextensions_dev/02-setup-swap.config
@@ -1,0 +1,8 @@
+commands:
+  setup_swap:
+    test: test ! -e /var/swapfile
+    command: |
+      /bin/dd if=/dev/zero of=/var/swapfile bs=128M count=16
+      /bin/chmod 600 /var/swapfile
+      /sbin/mkswap /var/swapfile
+      /sbin/swapon /var/swapfile

--- a/.idea/sonarlint/issuestore/1/9/19f6a32f8e4a977dfabc829d411ea4bf07d9bad2
+++ b/.idea/sonarlint/issuestore/1/9/19f6a32f8e4a977dfabc829d411ea4bf07d9bad2
@@ -1,13 +1,13 @@
 
 X
-java:S1141‰"5Extract this nested try block into a separate method.(¡»¢üùÿÿÿÿ8ÜËˆ™İ2
+java:S1141"5Extract this nested try block into a separate method.(¡»¢üùÿÿÿÿ8ÜËˆ™İ2
 ƒ
-java:S1488±"`Immediately return this expression instead of assigning it to the temporary variable "response".(ò¥µ¹şÿÿÿÿ8ÜËˆ™İ2
+java:S1488µ"`Immediately return this expression instead of assigning it to the temporary variable "response".(ò¥µ¹şÿÿÿÿ8ÜËˆ™İ2
 €
 java:S2229h"c"fetchThreadSummaryData's" @Transactional requirement is incompatible with the one for this method.(øñé8‚Ìˆ™İ2
 ~
 java:S2229"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8‚Ìˆ™İ2
 ~
-java:S2229¥"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8Ìˆ™İ2
+java:S2229©"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8Ìˆ™İ2
 p
 java:S6204š"RReplace this usage of 'Stream.collect(Collectors.toList())' with 'Stream.toList()'(ª™¨¹8’Ìˆ™İ2

--- a/.idea/sonarlint/issuestore/5/e/5ee88781c23185281d1eededf5742d62d7e1515d
+++ b/.idea/sonarlint/issuestore/5/e/5ee88781c23185281d1eededf5742d62d7e1515d
@@ -1,22 +1,23 @@
 
 r
-java:S2229«"T"getUser's" @Transactional requirement is incompatible with the one for this method.(ÌğØä8îØú˜İ2
+java:S2229«"T"getUser's" @Transactional requirement is incompatible with the one for this method.(ÌğØä8ó¬­à2
 x
-java:S2229®"Z"getThreadData's" @Transactional requirement is incompatible with the one for this method.(İ›8îØú˜İ2
+java:S2229®"Z"getThreadData's" @Transactional requirement is incompatible with the one for this method.(İ›8ô¬­à2
 U
-java:S1854s"8Remove this useless assignment to local variable "user".(ÌğØä8ôØú˜İ2
+java:S1854s"8Remove this useless assignment to local variable "user".(ÌğØä8û¬­à2
 F
-java:S1481s")Remove this unused "user" local variable.(ÌğØä8ôØú˜İ2
+java:S1481s")Remove this unused "user" local variable.(ÌğØä8û¬­à2
 V
-java:S1854"8Remove this useless assignment to local variable "user".(ÌğØä8öØú˜İ2
+java:S1854"8Remove this useless assignment to local variable "user".(ÌğØä8ü¬­à2
 G
-java:S1481")Remove this unused "user" local variable.(ÌğØä8öØú˜İ2
+java:S1481")Remove this unused "user" local variable.(ÌğØä8ı¬­à2
 V
-java:S1854«"8Remove this useless assignment to local variable "user".(ÌğØä8÷Øú˜İ2
+java:S1854«"8Remove this useless assignment to local variable "user".(ÌğØä8ş¬­à2
 G
-java:S1481«")Remove this unused "user" local variable.(ÌğØä8øØú˜İ2
-Y	java:S125™"<This block of commented-out lines of code should be removed.(ã¨üì8şØú˜İ2
+java:S1481«")Remove this unused "user" local variable.(ÌğØä8ÿ¬­à2
+v
+java:S1602Î"SRemove useless curly braces around statement and then remove useless return keyword(‚œ§Øÿÿÿÿÿ8ê‡ö­à2
 V
-java:S1854Â"8Remove this useless assignment to local variable "user".(õÌ¼²8ÿØú˜İ2
+java:S1854É"8Remove this useless assignment to local variable "user".(õÌ¼²8åù”­à2
 G
-java:S1481Â")Remove this unused "user" local variable.(õÌ¼²8ÿØú˜İ2
+java:S1481É")Remove this unused "user" local variable.(õÌ¼²8æù”­à2

--- a/.idea/sonarlint/issuestore/f/7/f730d55d7eed97158eecb1c301372e7686eb870a
+++ b/.idea/sonarlint/issuestore/f/7/f730d55d7eed97158eecb1c301372e7686eb870a
@@ -1,0 +1,3 @@
+
+p
+java:S1128"NRemove this unused import 'org.springframework.http.server.ServerHttpRequest'.(„ö¥¦þÿÿÿÿ8 ‡ö­à2


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
서버 장애의 유력한 원인으로 예상되는 EB의 메모리 부족를 해결하기 위해,
스왑 메모리를 자동으로 설정하는 .ebextensions/02-setup-swap.config 파일을 추가

## 📋 변경 사항
- .ebextensions/02-setup-swap.config 파일 생성
- EC2 인스턴스가 시작될 때 2GB의 스왑 메모리를 자동 생성 및 활성화

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
