### PR TITLE
feat: 2 stage llm -> prompt 생성층 추가(chaining)

### DIFF
--- a/.idea/sonarlint/issuestore/1/9/19f6a32f8e4a977dfabc829d411ea4bf07d9bad2
+++ b/.idea/sonarlint/issuestore/1/9/19f6a32f8e4a977dfabc829d411ea4bf07d9bad2
@@ -3,10 +3,10 @@ X
 java:S1141§"5Extract this nested try block into a separate method.(¡»¢üùÿÿÿÿ8Îˆ Ïò2
 ƒ
 java:S1488Ï"`Immediately return this expression instead of assigning it to the temporary variable "response".(ò¥µ¹şÿÿÿÿ8Ïˆ Ïò2
-ƒ
-java:S2229ç"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(Åù×Àúÿÿÿÿ8üˆ Ïò2
 ~
 java:S2229Ã"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(õ¾Å¼8üˆ Ïò2
+ƒ
+java:S2229ç"`"updateThreadSummary's" @Transactional requirement is incompatible with the one for this method.(Åù×Àúÿÿÿÿ8üˆ Ïò2
 €
 java:S2229y"c"fetchThreadSummaryData's" @Transactional requirement is incompatible with the one for this method.(øñé8üˆ Ïò2
 ~

--- a/.idea/sonarlint/issuestore/index.pb
+++ b/.idea/sonarlint/issuestore/index.pb
@@ -162,3 +162,7 @@ o
 ?src/main/java/com/melissa/diary/service/AiProfileServiceV2.java,4\8\480e3b349cd3bc7dafdd43fa74bb8240aa22b526
 y
 Isrc/main/java/com/melissa/diary/web/controller/AiProfileControllerV2.java,1\6\16c54c09bf4ec2e1eeb5250b158b7428cf0e786f
+|
+Lsrc/main/java/com/melissa/diary/service/ThreadImagePromptRefinerService.java,a\8\a81b333ca4f436f25a0ffce7ae2909ed6627005c
+z
+Jsrc/main/java/com/melissa/diary/service/AiProfilePromptRefinerService.java,2\4\24df4e47a3f828ed72b322265672ee4840fb1576

--- a/.idea/sonarlint/securityhotspotstore/index.pb
+++ b/.idea/sonarlint/securityhotspotstore/index.pb
@@ -162,3 +162,7 @@ r
 Bsrc/main/java/com/melissa/diary/service/AiProfileImageService.java,0\8\08022ae59b6f215213f1161285c5aaf4481627c6
 o
 ?src/main/java/com/melissa/diary/service/AiProfileServiceV2.java,4\8\480e3b349cd3bc7dafdd43fa74bb8240aa22b526
+z
+Jsrc/main/java/com/melissa/diary/service/AiProfilePromptRefinerService.java,2\4\24df4e47a3f828ed72b322265672ee4840fb1576
+|
+Lsrc/main/java/com/melissa/diary/service/ThreadImagePromptRefinerService.java,a\8\a81b333ca4f436f25a0ffce7ae2909ed6627005c

--- a/src/main/java/com/melissa/diary/config/AiConfig.java
+++ b/src/main/java/com/melissa/diary/config/AiConfig.java
@@ -123,4 +123,43 @@ public class AiConfig {
                 .defaultSystem(system)
                 .build();
     }
