### PR TITLE
fix: 이미지 생성 task를 AFTER_COMMIT events로 이전

### DIFF
--- a/.idea/sonarlint/issuestore/0/5/0509d354c43582967c9f7d7785e32a97dd654fb6
+++ b/.idea/sonarlint/issuestore/0/5/0509d354c43582967c9f7d7785e32a97dd654fb6
@@ -1,5 +1,0 @@
-
-u
-java:S1128"SRemove this unused import 'org.springframework.beans.factory.annotation.Qualifier'.(íàÄ®ıÿÿÿÿ8şÒÌ·è2
-c
-java:S1128"FRemove this unused import 'org.springframework.web.client.RestClient'.(Îüâ8şÒÌ·è2

--- a/.idea/sonarlint/issuestore/1/9/19f6a32f8e4a977dfabc829d411ea4bf07d9bad2
+++ b/.idea/sonarlint/issuestore/1/9/19f6a32f8e4a977dfabc829d411ea4bf07d9bad2
@@ -3,13 +3,13 @@ X
 java:S1141¡"5Extract this nested try block into a separate method.(¡»¢üùÿÿÿÿ8õëá¿í2
 ƒ
 java:S1488É"`Immediately return this expression instead of assigning it to the temporary variable "response".(ò¥µ¹şÿÿÿÿ8õëá¿í2
+~
+java:S2229½"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8ªìá¿í2
 ƒ
 java:S2229á"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(Åù×Àúÿÿÿÿ8ªìá¿í2
 €
 java:S2229s"c"fetchThreadSummaryData's" @Transactional requirement is incompatible with the one for this method.(øñé8ªìá¿í2
 ~
 java:S2229Œ"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8ªìá¿í2
-~
-java:S2229½"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8ªìá¿í2
 p
 java:S6204®"RReplace this usage of 'Stream.collect(Collectors.toList())' with 'Stream.toList()'(ª™¨¹8¿ìá¿í2

--- a/.idea/sonarlint/issuestore/index.pb
+++ b/.idea/sonarlint/issuestore/index.pb
@@ -156,3 +156,9 @@ g
 Msrc/main/java/com/melissa/diary/web/controller/ThreadSummaryV2Controller.java,c\5\c59533f8e15b9b3300fc83c917146f1bf5785973
 o
 ?src/main/java/com/melissa/diary/service/ThreadImageService.java,9\2\928e1bf58794ed5a0f1fa2d88ed3c085c9295d1d
+r
+Bsrc/main/java/com/melissa/diary/service/AiProfileImageService.java,0\8\08022ae59b6f215213f1161285c5aaf4481627c6
+o
+?src/main/java/com/melissa/diary/service/AiProfileServiceV2.java,4\8\480e3b349cd3bc7dafdd43fa74bb8240aa22b526
+y
+Isrc/main/java/com/melissa/diary/web/controller/AiProfileControllerV2.java,1\6\16c54c09bf4ec2e1eeb5250b158b7428cf0e786f

--- a/.idea/sonarlint/securityhotspotstore/index.pb
+++ b/.idea/sonarlint/securityhotspotstore/index.pb
@@ -156,3 +156,9 @@ g
 Msrc/main/java/com/melissa/diary/web/controller/ThreadSummaryV2Controller.java,c\5\c59533f8e15b9b3300fc83c917146f1bf5785973
 o
 ?src/main/java/com/melissa/diary/service/ThreadImageService.java,9\2\928e1bf58794ed5a0f1fa2d88ed3c085c9295d1d
+y
+Isrc/main/java/com/melissa/diary/web/controller/AiProfileControllerV2.java,1\6\16c54c09bf4ec2e1eeb5250b158b7428cf0e786f
+r
+Bsrc/main/java/com/melissa/diary/service/AiProfileImageService.java,0\8\08022ae59b6f215213f1161285c5aaf4481627c6
+o
+?src/main/java/com/melissa/diary/service/AiProfileServiceV2.java,4\8\480e3b349cd3bc7dafdd43fa74bb8240aa22b526

