### PR TITLE
fix: 일기요약 api 연속 요청 시 중복 처리 및 리소스 낭비 현상

### DIFF
--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -37,6 +37,10 @@ public enum ErrorStatus implements BaseErrorCode {
     CALENDAR_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CALENDAR5001", "캘린더 데이터를 처리하는 중 오류가 발생했습니다."),
     THREAD_ALREADY_ENROLL(HttpStatus.BAD_REQUEST, "THREAD4001", "해당 날짜의 스레드가 이미 존재합니다."),
     THREAD_LATEST_NOT_FOUND(HttpStatus.NOT_FOUND, "THREAD4002", "최근 스레드를 찾을 수 없습니다."),
+    THREAD_TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "THREAD4003", "요약 요청이 너무 자주 발생했습니다. 1분 후 다시 시도해주세요."),
+
+    // Thread Summary
+    THREADSUMMARY4001(HttpStatus.TOO_MANY_REQUESTS, "THREADSUMMARY4001", "요약 요청이 너무 자주 발생했습니다. 1분 후 다시 시도해주세요."),
 
     // CHAT
     CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4001", "해당 날짜의 채팅로그를 찾을 수 없습니다."),

--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -39,9 +39,6 @@ public enum ErrorStatus implements BaseErrorCode {
     THREAD_LATEST_NOT_FOUND(HttpStatus.NOT_FOUND, "THREAD4002", "최근 스레드를 찾을 수 없습니다."),
     THREAD_TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "THREAD4003", "요약 요청이 너무 자주 발생했습니다. 1분 후 다시 시도해주세요."),
 
-    // Thread Summary
-    THREADSUMMARY4001(HttpStatus.TOO_MANY_REQUESTS, "THREADSUMMARY4001", "요약 요청이 너무 자주 발생했습니다. 1분 후 다시 시도해주세요."),
-
     // CHAT
     CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4001", "해당 날짜의 채팅로그를 찾을 수 없습니다."),
 

