### PR TITLE
chore: Swagger API 명세 Enum 필드 정의 및 예시값

### DIFF
--- a/src/main/java/com/melissa/diary/web/dto/CalenderResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/CalenderResponseDTO.java
@@ -32,7 +32,9 @@ public class CalenderResponseDTO {
         @Schema(description = "일기 내용", example = "오늘은 좋은 하루였다.", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String content;
         
-        @Schema(description = "기분", example = "행복", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        @Schema(description = "기분 (기본값: HAPPY)", example = "HAPPY", 
+                allowableValues = {"HAPPY", "SAD", "TIRED", "ANGRY", "RELAX"},
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String mood;
         
         @Schema(description = "해시태그 1", example = "#좋은하루", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)

--- a/src/main/java/com/melissa/diary/web/dto/ChatLogResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/ChatLogResponseDTO.java
@@ -20,7 +20,9 @@ public class ChatLogResponseDTO {
         @Schema(description = "채팅 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long chatId;
         
-        @Schema(description = "발신자 역할 (user/assistant)", example = "user", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "발신자 역할", example = "USER", 
+                allowableValues = {"AI", "USER"},
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private String role;
         
         @Schema(description = "메시지 내용", example = "안녕하세요!", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/com/melissa/diary/web/dto/DiaryRequestDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/DiaryRequestDTO.java
@@ -53,7 +53,9 @@ public class DiaryRequestDTO {
         private String content;
         
         @Size(max = 40, message = "기분은 최대 40자까지 입력 가능합니다.")
-        @Schema(description = "기분", example = "행복", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        @Schema(description = "기분", example = "HAPPY", 
+                allowableValues = {"HAPPY", "SAD", "TIRED", "ANGRY", "RELAX"},
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String mood;
         
         // 해시태그는 LLM이 자동 생성 (사용자 입력 X)
@@ -82,7 +84,9 @@ public class DiaryRequestDTO {
         private String content;
         
         @Size(max = 40, message = "기분은 최대 40자까지 입력 가능합니다.")
-        @Schema(description = "기분", example = "평온", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        @Schema(description = "기분", example = "RELAX", 
+                allowableValues = {"HAPPY", "SAD", "TIRED", "ANGRY", "RELAX"},
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String mood;
         
         @Size(max = 30, message = "해시태그1은 최대 30자까지 입력 가능합니다.")

--- a/src/main/java/com/melissa/diary/web/dto/DiaryResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/DiaryResponseDTO.java
@@ -58,7 +58,9 @@ public class DiaryResponseDTO {
         @Schema(description = "일기 내용", example = "오늘은 좋은 하루였다.", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String content;
         
-        @Schema(description = "기분", example = "행복", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        @Schema(description = "기분 (기본값: HAPPY)", example = "HAPPY", 
+                allowableValues = {"HAPPY", "SAD", "TIRED", "ANGRY", "RELAX"},
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String mood;
         
         @Schema(description = "해시태그 1", example = "#좋은하루", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)

--- a/src/main/java/com/melissa/diary/web/dto/ExpoPushTokenResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/ExpoPushTokenResponseDTO.java
@@ -24,7 +24,9 @@ public class ExpoPushTokenResponseDTO {
         @Schema(description = "Expo Push Token", example = "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]", requiredMode = Schema.RequiredMode.REQUIRED)
         private String expoPushToken;
         
-        @Schema(description = "플랫폼", example = "ANDROID", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "플랫폼", example = "ANDROID", 
+                allowableValues = {"ANDROID", "IOS"},
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private Platform platform;
         
         @Schema(description = "기기 ID", example = "device-uuid-1234", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)

--- a/src/main/java/com/melissa/diary/web/dto/ThreadResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/ThreadResponseDTO.java
@@ -35,7 +35,9 @@ public class ThreadResponseDTO {
         @Schema(description = "채팅 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long chatId;
         
-        @Schema(description = "발신자 역할 (user/assistant)", example = "user", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "발신자 역할", example = "USER", 
+                allowableValues = {"AI", "USER"},
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private String role;
         
         @Schema(description = "메시지 내용", example = "안녕하세요!", requiredMode = Schema.RequiredMode.REQUIRED)


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
Swagger API 명세의 Enum 필드 정의 및 예시값(Example)을 개선하여, 프론트엔드 코드 생성(Codegen) 및 API 사용의 명확성을 높였습니다.

## 📋 변경 사항
주요 DTO(Data Transfer Object) 내의 Enum 타입 필드들에 대해 **정확한 예시값(`example`)과 허용 가능한 값 목록(`allowableValues`/`enum`)을 추가/수정**하여 Swagger 명세를 업데이트했습니다.

1. **기분(Mood) 관련 Enum 명확화:**
    - `DiaryRequestDTO.java`
    - `DiaryResponseDTO.java`
    - `CalenderResponseDTO.java`
    - **변경 내용:** `mood` 필드의 `example` 값을 실제 Enum 값(`HAPPY`, `RELAX` 등)으로 수정하고, Swagger에 **`allowableValues` (허용 가능한 Enum 목록)**를 추가했습니다.
2. **채팅 역할(Role) 관련 Enum 명확화:**
    - `ChatLogResponseDTO.java`
    - `ThreadResponseDTO.java`
    - **변경 내용:** `role` 필드의 `example`을 실제 Enum 값인 `USER`로 수정하고, **`allowableValues`*를 추가했습니다.
3. **푸시 토큰 플랫폼(Platform) Enum 명확화:**
    - `ExpoPushTokenResponseDTO.java`
    - **변경 내용:** `platform` 필드에 **`allowableValues`*를 추가하여 허용되는 플랫폼 값(`ANDROID`, `IOS`)을 명확히 했습니다.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
