### PR TITLE
feat: CORS 정책 특정 도메인으로 제약 추가

### DIFF
--- a/src/main/java/com/melissa/diary/config/CorsConfig.java
+++ b/src/main/java/com/melissa/diary/config/CorsConfig.java
@@ -1,0 +1,22 @@
+package com.melissa.diary.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "https://melissa-playground.nararia03.dev"
+                )
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("Authorization", "Content-Type", "X-Requested-With")
+                .allowCredentials(true)
+                .maxAge(3600); // preflight 요청 캐시 시간 (1시간)
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
테스트 웹 배포를 위한 CORS 설정 추가 작업을 진행
> 기존 와일드카드(*) 허용 방식에서 특정 도메인만 허용하도록 보안을 강화하면서, 요청된 테스트 환경에서의 API 접근을 가능하게 했습니다.

## 📋 변경 사항
- src/main/java/com/melissa/diary/config/CorsConfig.java 파일 추가
    - WebMvcConfigurer 인터페이스 구현

- 특정 도메인만 허용하는 CORS 정책 설정
    - 개발 테스트 환경 : "http://localhost:3000"                            
    - 배포 테스트 환경 : "https://melissa-playground.nararia03.dev"  

## 🔍 Code Review

기존 시스템 영향도
✅ 모바일 앱: CORS 무관하므로 영향 없음
✅ Swagger: Same-Origin
✅ 기존 API: JWT 인증 로직 그대로 유지

## 📸 ScreenShot
