### PR TITLE
feat: 구독 서비스 도입 전 임시 사용량 제한 추가

### DIFF
--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -41,6 +41,8 @@ public enum ErrorStatus implements BaseErrorCode {
     // CHAT
     CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4001", "해당 날짜의 채팅로그를 찾을 수 없습니다."),
 
+    // Quota
+    QUOTA_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "QUOTA4001", "일일 사용량을 초과하였습니다."),
 
     // Auth
     // 인증 관련 에러 상태

--- a/src/main/java/com/melissa/diary/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/melissa/diary/apiPayload/exception/GeneralException.java
@@ -2,6 +2,7 @@ package com.melissa.diary.apiPayload.exception;
 
 import com.melissa.diary.apiPayload.code.BaseErrorCode;
 import com.melissa.diary.apiPayload.code.ErrorReasonDTO;
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -17,5 +18,9 @@ public class GeneralException extends RuntimeException {
 
     public ErrorReasonDTO getErrorReasonHttpStatus(){
         return this.code.getReasonHttpStatus();
+    }
+
+    public BaseErrorCode getErrorCode() {
+        return this.code;
     }
 }

--- a/src/main/java/com/melissa/diary/bootstrap/QuotaInitializer.java
+++ b/src/main/java/com/melissa/diary/bootstrap/QuotaInitializer.java
@@ -1,0 +1,26 @@
+package com.melissa.diary.bootstrap;
+
+import com.melissa.diary.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class QuotaInitializer implements ApplicationRunner {
+
+    private final UserRepository userRepo;
+
+    // 이전 사용자 null 처리
+    @Transactional
+    public void run(ApplicationArguments args) {
+        userRepo.findAll().forEach(u -> {
+            if (u.getDailyQuota() == null) u.setDailyQuota(100);
+            if (u.getQuotaDate()  == null) u.setQuotaDate(LocalDate.now());
+        });
+    }
+}