--- a/src/main/java/com/melissa/diary/event/ProfileImageEvent.java
+++ b/src/main/java/com/melissa/diary/event/ProfileImageEvent.java
@@ -1,0 +1,2 @@
+package com.melissa.diary.event;
+public record ProfileImageEvent(Long profileId) {}

--- a/src/main/java/com/melissa/diary/event/ThreadImageEvent.java
+++ b/src/main/java/com/melissa/diary/event/ThreadImageEvent.java
@@ -1,0 +1,2 @@
+package com.melissa.diary.event;
+public record ThreadImageEvent(Long threadId) {}

--- a/src/main/java/com/melissa/diary/listener/ProfileImageListener.java
+++ b/src/main/java/com/melissa/diary/listener/ProfileImageListener.java
@@ -1,0 +1,22 @@
+package com.melissa.diary.listener;
+
+import com.melissa.diary.event.ProfileImageEvent;
+import com.melissa.diary.service.AiProfileImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ProfileImageListener {
+
+    private final AiProfileImageService imageSvc;
+
+    @Async("asyncTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ProfileImageEvent e) {
+        imageSvc.generateAndSaveProfileImage(e.profileId());
+    }
+}

--- a/src/main/java/com/melissa/diary/listener/ThreadImageListener.java
+++ b/src/main/java/com/melissa/diary/listener/ThreadImageListener.java
@@ -1,0 +1,22 @@
+package com.melissa.diary.listener;
+
+import com.melissa.diary.event.ThreadImageEvent;
+import com.melissa.diary.service.ThreadImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ThreadImageListener {
+
+    private final ThreadImageService imageSvc;
+
+    @Async("asyncTaskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(ThreadImageEvent e) {
+        imageSvc.generateAndSaveImage(e.threadId());
+    }
+}

