### PR TITLE
fix: OptimisticLockException 에러 해결

### DIFF
--- a/src/main/java/com/melissa/diary/domain/User.java
+++ b/src/main/java/com/melissa/diary/domain/User.java
@@ -49,8 +49,9 @@ public class User {
     private Integer dailyQuota;     // 오늘 남은 수량
     private LocalDate quotaDate;    // 마지막 초기화 날짜
 
-    @Version                       // 동시성 보호
-    private Long version;
+    @Version
+    @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+    private Long version = 0L;
 
     // 마이그레이션용, Initialize를 통해 기존 사용자도 처리위해 추가
     @PrePersist


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
낙관적 락이 참조하는 version의 기본 값이 0이 아닌 null로 설정되어 발생한 문제.

## 📋 변경 사항
@version의 기본값을 0으로 마이그레이션함과 동시에 DB단에서 디폴트값 설정

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