--- a/src/main/java/com/melissa/diary/domain/Thread.java
+++ b/src/main/java/com/melissa/diary/domain/Thread.java
@@ -80,6 +80,9 @@ public class Thread extends BaseEntity {
     @Column(nullable = true)
     private LocalDateTime summaryCreatedAt;
 
+    @Column(nullable = true)
+    private LocalDateTime lastSummaryRequestAt;
+
     @OneToMany(mappedBy = "thread", cascade = CascadeType.ALL)
     private List<DailyChatLog> dailyChatLogs = new ArrayList<>();
 

--- a/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
@@ -167,6 +167,11 @@ public class ThreadSummaryService {
             throw new ErrorHandler(ErrorStatus.CALENDAR_NOT_FOUND);
         }
         Thread thread = summaryData.getThread();
+        // 1분 이내 중복 요청 방지 (최초 생성 직후 요약은 허용)
+        if (thread.getUpdatedAt() != null && !thread.getUpdatedAt().isEqual(thread.getCreatedAt()) &&
+            thread.getUpdatedAt().isAfter(java.time.LocalDateTime.now().minusMinutes(1))) {
+            throw new ErrorHandler(ErrorStatus.THREAD_TOO_MANY_REQUESTS);
+        }
         
         // 채팅 로그 불러오기
         List<DailyChatLog> logs = summaryData.getLogs();

--- a/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
@@ -167,11 +167,12 @@ public class ThreadSummaryService {
             throw new ErrorHandler(ErrorStatus.CALENDAR_NOT_FOUND);
         }
         Thread thread = summaryData.getThread();
-        // 1분 이내 중복 요청 방지 (최초 생성 직후 요약은 허용)
-        if (thread.getUpdatedAt() != null && !thread.getUpdatedAt().isEqual(thread.getCreatedAt()) &&
-            thread.getUpdatedAt().isAfter(java.time.LocalDateTime.now().minusMinutes(1))) {
+        // 1분 이내 중복 요청 무조건 차단 (lastSummaryRequestAt 기준)
+        if (thread.getLastSummaryRequestAt() != null &&
+            thread.getLastSummaryRequestAt().isAfter(java.time.LocalDateTime.now().minusMinutes(1))) {
             throw new ErrorHandler(ErrorStatus.THREAD_TOO_MANY_REQUESTS);
         }
+        thread.setLastSummaryRequestAt(java.time.LocalDateTime.now());
         
         // 채팅 로그 불러오기
         List<DailyChatLog> logs = summaryData.getLogs();

--- a/src/main/java/com/melissa/diary/service/ThreadSummaryServiceV2.java
+++ b/src/main/java/com/melissa/diary/service/ThreadSummaryServiceV2.java
@@ -71,11 +71,12 @@ public class ThreadSummaryServiceV2 {
         if (data == null) throw new ErrorHandler(ErrorStatus.CALENDAR_NOT_FOUND);
 
         Thread thread = data.getThread();
-        // 1분 이내 중복 요청 방지 (최초 생성 직후 요약은 허용)
-        if (thread.getUpdatedAt() != null && !thread.getUpdatedAt().isEqual(thread.getCreatedAt()) &&
-            thread.getUpdatedAt().isAfter(java.time.LocalDateTime.now().minusMinutes(1))) {
+        // 1분 이내 중복 요청 무조건 차단 (lastSummaryRequestAt 기준)
+        if (thread.getLastSummaryRequestAt() != null &&
+            thread.getLastSummaryRequestAt().isAfter(java.time.LocalDateTime.now().minusMinutes(1))) {
             throw new ErrorHandler(ErrorStatus.THREAD_TOO_MANY_REQUESTS);
         }
+        thread.setLastSummaryRequestAt(java.time.LocalDateTime.now());
         List<DailyChatLog> logs = data.getLogs().stream()
                 .filter(l -> Role.USER.equals(l.getRole()))
                 .collect(Collectors.toList());

--- a/src/main/java/com/melissa/diary/service/ThreadSummaryServiceV2.java
+++ b/src/main/java/com/melissa/diary/service/ThreadSummaryServiceV2.java
@@ -71,6 +71,11 @@ public class ThreadSummaryServiceV2 {
         if (data == null) throw new ErrorHandler(ErrorStatus.CALENDAR_NOT_FOUND);
 
         Thread thread = data.getThread();
+        // 1분 이내 중복 요청 방지 (최초 생성 직후 요약은 허용)
+        if (thread.getUpdatedAt() != null && !thread.getUpdatedAt().isEqual(thread.getCreatedAt()) &&
+            thread.getUpdatedAt().isAfter(java.time.LocalDateTime.now().minusMinutes(1))) {
+            throw new ErrorHandler(ErrorStatus.THREAD_TOO_MANY_REQUESTS);
+        }
         List<DailyChatLog> logs = data.getLogs().stream()
                 .filter(l -> Role.USER.equals(l.getRole()))
                 .collect(Collectors.toList());


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- 일기요약(스레드 요약) API에 1분 이내 중복 요청을 무조건 차단하는 기능을 새롭게 추가하였습니다.
- Thread 엔티티에 lastSummaryRequestAt 필드를 도입하여, 최초 요청 이후 1분 쿨타임이 정확히 적용되도록 구현하였습니다.
- V1, V2 요약 서비스 모두 동일하게 적용하였으며, 마이그레이션 호환성도 고려하였습니다.

## 📋 변경 사항
- Thread 엔티티에 lastSummaryRequestAt(LocalDateTime) 필드 신규 추가
- V1 (ThreadSummaryService), V2 (ThreadSummaryServiceV2) 요약 서비스에
- lastSummaryRequestAt 기준 1분 이내 중복 요청 무조건 차단 로직 신규 추가 (최초 요청(null)만 허용, 이후부터는 쿨타임 적용)
- 중복 요청 시 429(THREAD_TOO_MANY_REQUESTS) 에러코드 반환
- 기존 데이터 마이그레이션 시 null로 시작하므로 문제 없음

> 최초에는 updatedAt/createdAt 기반으로 쿨타임 체크를 시도했으나, 최초 요청(createAt과 updateAt의 분단위가 같은 경우)시 여러 번 허용되는 문제가 있어 lastSummaryRequestAt 필드 추가로 노선을 변경하여 개발을 진행함.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
<img width="2453" height="1005" alt="image" src="https://github.com/user-attachments/assets/15e1dd0f-d97a-49c1-8dec-2eac90cadd8f" />
