### PR TITLE
fix: SSE 마지막에 null 문자 붙는것 replace로 삭제

### DIFF
--- a/src/main/java/com/melissa/diary/service/ThreadService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadService.java
@@ -230,14 +230,17 @@ public class ThreadService {
     }
 
     private void saveAiMessage(String answer, ThreadData threadData) {
-        // 모든 응답이 완료되면 최종 AI 응답을 DB에 저장
+        // "null" 문자열을 제거
+        String cleanAnswer = answer.replace("null", "").trim();
+
         DailyChatLog aiChat = DailyChatLog.builder()
                 .role(Role.AI)
-                .content(answer)
+                .content(cleanAnswer)
                 .thread(threadData.getThread())
                 .aiProfile(threadData.getAiProfile())
                 .createdAt(LocalDateTime.now())
                 .build();
+
         dailyChatLogRepository.save(aiChat);
     }
 


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
SSE를 논블로킹, 블로킹으로 분리하는 과정 속에서 기존 코드에서 사용됐던 Null 삭제를 saveAiMessage로 이전

## 📋 변경 사항
saveAiMessage에서 최종 메시지의 마지막 null 문자열을 지우고 저장하도록 수정

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