+
+    @Bean(name = "profilePromptRefinerClient")
+    ChatClient profilePromptRefinerClient() {
+        OpenAiApi api = OpenAiApi.builder().apiKey(apiKey).build();
+        OpenAiChatOptions opts = OpenAiChatOptions.builder()
+                .model(OpenAiApi.ChatModel.GPT_4_O)
+                .temperature(0.35)
+                .maxTokens(120)
+                .build();
+
+        String sys = """
+        당신은 ‘캐릭터 일러스트 프롬프트화’ 전문 엔지니어이다.
+        - 입력된 간단한 캐릭터 키워드를 바탕으로 특징을 추출하여 외형 특징, 표정·감정, 스타일, 분위기 등을 이미지 ai 모델이 이해하기 쉽도록 프롬프팅화 해라.
+        - 출력 값을 바로 이미지 모델의 입력을 집어넣을 것이기에 잡설하지말고 따옴표·마크다운 없이 반환하라.
+        """;
+        return ChatClient.builder(
+                        OpenAiChatModel.builder().openAiApi(api).defaultOptions(opts).build())
+                .defaultSystem(sys).build();
+    }
+
+    @Bean(name = "diaryPromptRefinerClient")
+    ChatClient diaryPromptRefinerClient() {
+        OpenAiApi api = OpenAiApi.builder().apiKey(apiKey).build();
+        OpenAiChatOptions opts = OpenAiChatOptions.builder()
+                .model(OpenAiApi.ChatModel.GPT_4_O)
+                .temperature(0.45)
+                .maxTokens(180)
+                .build();
+
+        String sys = """
+        당신은 ‘그림일기 삽화 프롬프트화’ 전문가이다.
+        - 입력 문장을 시간, 장소, 행동, 감정이 또렷한 장면 묘사로 표현하고, 이미지 ai 모델이 이해하기 쉽도록 프롬프팅화 해라.
+        - 여러 사람에 대해서 자신의 경험처럼 받아들이도록, 최대한 사람 그림은 넣지않도록 프롬프팅해(자신 얼굴이 아니면 어색하니까)
+        - 출력 값을 바로 이미지 모델의 입력을 집어넣을 것이기에 잡설하지말고 따옴표·마크다운 없이 반환하라.
+        """;
+        return ChatClient.builder(
+                        OpenAiChatModel.builder().openAiApi(api).defaultOptions(opts).build())
+                .defaultSystem(sys).build();
+    }
 }

