### PR TITLE
fix: getUser를 readonly로 사용해서 명시적 업데이트 지정

### DIFF
--- a/src/main/java/com/melissa/diary/service/QuotaService.java
+++ b/src/main/java/com/melissa/diary/service/QuotaService.java
@@ -30,6 +30,6 @@ public class QuotaService {
 
         u.setDailyQuota(u.getDailyQuota() - type.getCost());
 
-        userRepo.save(u)
+        userRepo.save(u);
     }
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
기존에 사용했던 함수은 getUser를 가져와서 사용했는데, 해당 함수는 readOnly 트랜잭션이므로 경계를 나가서 수정하면 자동으로 저장되지않음..

이 문제를 해결하기 위해 명시적 업데이트를 추가함.

## 📋 변경 사항
변경 사항이나 추가 사항을 작성해주세요.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
