### PR TITLE
feat: 이미지 생성 실패시, placehold 이미지 저장

### DIFF
--- a/.idea/sonarlint/issuestore/1/9/19f6a32f8e4a977dfabc829d411ea4bf07d9bad2
+++ b/.idea/sonarlint/issuestore/1/9/19f6a32f8e4a977dfabc829d411ea4bf07d9bad2
@@ -1,15 +1,17 @@
 
 X
-java:S1141¡"5Extract this nested try block into a separate method.(¡»¢üùÿÿÿÿ8õëá¿í2
+java:S1141§"5Extract this nested try block into a separate method.(¡»¢üùÿÿÿÿ8Îˆ Ïò2
 ƒ
-java:S1488É"`Immediately return this expression instead of assigning it to the temporary variable "response".(ò¥µ¹þÿÿÿÿ8õëá¿í2
+java:S1488Ï"`Immediately return this expression instead of assigning it to the temporary variable "response".(ò¥µ¹þÿÿÿÿ8Ïˆ Ïò2
+ƒ
+java:S2229ç"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(Åù×Àúÿÿÿÿ8üˆ Ïò2
 ~
-java:S2229½"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8ªìá¿í2
-ƒ
-java:S2229á"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(Åù×Àúÿÿÿÿ8ªìá¿í2
+java:S2229Ã"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8üˆ Ïò2
 €
-java:S2229s"c"fetchThreadSummaryData's" @Transactional requirement is incompatible with the one for this method.(žøñé8ªìá¿í2
+java:S2229y"c"fetchThreadSummaryData's" @Transactional requirement is incompatible with the one for this method.(žøñé8üˆ Ïò2
 ~
-java:S2229Œ"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8ªìá¿í2
+java:S2229’"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8üˆ Ïò2
 p
-java:S6204®"RReplace this usage of 'Stream.collect(Collectors.toList())' with 'Stream.toList()'(ª™¨¹8¿ìá¿í2
+java:S6204´"RReplace this usage of 'Stream.collect(Collectors.toList())' with 'Stream.toList()'(ª™¨¹8‘‰ Ïò2
+S
+java:S10686"6Remove this unused "threadImageService" private field.(£²‚ë8 ‰ Ïò2

--- a/src/main/java/com/melissa/diary/service/AiProfileImageService.java
+++ b/src/main/java/com/melissa/diary/service/AiProfileImageService.java
@@ -19,19 +19,23 @@ public class AiProfileImageService {
 
     private final AiProfileRepository aiProfileRepository;
     private final ImageGenerator imageGenerator;
+    private static final String DEFAULT_IMG =
+            "https://melissa-s3.s3.ap-northeast-2.amazonaws.com/default.png";
 
     /** 프로필 ID 기준으로 이미지 생성·S3 업로드·DB 반영을 비동기로 수행 */
     public void generateAndSaveProfileImage(Long aiProfileId) {
+        AiProfile profile = aiProfileRepository.findById(aiProfileId).orElse(null);
+        if (profile == null) {
+            log.error("[Async-ProfileImage] id={} not found", aiProfileId);
+            return;
+        }
+
         try {
-            AiProfile profile = aiProfileRepository.findById(aiProfileId)
-                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.PROFILE_NOT_FOUND));
-
-            String prompt = buildPromptProfileImage(profile);
-            String url    = imageGenerator.genProfileImage(prompt);
-
-            updateImageUrl(profile, url);
+            String url = imageGenerator.genProfileImage(buildPromptProfileImage(profile));
+            updateImageUrl(profile, url);                         // 정상 저장
         } catch (Exception e) {
             log.error("[Async-ProfileImage] 생성 실패 id={}", aiProfileId, e);
+            updateImageUrl(profile, DEFAULT_IMG);                 // 실패 시 기본 이미지
         }
     }
 

--- a/src/main/java/com/melissa/diary/service/ThreadImageService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadImageService.java
@@ -23,22 +23,26 @@ public class ThreadImageService {
 
     private final ThreadRepository threadRepository;
     private final ImageGenerator    imageGenerator;
+    private static final String DEFAULT_IMG =
+            "https://melissa-s3.s3.ap-northeast-2.amazonaws.com/default.png";
 
     /**
      * threadId 기준으로 이미지를 생성하고 imageUrl 을 저장한다.
      * 메서드가 @Async 이므로 별도 스레드에서 실행된다.
      */
     public void generateAndSaveImage(Long threadId) {
+        Thread t = threadRepository.findById(threadId).orElse(null);
+        if (t == null) {
+            log.error("[Async-Image] threadId={} not found", threadId);
+            return;
+        }
+
         try {
-            Thread thread = threadRepository.findById(threadId)
-                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.CALENDAR_NOT_FOUND));
-
-            String prompt = buildImagePrompt(thread);
-            String url    = imageGenerator.genProfileImage(prompt);
-
-            updateThreadImage(thread, url);
+            String url = imageGenerator.genProfileImage(buildImagePrompt(t));
+            updateThreadImage(t, url);                            // ✅ 정상 저장
         } catch (Exception e) {
             log.error("[Async-Image] threadId={} 처리 실패", threadId, e);
+            updateThreadImage(t, DEFAULT_IMG);                    // ✅ 실패 시 기본 이미지
         }
     }
 


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
이미지 생성 실패 시, placehold 이미지로 저장하도록 수정

- 생성도중 이미지와 실패한 경우의 placehold 이미지를 추후 제공받으면 url 교체 예정

## 📋 변경 사항
- ThreadImageService와 AiProfileImageService의 try-catch를 통해 이미지 생성 실패한 경우 updateImage로직을 placeholder image url로 적용하도록 수정함.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