--- a/src/main/java/com/melissa/diary/service/AiProfileImageService.java
+++ b/src/main/java/com/melissa/diary/service/AiProfileImageService.java
@@ -19,6 +19,7 @@ public class AiProfileImageService {
 
     private final AiProfileRepository aiProfileRepository;
     private final ImageGenerator imageGenerator;
+    private final AiProfilePromptRefinerService    refiner;
     private static final String DEFAULT_IMG =
             "https://melissa-s3.s3.ap-northeast-2.amazonaws.com/default.png";
 
@@ -30,8 +31,11 @@ public class AiProfileImageService {
             return;
         }
 
+        String rawPrompt   = buildPromptProfileImage(profile);     // 1차(raw)
+        String finalPrompt = refiner.refine(rawPrompt);            // 2차(LLM)
+
         try {
-            String url = imageGenerator.genProfileImage(buildPromptProfileImage(profile));
+            String url = imageGenerator.genProfileImage(finalPrompt);
             updateImageUrl(profile, url);                         // 정상 저장
         } catch (Exception e) {
             log.error("[Async-ProfileImage] 생성 실패 id={}", aiProfileId, e);

--- a/src/main/java/com/melissa/diary/service/AiProfilePromptRefinerService.java
+++ b/src/main/java/com/melissa/diary/service/AiProfilePromptRefinerService.java
@@ -1,0 +1,22 @@
+package com.melissa.diary.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AiProfilePromptRefinerService {
+
+    private final ChatClient client;
+
+    public AiProfilePromptRefinerService(
+            @Qualifier("profilePromptRefinerClient") ChatClient client) {
+        this.client = client;
+    }
+
+    public String refine(String raw) {
+        try { return client.prompt().user(raw).call().content().trim(); }
+        catch (Exception e) { return raw; }
+    }
+}

--- a/src/main/java/com/melissa/diary/service/ThreadImagePromptRefinerService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadImagePromptRefinerService.java
@@ -1,0 +1,22 @@
+package com.melissa.diary.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ThreadImagePromptRefinerService {
+
+    private final ChatClient client;
+
+    public ThreadImagePromptRefinerService(
+            @Qualifier("diaryPromptRefinerClient") ChatClient client) {
+        this.client = client;
+    }
+
+    public String refine(String raw) {
+        try { return client.prompt().user(raw).call().content().trim(); }
+        catch (Exception e) { return raw; }
+    }
+}

--- a/src/main/java/com/melissa/diary/service/ThreadImageService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadImageService.java
@@ -23,6 +23,7 @@ public class ThreadImageService {
 
     private final ThreadRepository threadRepository;
     private final ImageGenerator    imageGenerator;
+    private final ThreadImagePromptRefinerService refiner;
     private static final String DEFAULT_IMG =
             "https://melissa-s3.s3.ap-northeast-2.amazonaws.com/default.png";
 
@@ -37,12 +38,15 @@ public class ThreadImageService {
             return;
         }
 
+        String rawPrompt   = buildImagePrompt(t);          // 1차(raw)
+        String finalPrompt = refiner.refine(rawPrompt);    // 2차(LLM)
+
         try {
-            String url = imageGenerator.genProfileImage(buildImagePrompt(t));
-            updateThreadImage(t, url);                            // ✅ 정상 저장
+            String url = imageGenerator.genProfileImage(finalPrompt);
+            updateThreadImage(t, url);                            // 정상 저장
         } catch (Exception e) {
             log.error("[Async-Image] threadId={} 처리 실패", threadId, e);
-            updateThreadImage(t, DEFAULT_IMG);                    // ✅ 실패 시 기본 이미지
+            updateThreadImage(t, DEFAULT_IMG);                    // 실패 시 기본 이미지
         }
     }
 
@@ -57,7 +61,7 @@ public class ThreadImageService {
         String mood = t.getMood() == null ? Mood.HAPPY.name() : t.getMood().name();
         String tag1 = t.getHashtag1() == null ? "" : t.getHashtag1();
         String tag2 = t.getHashtag2() == null ? "" : t.getHashtag2();
-        return String.format("%s, %s, %s %s 지브리·디즈니 느낌 수채화 일러스트",
+        return String.format("%s, %s, %s %s 수채화 일러스트",
                 mood,
                 t.getSummaryTitle() == null ? "Untitled" : t.getSummaryTitle(),
                 tag1, tag2);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,15 +7,15 @@ spring:
       api-key: ${OPENAI_API_KEY}
       image:
         options:
-          model: dall-e-3
+          model: gpt-4o
           size: 512x512
           style: natural
           quality: standard
           response_format: b64_json
   datasource:
-    url: jdbc:mysql://${AWS_DB_URL}:3306/melissa_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=true&requireSSL=true #jdbc:mysql://127.0.0.1:3306/melissa_db  #
-    username: ${AWS_DB_USERNAME} # root #
-    password: ${AWS_DB_PASSWORD} #12341234 #
+    url: jdbc:mysql://127.0.0.1:3306/melissa_db  #jdbc:mysql://${AWS_DB_URL}:3306/melissa_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useSSL=true&requireSSL=true #
+    username: root #${AWS_DB_USERNAME} #
+    password: 12341234 #${AWS_DB_PASSWORD} #
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       maximum-pool-size: 20 # 풀 크기 늘리기


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약

이미지 생성 플로우 개편
> 기존 1차 프롬프트를 리파인 후 이미지 모델 호출

- Refiner 서비스를 추가해, llm을 통해 기존 raw prompt를 보완하도록 추가
- AiProfileImageService, ThreadImageService, ThreadSummaryService 에 리파인 단계 호출을 적용

## 📋 변경 사항
Refiner 서비스 2종 추가
- AiProfilePromptRefinerService (프로필 전용)
- ThreadImagePromptRefinerService (일기 삽화 전용)

각 서비스가 전용 ChatClient 빈(profilePromptRefinerClient, diaryPromptRefinerClient)을 사용하도록 명시적 생성자 주입 적용.
- 이미지 생성 서비스(refiner 서비스에 의존해서, refine 함수 호출)
- ThreadSummaryService 수정

DI 수정
- 관련 서비스 생성자에 전용 리파이너 주입 추가.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
