### PR TITLE
feat: Expo Push 알림 토큰 관리 API 구현

### DIFF
--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -60,7 +60,12 @@ public enum ErrorStatus implements BaseErrorCode {
     TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH4004", "토큰이 일치하지 않습니다."),
     TOKEN_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5001", "토큰 생성에 실패했습니다."),
     TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH4005", "토큰 검증에 실패했습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH4006", "해당 유저가 존재하지 않습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH4006", "해당 유저가 존재하지 않습니다."),
+
+    // Expo Push Token
+    EXPO_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "EXPO4001", "해당 Expo Push Token을 찾을 수 없습니다."),
+    EXPO_TOKEN_ALREADY_EXISTS(HttpStatus.CONFLICT, "EXPO4002", "이미 등록된 Expo Push Token입니다."),
+    EXPO_TOKEN_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "EXPO4003", "유효하지 않은 Expo Push Token 형식입니다.");
 
 
 

--- a/src/main/java/com/melissa/diary/converter/ExpoPushTokenConverter.java
+++ b/src/main/java/com/melissa/diary/converter/ExpoPushTokenConverter.java
@@ -1,0 +1,50 @@
+package com.melissa.diary.converter;
+
+import com.melissa.diary.domain.ExpoPushToken;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.web.dto.ExpoPushTokenRequestDTO;
+import com.melissa.diary.web.dto.ExpoPushTokenResponseDTO;
+
+public class ExpoPushTokenConverter {
+    
+    /**
+     * Request DTO → Entity 변환
+     */
+    public static ExpoPushToken toEntity(
+            ExpoPushTokenRequestDTO.RegisterTokenRequest request, 
+            User user) {
+        return ExpoPushToken.builder()
+                .expoPushToken(request.getExpoPushToken())
+                .platform(request.getPlatform())
+                .deviceId(request.getDeviceId())
+                .user(user)
+                .invalid(false)
+                .build();
+    }
+    
+    /**
+     * Entity → Response DTO 변환
+     */
+    public static ExpoPushTokenResponseDTO.TokenResponse toResponse(ExpoPushToken entity) {
+        return ExpoPushTokenResponseDTO.TokenResponse.builder()
+                .id(entity.getId())
+                .expoPushToken(entity.getExpoPushToken())
+                .platform(entity.getPlatform())
+                .deviceId(entity.getDeviceId())
+                .invalid(entity.getInvalid())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+    
+    /**
+     * 삭제 응답 DTO 생성
+     */
+    public static ExpoPushTokenResponseDTO.DeleteResponse toDeleteResponse(String expoPushToken) {
+        return ExpoPushTokenResponseDTO.DeleteResponse.builder()
+                .expoPushToken(expoPushToken)
+                .message("Expo Push Token이 삭제되었습니다.")
+                .build();
+    }
+}
+

--- a/src/main/java/com/melissa/diary/domain/ExpoPushToken.java
+++ b/src/main/java/com/melissa/diary/domain/ExpoPushToken.java
@@ -1,0 +1,59 @@
+package com.melissa.diary.domain;
+
+import com.melissa.diary.domain.enums.Platform;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "expo_push_token", 
+       uniqueConstraints = {
+           @UniqueConstraint(columnNames = {"expo_push_token"}) // 토큰 유니크 제약
+       },
+       indexes = {
+           @Index(name = "idx_user_id", columnList = "user_id"),
+           @Index(name = "idx_expo_push_token", columnList = "expo_push_token")
+       })
+@EntityListeners(AuditingEntityListener.class)
+public class ExpoPushToken {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = true)
+    private User user;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Platform platform;
+    
+    @Column(name = "device_id", length = 255)
+    private String deviceId;
+    
+    @Column(name = "expo_push_token", nullable = false, unique = true, length = 255)
+    private String expoPushToken;
+    
+    @Builder.Default
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+    private Boolean invalid = false;
+    
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+    
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/com/melissa/diary/domain/User.java
+++ b/src/main/java/com/melissa/diary/domain/User.java
@@ -72,6 +72,9 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<AiProfile> aiProfileList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<ExpoPushToken> expoPushTokenList = new ArrayList<>();
+
     // 연관관계 편의 메소드
     public void addUserSetting(UserSetting userSetting) {
         userSettingList.add(userSetting);
@@ -91,6 +94,11 @@ public class User {
     public void addAiProfile(AiProfile aiProfile) {
         aiProfileList.add(aiProfile);
         aiProfile.setUser(this);
+    }
+
+    public void addExpoPushToken(ExpoPushToken expoPushToken) {
+        expoPushTokenList.add(expoPushToken);
+        expoPushToken.setUser(this);
     }
 
 }

--- a/src/main/java/com/melissa/diary/domain/enums/Platform.java
+++ b/src/main/java/com/melissa/diary/domain/enums/Platform.java
@@ -1,0 +1,7 @@
+package com.melissa.diary.domain.enums;
+
+public enum Platform {
+    ANDROID,
+    IOS
+}
+

--- a/src/main/java/com/melissa/diary/repository/ExpoPushTokenRepository.java
+++ b/src/main/java/com/melissa/diary/repository/ExpoPushTokenRepository.java
@@ -1,0 +1,28 @@
+package com.melissa.diary.repository;
+
+import com.melissa.diary.domain.ExpoPushToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ExpoPushTokenRepository extends JpaRepository<ExpoPushToken, Long> {
+    
+    /**
+     * Expo Push Token으로 조회
+     */
+    Optional<ExpoPushToken> findByExpoPushToken(String expoPushToken);
+    
+    /**
+     * 사용자 ID로 토큰 목록 조회
+     */
+    List<ExpoPushToken> findByUserId(Long userId);
+    
+    /**
+     * 모든 유효한 토큰 조회 (배치 발송용)
+     */
+    List<ExpoPushToken> findByInvalidFalse();
+}
+

--- a/src/main/java/com/melissa/diary/service/ExpoPushTokenService.java
+++ b/src/main/java/com/melissa/diary/service/ExpoPushTokenService.java
@@ -1,0 +1,117 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.converter.ExpoPushTokenConverter;
+import com.melissa.diary.domain.ExpoPushToken;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.repository.ExpoPushTokenRepository;
+import com.melissa.diary.repository.UserRepository;
+import com.melissa.diary.web.dto.ExpoPushTokenRequestDTO;
+import com.melissa.diary.web.dto.ExpoPushTokenResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ExpoPushTokenService {
+    
+    private final ExpoPushTokenRepository expoPushTokenRepository;
+    private final UserRepository userRepository;
+    
+    /**
+     * Expo Push Token 등록 (로그인 O)
+     * - 이미 존재하는 토큰이면 사용자 정보만 업데이트
+     * - 새 토큰이면 신규 등록
+     */
+    @Transactional
+    public ExpoPushTokenResponseDTO.TokenResponse registerToken(
+            Long userId, 
+            ExpoPushTokenRequestDTO.RegisterTokenRequest request) {
+        
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+        
+        String tokenValue = request.getExpoPushToken();
+        
+        // 이미 존재하는 토큰인지 확인
+        Optional<ExpoPushToken> existingToken = expoPushTokenRepository.findByExpoPushToken(tokenValue);
+        
+        if (existingToken.isPresent()) {
+            // 기존 토큰이 있으면 사용자 정보 업데이트
+            ExpoPushToken token = existingToken.get();
+            token.setUser(user);
+            token.setPlatform(request.getPlatform());
+            token.setDeviceId(request.getDeviceId());
+            token.setInvalid(false); // 다시 활성화
+            
+            ExpoPushToken savedToken = expoPushTokenRepository.save(token);
+            log.info("[ExpoPushToken] 기존 토큰 업데이트 완료. userId={}, tokenId={}", userId, savedToken.getId());
+            
+            return ExpoPushTokenConverter.toResponse(savedToken);
+        } else {
+            // 새 토큰 등록
+            ExpoPushToken newToken = ExpoPushTokenConverter.toEntity(request, user);
+            
+            try {
+                ExpoPushToken savedToken = expoPushTokenRepository.save(newToken);
+                log.info("[ExpoPushToken] 새 토큰 등록 완료. userId={}, tokenId={}", userId, savedToken.getId());
+                
+                return ExpoPushTokenConverter.toResponse(savedToken);
+            } catch (DataIntegrityViolationException e) {
+                log.error("[ExpoPushToken] 토큰 등록 실패 (중복 가능성). userId={}, token={}", userId, tokenValue, e);
+                throw new ErrorHandler(ErrorStatus.EXPO_TOKEN_ALREADY_EXISTS);
+            }
+        }
+    }
+    
+    /**
+     * 사용자별 토큰 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<ExpoPushTokenResponseDTO.TokenResponse> getUserTokens(Long userId) {
+        List<ExpoPushToken> tokens = expoPushTokenRepository.findByUserId(userId);
+        
+        log.info("[ExpoPushToken] 토큰 목록 조회 완료. userId={}, count={}", userId, tokens.size());
+        
+        return tokens.stream()
+                .map(ExpoPushTokenConverter::toResponse)
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * 유효한 토큰만 조회 (배치 발송용)
+     */
+    @Transactional(readOnly = true)
+    public List<ExpoPushToken> getAllValidTokens() {
+        List<ExpoPushToken> tokens = expoPushTokenRepository.findByInvalidFalse();
+        
+        log.info("[ExpoPushToken] 유효한 토큰 전체 조회 완료. count={}", tokens.size());
+        
+        return tokens;
+    }
+    
+    /**
+     * 특정 토큰 삭제
+     */
+    @Transactional
+    public ExpoPushTokenResponseDTO.DeleteResponse deleteToken(String expoPushToken) {
+        ExpoPushToken token = expoPushTokenRepository.findByExpoPushToken(expoPushToken)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.EXPO_TOKEN_NOT_FOUND));
+        
+        expoPushTokenRepository.delete(token);
+        
+        log.info("[ExpoPushToken] 토큰 삭제 완료. tokenId={}, token={}", token.getId(), expoPushToken);
+        
+        return ExpoPushTokenConverter.toDeleteResponse(expoPushToken);
+    }
+}
+

