### PR TITLE
fix: userId가 아닌 user를 넘겨서, DB 접근 I/O 줄이기

### DIFF
--- a/src/main/java/com/melissa/diary/service/AiProfileService.java
+++ b/src/main/java/com/melissa/diary/service/AiProfileService.java
@@ -62,7 +62,7 @@ public class AiProfileService {
 
         User user = getUser(userId);
 
-        quotaService.checkAndConsume(userId, UsageCost.PROFILE);
+        quotaService.checkAndConsume(user, UsageCost.PROFILE);
 
 
         // 1) 프롬프트 생성

--- a/src/main/java/com/melissa/diary/service/QuotaService.java
+++ b/src/main/java/com/melissa/diary/service/QuotaService.java
@@ -18,10 +18,7 @@ public class QuotaService {
     private final UserRepository userRepo;
 
     @Transactional
-    public void checkAndConsume(Long userId, UsageCost type) {
-        User u = userRepo.findById(userId)
-                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
-
+    public void checkAndConsume(User u, UsageCost type) {
         /* 날짜 바뀌면 초기화 */
         if (!u.getQuotaDate().equals(LocalDate.now())) {
             u.setDailyQuota(100);

--- a/src/main/java/com/melissa/diary/service/ThreadService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadService.java
@@ -174,7 +174,7 @@ public class ThreadService {
         // 정상적인 유저인지 보호
         User user = getUser(userId);
 
-        quotaService.checkAndConsume(userId, UsageCost.CHAT);
+        quotaService.checkAndConsume(user, UsageCost.CHAT);
 
         // 프롬프트 생성 -> 좀더 자세히 보면, 여기서 이미 Lazy를 대비해 로드까지 해놓음
         ThreadData threadData = getThreadData(userId, year, month, day, userMessage);

--- a/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
@@ -134,14 +134,21 @@ public class ThreadSummaryService {
         updateThreadSummary(thread.getId(), llmResponse, imageUrl);
     }
 
+    @Transactional(readOnly = true)
+    public User getUser(Long userId) {
+        // db에 해당 유저 없으면 에러던지기(탈퇴 보호)
+        return userRepository.findById(userId).orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+    }
+
+
     /**
      * 유저가 API를 호출하면 즉각 실행되어 무조건 요약 데이터를 덮어씌우고,
      * 최신 스레드를 반환합니다.
      */
     @Transactional
     public ThreadSummaryResponseDTO.dailySummaryResponseDTO generateImmediateSummary(Long userId, int year, int month, int day) {
-
-        quotaService.checkAndConsume(userId, UsageCost.SUMMARY);
+        User user = getUser(userId);
+        quotaService.checkAndConsume(user, UsageCost.SUMMARY);
 
         ThreadSummaryData summaryData = fetchThreadSummaryData(userId, year, month, day);
         if (summaryData == null) {

--- a/src/test/java/com/melissa/diary/service/QuotaServiceTest.java
+++ b/src/test/java/com/melissa/diary/service/QuotaServiceTest.java
@@ -33,7 +33,7 @@ class QuotaServiceTest {
         user.setQuotaDate(java.time.LocalDate.now());
         when(userRepo.findById(anyLong())).thenReturn(Optional.of(user));
 
-        quotaService.checkAndConsume(1L, UsageCost.CHAT);   // 3 소비
+        quotaService.checkAndConsume(user, UsageCost.CHAT);   // 3 소비
 
         assertEquals(97, user.getDailyQuota());
     }
@@ -49,7 +49,7 @@ class QuotaServiceTest {
 
         // when + then
         ErrorHandler ex = assertThrows(ErrorHandler.class,
-                () -> quotaService.checkAndConsume(2L, UsageCost.CHAT));
+                () -> quotaService.checkAndConsume(user, UsageCost.CHAT));
 
         assertEquals(ErrorStatus.QUOTA_LIMIT_EXCEEDED, ex.getErrorCode());
     }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
이전 PR에서 작성한 Code 중, DB 접근이 중복되는 경우 발생 -> AI 응답이 확연하게 느려지는 현상 발견.

## 📋 변경 사항
DB 접근을 줄이기 위해 UserId가 아닌, User 객체를 넘기도록 시그니처 수정

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
