### PR TITLE
fix: [Spring Security] EB 환경 403 Forbidden 에러 수정 및 JWT 인증 강화

### DIFF
--- a/src/main/java/com/melissa/diary/config/SecurityConfig.java
+++ b/src/main/java/com/melissa/diary/config/SecurityConfig.java
@@ -12,6 +12,8 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -39,10 +41,9 @@ public class SecurityConfig {
                     )
 
                     .authorizeHttpRequests((authorizeRequests) ->
-                            authorizeRequests
-                                    .requestMatchers("/health","/api/v1/auth/**",
+                            authorizeRequests.requestMatchers("/health","/api/v1/auth/**",
                                             "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**", "/test/**").permitAll()
-                                    .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
+
                                     .anyRequest().authenticated()
                     )
                     .exceptionHandling((exceptionConfig) ->
@@ -75,4 +76,15 @@ public class SecurityConfig {
                 writer.flush();
 
             };
+
+    /**
+     * Spring Security의 기본 InMemoryUserDetailsManager 자동 생성을 비활성화
+     * JWT 기반 인증만 사용하므로 UserDetailsService는 필요하지 않음
+     */
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return username -> {
+            throw new UsernameNotFoundException("JWT 인증만 사용합니다. UserDetailsService는 비활성화되어 있습니다.");
+        };
+    }
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
AWS Elastic Beanstalk (EB) 환경에서 발생하던 POST/PUT 요청 시 403 Forbidden 에러를 해결하고, 애플리케이션이 JWT 기반의 Stateless 인증만을 사용하도록 Spring Security 설정을 강화했습니다.

주요 원인 해결: Spring Boot Security의 기본 동작으로 인해 EB 환경에서 자동으로 활성화되었던 **InMemoryUserDetailsManager**와 Basic Authentication을 명시적으로 비활성화했습니다.

해결 방법: 커스텀 UserDetailsService Bean을 정의하여 기본 인증 로직을 오버라이드하고, JWT 인증 필터가 정상적으로 작동하도록 보장했습니다.

결과: 인증이 필요한 요청에서 토큰이 없을 경우, 로컬 환경과 동일하게 401 Unauthorized 응답이 반환되는 것을 확인했습니다.

## 📋 변경 사항
> SecurityConfig.java에 UserDetailsService Bean 추가:

Spring Security의 기본 인증(Basic Authentication) 활성화를 유발하는 InMemoryUserDetailsManager의 자동 생성을 막기 위해 더미 UserDetailsService Bean을 추가했습니다.

이 Bean은 실제 사용자 정보를 로드하는 대신 예외를 발생시켜, JWT 기반 인증이 주요 인증 수단임을 명확히 합니다.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