--- a/src/main/java/com/melissa/diary/web/controller/ExpoPushTokenController.java
+++ b/src/main/java/com/melissa/diary/web/controller/ExpoPushTokenController.java
@@ -1,0 +1,89 @@
+package com.melissa.diary.web.controller;
+
+import com.melissa.diary.apiPayload.ApiResponse;
+import com.melissa.diary.service.ExpoPushTokenService;
+import com.melissa.diary.web.dto.ExpoPushTokenRequestDTO;
+import com.melissa.diary.web.dto.ExpoPushTokenResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@Tag(name = "ExpoPushTokenAPI", description = "Expo Push 알림 토큰 관리 API")
+@RequestMapping("/api/v1/expo-push-tokens")
+@RequiredArgsConstructor
+@Slf4j
+public class ExpoPushTokenController {
+    
+    private final ExpoPushTokenService expoPushTokenService;
+    
+    /**
+     * Expo Push Token 등록 (로그인 사용자)
+     */
+    @Operation(
+            summary = "Expo Push Token 등록",
+            description = "로그인한 사용자의 Expo Push Token을 등록합니다. 이미 존재하는 토큰이면 사용자 정보를 업데이트합니다."
+    )
+    @PostMapping
+    public ApiResponse<ExpoPushTokenResponseDTO.TokenResponse> registerToken(
+            Principal principal,
+            @Valid @RequestBody ExpoPushTokenRequestDTO.RegisterTokenRequest request) {
+        
+        Long userId = Long.parseLong(principal.getName());
+        log.info("[ExpoPushTokenController] 토큰 등록 요청. userId={}, platform={}", 
+                userId, request.getPlatform());
+        
+        ExpoPushTokenResponseDTO.TokenResponse response = 
+                expoPushTokenService.registerToken(userId, request);
+        
+        return ApiResponse.onSuccess(response);
+    }
+    
+    /**
+     * 사용자별 토큰 목록 조회
+     */
+    @Operation(
+            summary = "내 Expo Push Token 목록 조회",
+            description = "현재 로그인한 사용자의 등록된 모든 Expo Push Token을 조회합니다."
+    )
+    @GetMapping
+    public ApiResponse<List<ExpoPushTokenResponseDTO.TokenResponse>> getUserTokens(
+            Principal principal) {
+        
+        Long userId = Long.parseLong(principal.getName());
+        log.info("[ExpoPushTokenController] 토큰 목록 조회 요청. userId={}", userId);
+        
+        List<ExpoPushTokenResponseDTO.TokenResponse> tokens = 
+                expoPushTokenService.getUserTokens(userId);
+        
+        return ApiResponse.onSuccess(tokens);
+    }
+    
+    /**
+     * 특정 토큰 삭제
+     */
+    @Operation(
+            summary = "Expo Push Token 삭제",
+            description = "특정 Expo Push Token을 삭제합니다. 더 이상 해당 기기로 알림이 발송되지 않습니다."
+    )
+    @DeleteMapping("/{expoPushToken}")
+    public ApiResponse<ExpoPushTokenResponseDTO.DeleteResponse> deleteToken(
+            @Parameter(description = "삭제할 Expo Push Token", required = true)
+            @PathVariable String expoPushToken) {
+        
+        log.info("[ExpoPushTokenController] 토큰 삭제 요청. token={}", expoPushToken);
+        
+        ExpoPushTokenResponseDTO.DeleteResponse response = 
+                expoPushTokenService.deleteToken(expoPushToken);
+        
+        return ApiResponse.onSuccess(response);
+    }
+}
+

