### PR TITLE
feat: AI 프로필 생성 api V2 - 이미지 생성을 비동기로 처리해 3.6배 체감 시간단축

### DIFF
--- a/.idea/sonarlint/issuestore/1/9/19f6a32f8e4a977dfabc829d411ea4bf07d9bad2
+++ b/.idea/sonarlint/issuestore/1/9/19f6a32f8e4a977dfabc829d411ea4bf07d9bad2
@@ -1,15 +1,15 @@
 
 X
-java:S1141¡"5Extract this nested try block into a separate method.(¡»¢üùÿÿÿÿ8Þöñ½í2
+java:S1141¡"5Extract this nested try block into a separate method.(¡»¢üùÿÿÿÿ8õëá¿í2
 ƒ
-java:S1488É"`Immediately return this expression instead of assigning it to the temporary variable "response".(ò¥µ¹þÿÿÿÿ8Þöñ½í2
+java:S1488É"`Immediately return this expression instead of assigning it to the temporary variable "response".(ò¥µ¹þÿÿÿÿ8õëá¿í2
+ƒ
+java:S2229á"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(Åù×Àúÿÿÿÿ8ªìá¿í2
 €
-java:S2229s"c"fetchThreadSummaryData's" @Transactional requirement is incompatible with the one for this method.(žøñé8–÷ñ½í2
+java:S2229s"c"fetchThreadSummaryData's" @Transactional requirement is incompatible with the one for this method.(žøñé8ªìá¿í2
 ~
-java:S2229Œ"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8–÷ñ½í2
-ƒ
-java:S2229á"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(Åù×Àúÿÿÿÿ8ó¡ó½í2
+java:S2229Œ"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8ªìá¿í2
 ~
-java:S2229½"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8¸ç–¾í2
+java:S2229½"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8ªìá¿í2
 p
-java:S6204®"RReplace this usage of 'Stream.collect(Collectors.toList())' with 'Stream.toList()'(ª™¨¹8¯÷ñ½í2
+java:S6204®"RReplace this usage of 'Stream.collect(Collectors.toList())' with 'Stream.toList()'(ª™¨¹8¿ìá¿í2

--- a/src/main/java/com/melissa/diary/service/AiProfileImageService.java
+++ b/src/main/java/com/melissa/diary/service/AiProfileImageService.java
@@ -1,0 +1,49 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.ai.ImageGenerator;
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.AiProfile;
+import com.melissa.diary.repository.AiProfileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AiProfileImageService {
+
+    private final AiProfileRepository aiProfileRepository;
+    private final ImageGenerator imageGenerator;
+
+    /** 프로필 ID 기준으로 이미지 생성·S3 업로드·DB 반영을 비동기로 수행 */
+    @Async("asyncTaskExecutor")
+    public void generateAndSaveProfileImage(Long aiProfileId) {
+        try {
+            AiProfile profile = aiProfileRepository.findById(aiProfileId)
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.PROFILE_NOT_FOUND));
+
+            String prompt = buildPromptProfileImage(profile);
+            String url    = imageGenerator.genProfileImage(prompt);
+
+            updateImageUrl(profile, url);
+        } catch (Exception e) {
+            log.error("[Async-ProfileImage] 생성 실패 id={}", aiProfileId, e);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateImageUrl(AiProfile profile, String url) {
+        profile.setImageS3(url);
+        aiProfileRepository.save(profile);
+    }
+
+    private String buildPromptProfileImage(AiProfile p) {
+        // 간단 예시: 프로필 이름만 넣어도 충분히 유니크한 캐릭터 그림을 얻을 수 있음
+        return "%s, 단일 캐릭터, 픽사 스타일, 귀여운 일러스트".formatted(p.getProfileName());
+    }
+}

