### PR TITLE
feat: Recent used Ai Profile의 로직을 채팅로그 기반으로 변경

### DIFF
--- a/src/main/java/com/melissa/diary/repository/DailyChatLogRepository.java
+++ b/src/main/java/com/melissa/diary/repository/DailyChatLogRepository.java
@@ -3,5 +3,9 @@ package com.melissa.diary.repository;
 import com.melissa.diary.domain.DailyChatLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DailyChatLogRepository extends JpaRepository<DailyChatLog, Long> {
+    
+    Optional<DailyChatLog> findFirstByThreadUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/src/main/java/com/melissa/diary/service/AiProfileService.java
+++ b/src/main/java/com/melissa/diary/service/AiProfileService.java
@@ -4,9 +4,9 @@ import com.melissa.diary.apiPayload.code.status.ErrorStatus;
 import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
 import com.melissa.diary.converter.AiProfileConverter;
 import com.melissa.diary.domain.AiProfile;
-import com.melissa.diary.domain.Thread;
+import com.melissa.diary.domain.DailyChatLog;
 import com.melissa.diary.repository.AiProfileRepository;
-import com.melissa.diary.repository.ThreadRepository;
+import com.melissa.diary.repository.DailyChatLogRepository;
 import com.melissa.diary.repository.UserRepository;
 import com.melissa.diary.web.dto.AiProfileResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,7 @@ import java.util.Optional;
 public class AiProfileService {
 
     private final AiProfileRepository aiProfileRepository;
-    private final ThreadRepository threadRepository;
+    private final DailyChatLogRepository dailyChatLogRepository;
     private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
@@ -58,15 +58,17 @@ public class AiProfileService {
 
     @Transactional(readOnly = true)
     public AiProfileResponseDTO.AiProfileResponse getRecentAiProfileId(Long userId) {
-        Optional<Thread> recentThread = threadRepository.findFirstByUserIdOrderByYearDescMonthDescDayDesc(userId);
+        // 가장 최근 채팅 로그 기반으로 AI 프로필 조회
+        Optional<DailyChatLog> recentChatLog = dailyChatLogRepository.findFirstByThreadUserIdOrderByCreatedAtDesc(userId);
         
-        if (recentThread.isEmpty()) {
+        if (recentChatLog.isEmpty()) {
+            // 채팅 기록이 없으면 첫 번째 프로필 반환
             List<AiProfile> profiles = aiProfileRepository.findByActiveIsTrueOrderByIdAsc();
             if (profiles.isEmpty()) throw new ErrorHandler(ErrorStatus.PROFILE_NOT_FOUND);
             return AiProfileConverter.toResponse(profiles.get(0));
         }
         
-        AiProfile recentProfile = recentThread.get().getAiProfile();
+        AiProfile recentProfile = recentChatLog.get().getThread().getAiProfile();
         if (!recentProfile.isActive()) {
             throw new ErrorHandler(ErrorStatus.PROFILE_NOT_FOUND);
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,7 +31,7 @@ spring:
         format_sql: true
         use_sql_comments: true
         hbm2ddl:
-          auto: create
+          auto: update
         default_batch_fetch_size: 1000
   servlet:
     multipart:


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
1.3.0 업데이트로 인한 AI Profile의 구조 변화와 채팅방 역할을 하는 Thread가 하루에 여러개 생성 가능하게 되면서 최근 사용된 Ai Profile을 찾는 로직에 대한 수정. (채팅로그 기반으로 가장 최근에 사용한 Thread를 찾아 해당 Thread가 지닌 Profile Id를 리턴)

## 📋 변경 사항

사용자 A가 오늘 프로필 1, 3, 2 순서로 대화했다면:
- Before: Thread 날짜가 같으면 어떤 프로필인지 불명확
- After: 마지막 채팅 로그 (프로필 2) 정확히 반환 ✅

<img width="1070" height="238" alt="image" src="https://github.com/user-attachments/assets/3b20d287-acf9-4f4f-9a58-cb9825ea8aa9" />

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