--- a/src/main/java/com/melissa/diary/web/dto/ExpoPushTokenRequestDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/ExpoPushTokenRequestDTO.java
@@ -1,0 +1,41 @@
+package com.melissa.diary.web.dto;
+
+import com.melissa.diary.domain.enums.Platform;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class ExpoPushTokenRequestDTO {
+    
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RegisterTokenRequest {
+        
+        @NotBlank(message = "Expo Push Token은 필수입니다.")
+        @Pattern(regexp = "^ExponentPushToken\\[.+\\]$", 
+                 message = "유효한 Expo Push Token 형식이 아닙니다. (ExponentPushToken[...])")
+        @Schema(description = "Expo Push Token", 
+                example = "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]",
+                required = true)
+        private String expoPushToken;
+        
+        @NotNull(message = "플랫폼 정보는 필수입니다.")
+        @Schema(description = "플랫폼 (ANDROID 또는 IOS)", 
+                example = "ANDROID",
+                allowableValues = {"ANDROID", "IOS"},
+                required = true)
+        private Platform platform;
+        
+        @Schema(description = "기기 ID (선택사항) nullable", 
+                example = "device-uuid-1234")
+        private String deviceId;
+    }
+}
+

--- a/src/main/java/com/melissa/diary/web/dto/ExpoPushTokenResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/ExpoPushTokenResponseDTO.java
@@ -1,0 +1,36 @@
+package com.melissa.diary.web.dto;
+
+import com.melissa.diary.domain.enums.Platform;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class ExpoPushTokenResponseDTO {
+    
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TokenResponse {
+        private Long id;
+        private String expoPushToken;
+        private Platform platform;
+        private String deviceId;
+        private Boolean invalid;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+    }
+    
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DeleteResponse {
+        private String expoPushToken;
+        private String message;
+    }
+}
+


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
사용자 기기별 Expo Push Token을 등록/관리하는 API를 구현

