### PR TITLE
fix: [Security] 403 에러 해결 및 JWT 필터 우선 순위 조정

### DIFF
--- a/src/main/java/com/melissa/diary/config/SecurityConfig.java
+++ b/src/main/java/com/melissa/diary/config/SecurityConfig.java
@@ -17,8 +17,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-
-import org.springframework.web.filter.CorsFilter;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import java.io.PrintWriter;
 
@@ -35,6 +34,7 @@ public class SecurityConfig {
 
             http.csrf(AbstractHttpConfigurer::disable)
                     .httpBasic(AbstractHttpConfigurer::disable)
+                    .formLogin(AbstractHttpConfigurer::disable)
                     .cors(Customizer.withDefaults())
                     .sessionManagement((sessionManagement) ->
                             sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
@@ -51,9 +51,9 @@ public class SecurityConfig {
                                     .authenticationEntryPoint(unauthorizedEntryPoint)
                     ); // 401 403 관련 예외처리
             ;
-            http.addFilterAfter(
+            http.addFilterBefore(
                     jwtAuthenticationFilter,
-                    CorsFilter.class
+                    UsernamePasswordAuthenticationFilter.class
             );
             return http.build();
         } catch (Exception e) {


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
AWS EB 환경에서 POST/PUT 요청 시 403 Forbidden 에러가 발생하는 문제를 해결하기 위해 Spring Security 필터 체인의 동작 방식을 수정했습니다. 핵심은 세션 기반 인증 시도를 명확히 차단하고, JWT 인증 필터가 다른 인증 필터보다 먼저 실행되도록 우선순위를 높인 것입니다.

1. formLogin 비활성화: 세션 기반의 기본 폼 로그인 메커니즘을 명시적으로 비활성화하여 POST 요청 시 발생할 수 있는 잠재적인 세션 인증 시도를 차단했습니다.

2. JWT 필터 위치 조정: JWT 인증 필터의 위치를 CorsFilter 뒤에서 Spring Security의 표준 인증 필터인 UsernamePasswordAuthenticationFilter 앞으로 이동시켜 JWT 검증이 가장 먼저 이루어지도록 변경했습니다.

## 📋 변경 사항
변경 사항이나 추가 사항을 작성해주세요.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