--- a/src/main/java/com/melissa/diary/domain/User.java
+++ b/src/main/java/com/melissa/diary/domain/User.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +44,20 @@ public class User {
 
     @LastModifiedDate
     private LocalDateTime updateAt;
+
+    // ✨ 새 필드
+    private Integer dailyQuota;     // 오늘 남은 수량
+    private LocalDate quotaDate;    // 마지막 초기화 날짜
+
+    @Version                       // 동시성 보호
+    private Long version;
+
+    // 마이그레이션용, Initialize를 통해 기존 사용자도 처리위해 추가
+    @PrePersist
+    public void initQuota() {          // 신규 가입 시
+        if (dailyQuota == null) dailyQuota = 100;
+        if (quotaDate  == null) quotaDate  = LocalDate.now();
+    }
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserSetting> userSettingList = new ArrayList<>();

--- a/src/main/java/com/melissa/diary/domain/enums/UsageCost.java
+++ b/src/main/java/com/melissa/diary/domain/enums/UsageCost.java
@@ -1,2 +1,11 @@
-package com.melissa.diary.domain.enums;public enum UsageCost {
+package com.melissa.diary.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UsageCost {
+    CHAT(3), SUMMARY(10), PROFILE(10);
+    private final int cost;
 }

--- a/src/main/java/com/melissa/diary/domain/enums/UsageCost.java
+++ b/src/main/java/com/melissa/diary/domain/enums/UsageCost.java
@@ -1,0 +1,2 @@
+package com.melissa.diary.domain.enums;public enum UsageCost {
+}

--- a/src/main/java/com/melissa/diary/repository/UserRepository.java
+++ b/src/main/java/com/melissa/diary/repository/UserRepository.java
@@ -3,8 +3,12 @@ package com.melissa.diary.repository;
 
 import com.melissa.diary.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 @Repository
@@ -14,5 +18,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // Refresh 토큰으로 유저 찾기 (간단 예시 - 실제론 해시 등 보안처리)
     Optional<User> findByRefreshToken(String refreshToken);
 
-
+    @Modifying
+    @Query("""
+    UPDATE User u
+       SET u.dailyQuota = 100,
+           u.quotaDate  = :today
+""")
+    void resetAll(@Param("today") LocalDate today);
 }

--- a/src/main/java/com/melissa/diary/scheduler/QuotaResetScheduler.java
+++ b/src/main/java/com/melissa/diary/scheduler/QuotaResetScheduler.java
@@ -1,0 +1,23 @@
+package com.melissa.diary.scheduler;
+
+import com.melissa.diary.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class QuotaResetScheduler {
+
+    private final UserRepository userRepo;
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void reset() {
+        // 스케줄러를 통해 매일 100으로 초기화
+        userRepo.resetAll(LocalDate.now());
+    }
+}

--- a/src/main/java/com/melissa/diary/service/AiProfileService.java
+++ b/src/main/java/com/melissa/diary/service/AiProfileService.java
@@ -11,6 +11,7 @@ import com.melissa.diary.domain.AiProfile;
 import com.melissa.diary.domain.Thread;
 import com.melissa.diary.domain.User;
 import com.melissa.diary.domain.Uuid;
+import com.melissa.diary.domain.enums.UsageCost;
 import com.melissa.diary.repository.AiProfileRepository;
 import com.melissa.diary.repository.ThreadRepository;
 import com.melissa.diary.repository.UserRepository;
@@ -41,21 +42,28 @@ public class AiProfileService {
     private final UserRepository userRepository;
     private final ChatClient chatClient;
     private final ImageGenerator imageGenerator;
+
+    private final QuotaService quotaService;
     // Jackson : json 맵핑 도와주는 객체
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public AiProfileService(AiProfileRepository aiProfileRepository, ThreadRepository threadRepository,UserRepository userRepository, @Qualifier("profileClient") ChatClient chatClient, ImageGenerator imageGenerator) {
+    public AiProfileService(AiProfileRepository aiProfileRepository, ThreadRepository threadRepository,UserRepository userRepository, @Qualifier("profileClient") ChatClient chatClient, ImageGenerator imageGenerator, QuotaService quotaService) {
         this.aiProfileRepository = aiProfileRepository;
         this.threadRepository = threadRepository;
         this.userRepository = userRepository;
         this.chatClient = chatClient;
         this.imageGenerator = imageGenerator;
+        this.quotaService = quotaService;
     }
 
     @Transactional
     public AiProfileResponseDTO.AiProfileResponse createAiProfile(Long userId,
                                                                   AiProfileRequestDTO.AiProfileCreateRequest request) {
+
         User user = getUser(userId);
+
+        quotaService.checkAndConsume(userId, UsageCost.PROFILE);
+
 
         // 1) 프롬프트 생성
         String promptText = buildPromptProfileText(request);

--- a/src/main/java/com/melissa/diary/service/QuotaService.java
+++ b/src/main/java/com/melissa/diary/service/QuotaService.java
@@ -1,2 +1,36 @@
-package com.melissa.diary.service;public class QuotaService {
+package com.melissa.diary.service;
+
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.enums.UsageCost;
+import com.melissa.diary.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class QuotaService {
+
+    private final UserRepository userRepo;
+
+    @Transactional
+    public void checkAndConsume(Long userId, UsageCost type) {
+        User u = userRepo.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        /* 날짜 바뀌면 초기화 */
+        if (!u.getQuotaDate().equals(LocalDate.now())) {
+            u.setDailyQuota(100);
+            u.setQuotaDate(LocalDate.now());
+        }
+
+        if (u.getDailyQuota() < type.getCost())
+            throw new ErrorHandler(ErrorStatus.QUOTA_LIMIT_EXCEEDED);
+
+        u.setDailyQuota(u.getDailyQuota() - type.getCost());
+    }
 }

--- a/src/main/java/com/melissa/diary/service/QuotaService.java
+++ b/src/main/java/com/melissa/diary/service/QuotaService.java
@@ -1,0 +1,2 @@
+package com.melissa.diary.service;public class QuotaService {
+}

--- a/src/main/java/com/melissa/diary/service/ThreadService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadService.java
@@ -6,6 +6,7 @@ import com.melissa.diary.domain.AiProfile;
 import com.melissa.diary.domain.DailyChatLog;
 import com.melissa.diary.domain.User;
 import com.melissa.diary.domain.enums.Role;
+import com.melissa.diary.domain.enums.UsageCost;
 import com.melissa.diary.repository.AiProfileRepository;
 import com.melissa.diary.repository.DailyChatLogRepository;
 import com.melissa.diary.repository.ThreadRepository;
@@ -45,12 +46,15 @@ public class ThreadService {
     private final DailyChatLogRepository dailyChatLogRepository;
     private final ChatClient chatClient;
 
-    public ThreadService(ThreadRepository threadRepository, UserRepository userRepository, AiProfileRepository aiProfileRepository, DailyChatLogRepository dailyChatLogRepository, @Qualifier("aiChatClient") ChatClient chatClient) {
+    private final QuotaService quotaService;
+
+    public ThreadService(ThreadRepository threadRepository, UserRepository userRepository, AiProfileRepository aiProfileRepository, DailyChatLogRepository dailyChatLogRepository, @Qualifier("aiChatClient") ChatClient chatClient, QuotaService quotaService) {
         this.threadRepository = threadRepository;
         this.userRepository = userRepository;
         this.aiProfileRepository = aiProfileRepository;
         this.dailyChatLogRepository = dailyChatLogRepository;
         this.chatClient = chatClient;
+        this.quotaService = quotaService;
     }
 
     @Transactional
@@ -169,6 +173,8 @@ public class ThreadService {
     public Flux<ServerSentEvent<String>> messageToAi(Long userId, int year, int month, int day, String userMessage) {
         // 정상적인 유저인지 보호
         User user = getUser(userId);
+
+        quotaService.checkAndConsume(userId, UsageCost.CHAT);
 
         // 프롬프트 생성 -> 좀더 자세히 보면, 여기서 이미 Lazy를 대비해 로드까지 해놓음
         ThreadData threadData = getThreadData(userId, year, month, day, userMessage);

--- a/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
@@ -10,6 +10,7 @@ import com.melissa.diary.domain.*;
 import com.melissa.diary.domain.Thread;
 import com.melissa.diary.domain.enums.Mood;
 import com.melissa.diary.domain.enums.Role;
+import com.melissa.diary.domain.enums.UsageCost;
 import com.melissa.diary.repository.ThreadRepository;
 import com.melissa.diary.repository.UserRepository;
 import com.melissa.diary.repository.UserSettingRepository;
@@ -45,18 +46,22 @@ public class ThreadSummaryService {
     private final ChatClient summaryClient;
     private final ImageGenerator imageGenerator;
 
+    private final QuotaService quotaService;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
     public ThreadSummaryService(UserRepository userRepository,
                                 ThreadRepository threadRepository,
                                 UserSettingRepository userSettingRepository,
                                 @Qualifier("summaryClient")
                                 ChatClient summaryClient,
-                                ImageGenerator imageGenerator) {
+                                ImageGenerator imageGenerator,
+                                QuotaService quotaService) {
         this.userRepository = userRepository;
         this.threadRepository = threadRepository;
         this.userSettingRepository = userSettingRepository;
         this.summaryClient = summaryClient;
         this.imageGenerator = imageGenerator;
+        this.quotaService = quotaService;
     }
 
     /**
@@ -135,6 +140,8 @@ public class ThreadSummaryService {
      */
     @Transactional
     public ThreadSummaryResponseDTO.dailySummaryResponseDTO generateImmediateSummary(Long userId, int year, int month, int day) {
+
+        quotaService.checkAndConsume(userId, UsageCost.SUMMARY);
 
         ThreadSummaryData summaryData = fetchThreadSummaryData(userId, year, month, day);
         if (summaryData == null) {

--- a/src/test/java/com/melissa/diary/service/QuotaServiceTest.java
+++ b/src/test/java/com/melissa/diary/service/QuotaServiceTest.java
@@ -1,0 +1,56 @@
+package com.melissa.diary.service;
+
+
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.enums.UsageCost;
+import com.melissa.diary.repository.UserRepository;
+import org.junit.jupiter.api.*;
+import org.mockito.Mockito;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+class QuotaServiceTest {
+
+    private UserRepository userRepo;
+    private QuotaService quotaService;
+
+    @BeforeEach
+    void setUp() {
+        userRepo = Mockito.mock(UserRepository.class);      // 가짜 레포지토리
+        quotaService = new QuotaService(userRepo);
+    }
+
+    @Test
+    void 정상_차감() {
+        User user = new User();
+        user.setDailyQuota(100);
+        user.setQuotaDate(java.time.LocalDate.now());
+        when(userRepo.findById(anyLong())).thenReturn(Optional.of(user));
+
+        quotaService.checkAndConsume(1L, UsageCost.CHAT);   // 3 소비
+
+        assertEquals(97, user.getDailyQuota());
+    }
+
+    @Test
+    void 한도_초과_예외() {
+        // given
+        User user = new User();
+        user.setId(2L);
+        user.setDailyQuota(0);
+        user.setQuotaDate(java.time.LocalDate.now());
+        when(userRepo.findById(anyLong())).thenReturn(Optional.of(user));
+
+        // when + then
+        ErrorHandler ex = assertThrows(ErrorHandler.class,
+                () -> quotaService.checkAndConsume(2L, UsageCost.CHAT));
+
+        assertEquals(ErrorStatus.QUOTA_LIMIT_EXCEEDED, ex.getErrorCode());
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
일일 사용량 제한 기능 추가
관련 테스트 코드 2종 작성

## 📋 변경 사항
- User 엔티티 변경 (사용량 관련 필드 추가) : dailyQuota (INT), quotaDate (DATE) 필드 + @Version
- QuotaService 추가 → 잔여량 차감·초과 확인
- QuotaResetScheduler 추가 → 매일 00:00 초기화
- QuotaInitializer 추가 → 기존 유저 기본값 세팅
- 각 API 진입부에 quotaService.checkAndConsume(...) 한 줄 삽입

## 🧪 테스트
- QuotaServiceTest : 정상 차감 / 한도 초과
- ThreadServiceTest : 메시지 API 차감 호출 검증

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