- User와 1:N 관계로 설계하여 한 사용자가 여러 기기에서 알림을 받을 수 있도록 구현
- 로그인 필수 인증 기반으로 사용자별 토큰 격리 보장
- 중복 토큰 자동 업데이트 로직으로 불필요한 중복 저장 방지

## 📋 변경 사항

### 추가된 파일
- `ExpoPushToken.java` - 엔티티 (User 1:N, Unique 제약)
- `Platform.java` - Enum (ANDROID/IOS)
- `ExpoPushTokenRepository.java` - Repository (3개 메서드)
- `ExpoPushTokenService.java` - Service (등록/조회/삭제/배치조회)
- `ExpoPushTokenController.java` - REST API (3개 엔드포인트)
- `ExpoPushTokenRequestDTO.java` - Request DTO (Validation 포함)
- `ExpoPushTokenResponseDTO.java` - Response DTO
- `ExpoPushTokenConverter.java` - Entity ↔ DTO 변환

### 수정된 파일
- `User.java` - ExpoPushToken 관계 추가 (1:N)
- `ErrorStatus.java` - 에러 코드 3개 추가 (EXPO4001~4003)

### API 엔드포인트
- POST /api/v1/expo-push-tokens # 토큰 등록
- GET /api/v1/expo-push-tokens # 내 토큰 목록
- DELETE /api/v1/expo-push-tokens/{token} # 토큰 삭제

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.
- [x] JWT 인증 필수 (모든 API)
- [x] expo_push_token 필드 Unique 제약 조건
- [x] 중복 토큰 등록 시 업데이트 로직
- [x] User 삭제 시 토큰도 함께 삭제 (cascade ALL)

## 📸 ScreenShot