--- a/src/main/java/com/melissa/diary/service/AiProfileServiceV2.java
+++ b/src/main/java/com/melissa/diary/service/AiProfileServiceV2.java
@@ -1,0 +1,157 @@
+package com.melissa.diary.service;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.converter.AiProfileConverter;
+import com.melissa.diary.domain.AiProfile;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.enums.UsageCost;
+import com.melissa.diary.repository.AiProfileRepository;
+import com.melissa.diary.repository.UserRepository;
+import com.melissa.diary.web.dto.AiProfileRequestDTO;
+import com.melissa.diary.web.dto.AiProfileResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service("aiProfileV2")
+public class AiProfileServiceV2 {
+
+    private final UserRepository userRepo;
+    private final AiProfileRepository profileRepo;
+    private final @Qualifier("profileClient") ChatClient profileClient;
+    private final AiProfileImageService     imageService;
+    private final QuotaService              quotaService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public AiProfileServiceV2(UserRepository userRepo, AiProfileRepository profileRepo, @Qualifier("profileClient") ChatClient profileClient, AiProfileImageService imageService, QuotaService quotaService) {
+        this.userRepo = userRepo;
+        this.profileRepo = profileRepo;
+        this.profileClient = profileClient;
+        this.imageService = imageService;
+        this.quotaService = quotaService;
+    }
+
+    /** V2: 텍스트 프로필 즉시 리턴, 이미지 비동기 */
+    @Transactional
+    public AiProfileResponseDTO.AiProfileResponse createAiProfile(
+            Long userId, AiProfileRequestDTO.AiProfileCreateRequest req) {
+
+        User user = userRepo.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+        quotaService.checkAndConsume(user, UsageCost.PROFILE);
+
+        // 1) LLM 호출로 프로필 텍스트 생성
+        String prompt       = buildPromptProfileText(req);
+        String llmJson      = profileClient.prompt().user(prompt).call().content();
+
+        // 2) JSON 파싱 → AiProfile entity (imageS3 = null)
+        AiProfile profile   = parseLlmResponse(llmJson);
+        profile.setUser(user);
+        profile.setQ1(req.getQ1());
+        profile.setQ2(req.getQ2());
+        profile.setQ3(req.getQ3());
+        profile.setQ4(req.getQ4());
+        profile.setQ5(req.getQ5());
+        profile.setQ6(req.getQ6());
+        profile.setImageS3(null);                // **중요**
+
+        // 3) 저장 (same TX)
+        AiProfile saved = profileRepo.save(profile);
+
+        // 4) 비동기 이미지 생성 시작
+        imageService.generateAndSaveProfileImage(saved.getId());
+
+        // 5) DTO 변환 (imageUrl == null) 즉시 리턴
+        return AiProfileConverter.toResponse(saved);
+    }
+
+    /* ===================== util ====================== */
+
+    private String buildPromptProfileText(AiProfileRequestDTO.AiProfileCreateRequest req) {
+        return """
+                 아래의 6가지 정보를 바탕으로, 다음 JSON을 생성해주세요:
+                 반드시 형식을 지켜 예시 응답(Json)처럼 리턴해주세요.
+                
+                 1) profileName: 대화 상대에 어울리는 귀여운 이름. 형용사 뒤의 이름은 사물 또는 동물로 한정
+                 (예: '행복한 빵빵이, 즐거운 몽몽이, 말랑한 구름이, 달콤한 마시멜로우, 보송한 리본, 엉뚱한 솔방울')
+                 2) firstChat : 첫 인사말 작성
+                 - 연령대와 성격에 맞는 표현 활용
+                 - 이모티콘 적절히 사용 (profileName에 관련된 이모티콘 또는 인사말에 맞는 이모티콘 선택)
+                 ٩(ˊᗜˋ*)و // ｡•̀ᴗ-)✧//◝(⑅•ᴗ•⑅)◜..°♡ //  (◍•ᴗ•◍) //  (ﾉ≧∀≦)ﾉ
+                 - 함께할 내용 제안, 상대방 상황에 대한 공감/질문, 인사말
+                 3) hashTag1, hashTag2: 2가지 해시태그
+                 - 대화 상대의 연령대와 분위기 반영
+                 4) feature1, feature2, feature3: 3가지 구체적인 행동이나 특징, 15자 이내
+                 5) defaultSystem: 채팅 서비스에서 ai의 성격 정리
+                 - 사용자가 원하는 특징을 지닌 프로필에 대한 설명을 적어줘.
+                 - 이는 사용자의 대화를 이끌 AI의 시스템 메시지로 들어갈 거야.
+                
+                 질문과 답변:
+                 Q1. 말투 스타일을 어떻게 할까? - %s
+                 Q2. 응답 방식은 어떻게 할까? - %s
+                 Q3. 감정 표현은 어느 정도로 할까? - %s
+                 Q4. 질문 방식은 어떻게 할까? - %s
+                 Q5. 대화의 개입 정도는? - %s
+                 Q6. 유머 사용 여부는? - %s
+                
+                
+                 반드시 형식을 지켜 예시 응답(Json)처럼 리턴해주세요.
+                 형식:
+                 {
+                   "profileName": "...",
+                   "firstChat": "...",
+                   "hashTag1": "...",
+                   "hashTag2": "...",
+                   "feature1": "...",
+                   "feature2": "...",
+                   "feature3": "...",
+                   "defaultSystem": "..."
+                 }
+                
+                 답변 예시:
+                 {
+                    "profileName": "달콤한 마시멜로우",
+                    "firstChat": "오늘 뭐 재밌는 일 있었어? 같이 이야기 나눠보자!",
+                    "hashTag1": "청춘의_하루",
+                    "hashTag2": "웃음치료사",
+                    "feature1": "오글거릴 정도로 진심인 칭찬",
+                    "feature2": "잘 웃어주는 리액션",
+                    "feature3": "틈새 유머 투척",
+                    "defaultSystem": "이 AI의 프로필 이름은 '달콤한 마시멜로우'이다. 이 AI는 다음과 같은 특징을 갖는다.
+                    첫째, 대화 상대에게 진심 어린 칭찬을 아끼지 않으며 언제나 긍정적인 에너지를 전달한다.
+                    둘째, 대화 중 자주 웃어주어 밝고 유쾌한 분위기를 조성한다.
+                    셋째, 대화 중 필요할 때마다 유머를 던져 상대방에게 즐거움을 준다."
+                  }
+                """.formatted(
+                req.getQ1(), req.getQ2(), req.getQ3(),
+                req.getQ4(), req.getQ5(), req.getQ6()
+        );
+    }
+
+    private AiProfile parseLlmResponse(String json){
+        try{
+            int s=json.indexOf("{"); int e=json.lastIndexOf("}");
+            if(s<0||e<0) throw new ErrorHandler(ErrorStatus.PARSING_FAIL);
+            JsonNode n=objectMapper.readTree(json.substring(s,e+1));
+            return AiProfile.builder()
+                    .profileName(n.get("profileName").asText())
+                    .firstChat(n.get("firstChat").asText())
+                    .hashTag1(n.get("hashTag1").asText())
+                    .hashTag2(n.get("hashTag2").asText())
+                    .feature1(n.get("feature1").asText())
+                    .feature2(n.get("feature2").asText())
+                    .feature3(n.get("feature3").asText())
+                    .promptText(n.get("defaultSystem").asText())
+                    .active(true)
+                    .build();
+        }catch(Exception e){ throw new ErrorHandler(ErrorStatus.PARSING_FAIL); }
+    }
+}