--- a/src/main/java/com/melissa/diary/service/AiProfileImageService.java
+++ b/src/main/java/com/melissa/diary/service/AiProfileImageService.java
@@ -21,7 +21,6 @@ public class AiProfileImageService {
     private final ImageGenerator imageGenerator;
 
     /** 프로필 ID 기준으로 이미지 생성·S3 업로드·DB 반영을 비동기로 수행 */
-    @Async("asyncTaskExecutor")
     public void generateAndSaveProfileImage(Long aiProfileId) {
         try {
             AiProfile profile = aiProfileRepository.findById(aiProfileId)

--- a/src/main/java/com/melissa/diary/service/AiProfileServiceV2.java
+++ b/src/main/java/com/melissa/diary/service/AiProfileServiceV2.java
@@ -9,6 +9,7 @@ import com.melissa.diary.converter.AiProfileConverter;
 import com.melissa.diary.domain.AiProfile;
 import com.melissa.diary.domain.User;
 import com.melissa.diary.domain.enums.UsageCost;
+import com.melissa.diary.event.ProfileImageEvent;
 import com.melissa.diary.repository.AiProfileRepository;
 import com.melissa.diary.repository.UserRepository;
 import com.melissa.diary.web.dto.AiProfileRequestDTO;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,12 +33,16 @@ public class AiProfileServiceV2 {
     private final QuotaService              quotaService;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    public AiProfileServiceV2(UserRepository userRepo, AiProfileRepository profileRepo, @Qualifier("profileClient") ChatClient profileClient, AiProfileImageService imageService, QuotaService quotaService) {
+    private final ApplicationEventPublisher publisher;
+
+    public AiProfileServiceV2(UserRepository userRepo, AiProfileRepository profileRepo, @Qualifier("profileClient") ChatClient profileClient, AiProfileImageService imageService, QuotaService quotaService,
+                              ApplicationEventPublisher publisher) {
         this.userRepo = userRepo;
         this.profileRepo = profileRepo;
         this.profileClient = profileClient;
         this.imageService = imageService;
         this.quotaService = quotaService;
+        this.publisher = publisher;
     }
 
     /** V2: 텍스트 프로필 즉시 리턴, 이미지 비동기 */
@@ -67,7 +73,8 @@ public class AiProfileServiceV2 {
         AiProfile saved = profileRepo.save(profile);
 
         // 4) 비동기 이미지 생성 시작
-        imageService.generateAndSaveProfileImage(saved.getId());
+        publisher.publishEvent(new ProfileImageEvent(saved.getId()));
+
 
         // 5) DTO 변환 (imageUrl == null) 즉시 리턴
         return AiProfileConverter.toResponse(saved);

--- a/src/main/java/com/melissa/diary/service/ThreadImageService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadImageService.java
@@ -28,7 +28,6 @@ public class ThreadImageService {
      * threadId 기준으로 이미지를 생성하고 imageUrl 을 저장한다.
      * 메서드가 @Async 이므로 별도 스레드에서 실행된다.
      */
-    @Async("asyncTaskExecutor")
     public void generateAndSaveImage(Long threadId) {
         try {
             Thread thread = threadRepository.findById(threadId)

--- a/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
@@ -11,6 +11,7 @@ import com.melissa.diary.domain.Thread;
 import com.melissa.diary.domain.enums.Mood;
 import com.melissa.diary.domain.enums.Role;
 import com.melissa.diary.domain.enums.UsageCost;
+import com.melissa.diary.event.ThreadImageEvent;
 import com.melissa.diary.repository.ThreadRepository;
 import com.melissa.diary.repository.UserRepository;
 import com.melissa.diary.repository.UserSettingRepository;
@@ -25,6 +26,7 @@ import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.openai.OpenAiChatOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -51,6 +53,8 @@ public class ThreadSummaryService {
 
     private final ThreadImageService threadImageService;
 
+    private final ApplicationEventPublisher publisher;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
     public ThreadSummaryService(UserRepository userRepository,
                                 ThreadRepository threadRepository,
@@ -59,7 +63,8 @@ public class ThreadSummaryService {
                                 ChatClient summaryClient,
                                 ImageGenerator imageGenerator,
                                 QuotaService quotaService,
-                                ThreadImageService threadImageService
+                                ThreadImageService threadImageService,
+                                ApplicationEventPublisher publisher
     ) {
         this.userRepository = userRepository;
         this.threadRepository = threadRepository;
@@ -68,6 +73,7 @@ public class ThreadSummaryService {
         this.imageGenerator = imageGenerator;
         this.quotaService = quotaService;
         this.threadImageService = threadImageService;
+        this.publisher = publisher;
     }
 
     /**
@@ -353,7 +359,7 @@ public class ThreadSummaryService {
         updateThreadSummary(thread.getId(), llmResp, null);
 
         // 이미지 처리 비동기 시작
-        threadImageService.generateAndSaveImage(thread.getId());
+        publisher.publishEvent(new ThreadImageEvent(thread.getId()));
 
         // 7) 즉시 응답
         return dto;


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
비동기 이미지 태스크가 트랜잭션 커밋보다 먼저 실행돼 id not found 예외가 터지던 레이스를 해결했다.

해결한 방식 : 커밋 직후 (AFTER_COMMIT) 이벤트를 발행하고, 별도 @Async 리스너에서 이미지 생성·S3 업로드·DB 업데이트를 수행하도록 구조를 변경

## 📋 변경 사항
- 새 이벤트 ProfileImageEvent / ThreadImageEvent 신설
- @TransactionalEventListener(phase = AFTER_COMMIT) + @Async 리스너 2종 추가
- AiProfileServiceV2 / ThreadSummaryService ⇒ 이벤트 publish 로 변경
- ImageService 쪽 @Async 제거(동기 호출) + REQUIRES_NEW 유지
→ DB 커밋 완료 후에만 이미지 생성 스레드 실행, id not-found 레이스 완전 제거

이미지 태스크가 DB 레코드 커밋 이후에만 실행되어 Optional.orElseThrow 예외 재발 X
최초 API 응답 지연 없음(요약 5 초, 프로필 4 초 유지)
실패 시 여전히 [Async-ProfileImage] / [Async-Image] 로그로 추적 가능

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
