### PR TITLE
feat: 채팅메시지 삭제 및 수정 API 추가(권한 검증 로직 추가)

### DIFF
--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -45,6 +45,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // CHAT
     CHAT_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4001", "해당 날짜의 채팅로그를 찾을 수 없습니다."),
+    CHAT_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4002", "해당 채팅 메시지를 찾을 수 없습니다."),
+    CHAT_LOG_FORBIDDEN(HttpStatus.FORBIDDEN, "CHAT4003", "해당 채팅 메시지에 접근할 권한이 없습니다."),
+    CHAT_LOG_AI_MESSAGE(HttpStatus.BAD_REQUEST, "CHAT4004", "AI 메시지는 수정/삭제할 수 없습니다."),
 
     // Quota
     QUOTA_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "QUOTA4001", "일일 사용량을 초과하였습니다."),

--- a/src/main/java/com/melissa/diary/service/ChatLogService.java
+++ b/src/main/java/com/melissa/diary/service/ChatLogService.java
@@ -1,0 +1,91 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.DailyChatLog;
+import com.melissa.diary.domain.enums.Role;
+import com.melissa.diary.repository.DailyChatLogRepository;
+import com.melissa.diary.web.dto.ChatLogRequestDTO;
+import com.melissa.diary.web.dto.ChatLogResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatLogService {
+
+    private final DailyChatLogRepository dailyChatLogRepository;
+
+    /**
+     * 채팅 메시지 삭제
+     * - 본인 메시지만 삭제 가능
+     * - AI 메시지는 삭제 불가
+     */
+    @Transactional
+    public ChatLogResponseDTO.ChatLogDeleteResponse deleteChatLog(Long userId, Long chatLogId) {
+        // 채팅 로그 조회
+        DailyChatLog chatLog = dailyChatLogRepository.findById(chatLogId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.CHAT_LOG_NOT_FOUND));
+
+        // AI 메시지 삭제 차단
+        if (chatLog.getRole() == Role.AI) {
+            throw new ErrorHandler(ErrorStatus.CHAT_LOG_AI_MESSAGE);
+        }
+
+        // 권한 검증: 본인의 Thread에 속한 메시지인지 확인
+        if (chatLog.getThread() == null || !chatLog.getThread().getUser().getId().equals(userId)) {
+            throw new ErrorHandler(ErrorStatus.CHAT_LOG_FORBIDDEN);
+        }
+
+        // 삭제 실행
+        dailyChatLogRepository.delete(chatLog);
+        
+        log.info("[ChatLog] 채팅 메시지 삭제 완료. userId={}, chatLogId={}", userId, chatLogId);
+
+        return ChatLogResponseDTO.ChatLogDeleteResponse.builder()
+                .chatId(chatLogId)
+                .message("채팅 메시지가 삭제되었습니다.")
+                .build();
+    }
+
+    /**
+     * 채팅 메시지 수정
+     * - 본인 메시지만 수정 가능
+     * - AI 메시지는 수정 불가
+     */
+    @Transactional
+    public ChatLogResponseDTO.ChatLogResponse updateChatLog(
+            Long userId, Long chatLogId, ChatLogRequestDTO.ChatLogUpdateRequest request) {
+        
+        // 채팅 로그 조회
+        DailyChatLog chatLog = dailyChatLogRepository.findById(chatLogId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.CHAT_LOG_NOT_FOUND));
+
+        // AI 메시지 수정 차단
+        if (chatLog.getRole() == Role.AI) {
+            throw new ErrorHandler(ErrorStatus.CHAT_LOG_AI_MESSAGE);
+        }
+
+        // 권한 검증: 본인의 Thread에 속한 메시지인지 확인
+        if (chatLog.getThread() == null || !chatLog.getThread().getUser().getId().equals(userId)) {
+            throw new ErrorHandler(ErrorStatus.CHAT_LOG_FORBIDDEN);
+        }
+
+        // 내용 수정
+        chatLog.setContent(request.getContent());
+        dailyChatLogRepository.save(chatLog);
+        
+        log.info("[ChatLog] 채팅 메시지 수정 완료. userId={}, chatLogId={}", userId, chatLogId);
+
+        return ChatLogResponseDTO.ChatLogResponse.builder()
+                .chatId(chatLog.getId())
+                .role(chatLog.getRole().name())
+                .content(chatLog.getContent())
+                .createdAt(chatLog.getCreatedAt())
+                .build();
+    }
+}
+

