### PR TITLE
fix: 리프레시 토큰 인증 api 방식을 Bearer 헤더 방식으로 개선(OAuth 2.0 표준)

### DIFF
--- a/src/main/java/com/melissa/diary/web/controller/AuthController.java
+++ b/src/main/java/com/melissa/diary/web/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.melissa.diary.web.controller;
 
 import com.melissa.diary.apiPayload.ApiResponse;
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
 import com.melissa.diary.converter.UserConverter;
 import com.melissa.diary.domain.User;
 import com.melissa.diary.service.UserService;
@@ -76,24 +78,27 @@ public class AuthController {
         return ApiResponse.onSuccess(result);
     }
 
-
-    // Refresh Token 재발급
     // Refresh Token 재발급
     @PostMapping("/refresh")
-    @Operation(description = "Refresh토큰을 입력해, AccessToken 재생성합니다.")
+    @Operation(description = "Authorization 헤더에 Refresh토큰을 입력해, AccessToken 재생성합니다.")
     public ApiResponse<UserResponseDTO.OAuthLoginResultDTO> refreshToken(
-            @RequestBody @Valid UserRequestDTO.RefreshRequestDTO request
+            HttpServletRequest request
     ) {
-        // [1] refreshToken으로 사용자 조회 & 검증
-        User user = userService.refreshAccessToken(request.getRefreshToken());
+        // [1] Authorization 헤더에서 refreshToken 추출
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new ErrorHandler(ErrorStatus.INVALID_TOKEN);
+        }
+        String refreshToken = authHeader.substring(7);
 
-        // [2] 새로운 Token 생성
+        // [2] refreshToken으로 사용자 조회 & 검증
+        User user = userService.refreshAccessToken(refreshToken);
+
+        // [3] 새로운 Token 생성
         String newAccessToken = userService.createAccessToken(user);
         String newRefreshToken = userService.createRefreshToken(user);
 
-
-
-        // [3] 결과 DTO 생성
+        // [4] 결과 DTO 생성
         UserResponseDTO.OAuthLoginResultDTO result =
                 UserResponseDTO.OAuthLoginResultDTO.builder()
                         .userId(user.getId())

--- a/src/main/java/com/melissa/diary/web/dto/UserRequestDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/UserRequestDTO.java
@@ -36,15 +36,6 @@ public class UserRequestDTO {
         @NotBlank
         private String idToken;
     }
-    
 
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class RefreshRequestDTO {
-        @NotBlank
-        private String refreshToken;
-    }
 
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
토큰 리프레시 API 인증 방식 개선(OAuth 2.0 표준)

## 📋 변경 사항
- 백엔드 토큰 리프레시 API를 Authorization 헤더 방식으로 변경
- 불필요한 RefreshRequestDTO 제거
- API 명세서 업데이트

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
![image](https://github.com/user-attachments/assets/c614f144-7fbe-45ec-b078-767b359df317)
