### PR TITLE
fix: JPA Auditing 활성화 및 UserMemory 엔티티 DB 제약조건 오류 해결

### DIFF
--- a/src/main/java/com/melissa/diary/MelissaDiaryAssistantApplication.java
+++ b/src/main/java/com/melissa/diary/MelissaDiaryAssistantApplication.java
@@ -14,12 +14,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaRepositories
 @EnableScheduling
+@EnableJpaAuditing
 public class MelissaDiaryAssistantApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/melissa/diary/converter/UserMemoryConverter.java
+++ b/src/main/java/com/melissa/diary/converter/UserMemoryConverter.java
@@ -21,7 +21,7 @@ public class UserMemoryConverter {
         
         return UserMemoryResponseDTO.MemoryResponse.builder()
                 .memoryContent(hasMemory ? userMemory.getMemoryContent() : "")
-                .lastUpdatedAt(userMemory.getLastUpdatedAt())
+                .lastUpdatedAt(userMemory.getUpdatedAt())
                 .hasMemory(hasMemory)
                 .build();
     }

--- a/src/main/java/com/melissa/diary/domain/UserMemory.java
+++ b/src/main/java/com/melissa/diary/domain/UserMemory.java
@@ -1,10 +1,9 @@
 package com.melissa.diary.domain;
 
 import com.melissa.diary.converter.EncryptionAttributeConverter;
+import com.melissa.diary.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -14,7 +13,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class UserMemory {
+public class UserMemory extends BaseEntity {
     
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,14 +27,6 @@ public class UserMemory {
     @Convert(converter = EncryptionAttributeConverter.class)
     private String memoryContent;
     
-    @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-    
-    @LastModifiedDate
-    @Column(name = "last_updated_at")
-    private LocalDateTime lastUpdatedAt;
-    
     @Version
     @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     @Builder.Default
@@ -44,6 +35,6 @@ public class UserMemory {
     // 메모리 업데이트를 위한 편의 메서드
     public void updateMemoryContent(String newContent) {
         this.memoryContent = newContent;
-        this.lastUpdatedAt = LocalDateTime.now();
+        // BaseEntity의 updatedAt이 자동으로 설정됨
     }
 }

--- a/src/main/java/com/melissa/diary/repository/UserMemoryRepository.java
+++ b/src/main/java/com/melissa/diary/repository/UserMemoryRepository.java
@@ -35,6 +35,6 @@ public interface UserMemoryRepository extends JpaRepository<UserMemory, Long> {
     /**
      * 특정 기간 이후 업데이트된 메모리 개수 조회
      */
-    @Query("SELECT COUNT(um) FROM UserMemory um WHERE um.lastUpdatedAt >= :since")
+    @Query("SELECT COUNT(um) FROM UserMemory um WHERE um.updatedAt >= :since")
     long countRecentlyUpdatedMemories(@Param("since") java.time.LocalDateTime since);
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
> JPA Auditing 활성화 및 UserMemory 엔티티 DB 제약조건 오류 해결

UserMemory 생성 시 발생하던 created_at cannot be null DB 제약조건 위반 오류를 JPA Auditing 활성화를 통해 해결했습니다. 이와 함께 스케줄러 시스템의 안정성을 개선하여 메모리 업데이트 기능이 정상 동작하도록 수정했습니다.

## 📋 변경 사항
- JPA Auditing 활성화: @EnableJpaAuditing 추가로 엔티티 생성/수정 시간 자동 관리
- DB 제약조건 준수: UserMemory 엔티티의 created_at, updated_at 필드 자동 설정
- 엔티티 구조 최적화: BaseEntity 상속을 통한 Auditing 필드 중앙집중화
- 스케줄러 안정성 강화: ThreadSummaryService 예외 처리 개선으로 시스템 연쇄 장애 방지
- Repository 쿼리 필드 동기화

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

JPA Auditing 정상 동작(@EnableJpaAuditing으로 AuditingEntityListener 활성화 및 BaseEntity의 @CreatedDate, @LastModifiedDate 자동 처리)
스케줄러 간 의존성 제거로 격리된 예외 처리
부분 실패 허용을 통한 전체 서비스 가용성 확보

## 📸 ScreenShot

로컬 서버 스케줄러 및 메모리 업데이트 로직 정상작동 확인

<img width="2192" height="147" alt="image" src="https://github.com/user-attachments/assets/007b8146-f8a2-489d-9a73-76d8523bfbdd" />