--- a/src/main/java/com/melissa/diary/web/controller/ChatLogController.java
+++ b/src/main/java/com/melissa/diary/web/controller/ChatLogController.java
@@ -1,0 +1,50 @@
+package com.melissa.diary.web.controller;
+
+import com.melissa.diary.apiPayload.ApiResponse;
+import com.melissa.diary.service.ChatLogService;
+import com.melissa.diary.web.dto.ChatLogRequestDTO;
+import com.melissa.diary.web.dto.ChatLogResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+
+@RestController
+@Tag(name = "ChatLog API", description = "채팅 메시지 관리 API")
+@RequestMapping("/api/v1/chats")
+@RequiredArgsConstructor
+@Slf4j
+public class ChatLogController {
+
+    private final ChatLogService chatLogService;
+
+    @Operation(summary = "채팅 메시지 삭제", description = "사용자가 작성한 채팅 메시지를 삭제합니다. AI 메시지는 삭제할 수 없습니다.")
+    @DeleteMapping("/{chatLogId}")
+    public ApiResponse<ChatLogResponseDTO.ChatLogDeleteResponse> deleteChatLog(
+            @PathVariable Long chatLogId,
+            Principal principal) {
+
+        Long userId = Long.parseLong(principal.getName());
+        ChatLogResponseDTO.ChatLogDeleteResponse response = chatLogService.deleteChatLog(userId, chatLogId);
+
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(summary = "채팅 메시지 수정", description = "사용자가 작성한 채팅 메시지를 수정합니다. AI 메시지는 수정할 수 없습니다.")
+    @PatchMapping("/{chatLogId}")
+    public ApiResponse<ChatLogResponseDTO.ChatLogResponse> updateChatLog(
+            @PathVariable Long chatLogId,
+            @Valid @RequestBody ChatLogRequestDTO.ChatLogUpdateRequest request,
+            Principal principal) {
+
+        Long userId = Long.parseLong(principal.getName());
+        ChatLogResponseDTO.ChatLogResponse response = chatLogService.updateChatLog(userId, chatLogId, request);
+
+        return ApiResponse.onSuccess(response);
+    }
+}
+

--- a/src/main/java/com/melissa/diary/web/dto/ChatLogRequestDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/ChatLogRequestDTO.java
@@ -1,0 +1,20 @@
+package com.melissa.diary.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+public class ChatLogRequestDTO {
+
+    @Getter
+    @Setter
+    public static class ChatLogUpdateRequest {
+        @NotBlank(message = "메시지 내용은 필수입니다.")
+        @Size(max = 1000, message = "메시지 내용은 1000자 이하여야 합니다.")
+        @Schema(description = "수정할 메시지 내용", example = "수정된 메시지 내용입니다.")
+        private String content;
+    }
+}
+

--- a/src/main/java/com/melissa/diary/web/dto/ChatLogResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/ChatLogResponseDTO.java
@@ -1,0 +1,32 @@
+package com.melissa.diary.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class ChatLogResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatLogResponse {
+        private Long chatId;
+        private String role;
+        private String content;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatLogDeleteResponse {
+        private Long chatId;
+        private String message;
+    }
+}
+


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
일기 요약에 필요한 핵심 데이터인 채팅 메시지 수정 및 삭제 기능을 제공하기 위해 API를 추가하였다.
> 사용자가 본인이 작성한 메시지만 수정/삭제할 수 있도록 권한 검증 로직을 구현
> 시스템(AI) 메시지는 수정/삭제가 불가능하도록 처리

## 📋 변경 사항
- DELETE /api/v1/chats/{chatId} 엔드포인트 추가
사용자 본인 메시지만 삭제 가능
AI 메시지 삭제 금지

- PATCH /api/v1/chats/{chatId} 엔드포인트 추가
사용자 본인 메시지만 수정 가능
수정 시 기존 내용 검증 및 저장

- 권한 검증 로직 추가
JWT 기반 사용자 식별
작성자와 요청자 비교

- 예외 처리 추가
AccessDeniedException
NotFoundException
AI 메시지 수정/삭제 요청 시 예외 반환

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
