### PR TITLE
fix: 토큰 검증용 유효기간 설정이 하루로 되어있는 것을 15일로 수정

### DIFF
--- a/src/main/java/com/melissa/diary/service/UserService.java
+++ b/src/main/java/com/melissa/diary/service/UserService.java
@@ -125,7 +125,7 @@ public class UserService {
     public String createRefreshToken(User user) {
         String token = jwtProvider.createRefreshToken(user.getId(), user.getProvider());
         user.setRefreshToken(token);
-        user.setRefreshTokenExpiry(LocalDateTime.now().plusDays(1));
+        user.setRefreshTokenExpiry(LocalDateTime.now().plusDays(15));
         userRepository.save(user);
         return token;
     }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
기존 리프레시 토큰을 발급하는 시간을 1000L * 60 * 60 * 24 * 15(15일)로 설정하여 제대로 수정한 줄 알았으나, Test API 구축을 위해 코드를 리뷰하면서 검증용 UserDB에 저장하는 유효기간 자체를 업데이트 하지 않은 것을 발견함.

이를 통해 코드 교차 검증의 중요성을 깨달았음.

## 📋 변경 사항
- UserDB에 저장하고 있던 검증용 유효기간을 1일 -> 15일로 업데이트

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