--- a/src/main/java/com/melissa/diary/web/controller/AiProfileControllerV2.java
+++ b/src/main/java/com/melissa/diary/web/controller/AiProfileControllerV2.java
@@ -1,0 +1,37 @@
+package com.melissa.diary.web.controller;
+
+import com.melissa.diary.apiPayload.ApiResponse;
+import com.melissa.diary.service.AiProfileServiceV2;
+import com.melissa.diary.web.dto.AiProfileRequestDTO;
+import com.melissa.diary.web.dto.AiProfileResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@Tag(name = "AiProfileAPI-V2", description = "AI 프로필 생성 – 텍스트 즉시 · 이미지 비동기")
+@RequestMapping("/api/v2/ai-profiles")
+@RequiredArgsConstructor
+public class AiProfileControllerV2 {
+
+    private final @Qualifier("aiProfileV2") AiProfileServiceV2 profileService;
+
+    @Operation(description = "V2: LLM 프로필 텍스트만 즉시 반환, 이미지 비동기")
+    @PostMapping
+    public ApiResponse<AiProfileResponseDTO.AiProfileResponse> createProfileV2(
+            Principal principal,
+            @RequestBody AiProfileRequestDTO.AiProfileCreateRequest request) {
+
+        Long userId = Long.parseLong(principal.getName());
+        var dto = profileService.createAiProfile(userId, request);  // imageUrl == null
+        return ApiResponse.onSuccess(dto);
+    }
+
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- V2 프로필 생성 API: 텍스트 요약은 즉시 반환, 이미지 생성‧S3 업로드는 비동기(@Async) 로 분리
- 같은 클래스 내부에서 @Async 메서드를 호출하면 동기로 실행된다는 점을 간과해 최초 구현이 실패 → 이미지 전담  AIProfileImageService로 분리해 진짜 비동기 수행 보장
- 평균 응답 지연 18 초 → 5 초 (-72 %) 로 단축, 사용자 경험 관점에서 체감 속도 3.6 배 향상

## 📋 변경 사항
- AiProfileImageService 생성: 이미지 생성‧업로드‧DB 반영 전담, @Async 적용
- 요약 로직을 AiProfileServiceV2 로 분리: 요약만 저장 후 AiProfileImageService 호출
- 기존 V1 API 완전 유지, 새 버전은 /api/v2/ai-profiles 경로로 제공

## 🔍 Code Review
- 기존 AsyncConfig 활용: asyncTaskExecutor 스레드풀(고정 4) 설정

## 📸 ScreenShot
빌드 전후 응답 시간 비교 — 18 s → 5 s 로 감소