### PR TITLE
feat: 배치 일기 생성시 유저 채팅 3개 이상 제한로직 추가(기존로직 활용)

### DIFF
--- a/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadSummaryService.java
@@ -136,6 +136,19 @@ public class ThreadSummaryService {
             log.warn("[ThreadSummary] 채팅 로그가 없어 요약 불필요. userId={}, {}-{}-{}", userId, year, month, day);
             return;
         }
+        
+        // 사용자 메시지만 필터링
+        List<DailyChatLog> userLogs = logs.stream()
+                .filter(s -> Role.USER.equals(s.getRole()))
+                .collect(Collectors.toList());
+        
+        // 사용자 메시지 최소 개수 체크 (3개 이상)
+        if (userLogs.size() <= 2) {
+            log.warn("[ThreadSummary] 사용자 메시지가 부족하여 요약 생략. userId={}, {}-{}-{}, userMessageCount={}", 
+                    userId, year, month, day, userLogs.size());
+            return;
+        }
+        
         // 이미 요약 내용이 존재하면 스케줄러에서는 실행하지 않도록 수정!!
         if (thread.getSummaryContent() != null && !thread.getSummaryContent().trim().isEmpty()) {
             log.info("[ThreadSummary] 요약 내용이 이미 존재하여 스케줄러 생략. userId={}, {}-{}-{}", userId, year, month, day);


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
기존 로직(수동 요약 일기 생성 Service code)의 채팅 최소 개수 로직을 활용하여 배치 일기 생성시 유저 채팅 3개 이상 제한로직 추가

## 📋 변경 사항
- generateDailySummaryForUserScheduled의 사용자 메시지만 필터링한 이후 3개 제한로직 추가

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
