### PR TITLE
chore: Cloud Watch 메모리 사용률 관련 모니터링 설정 추가

### DIFF
--- a/.ebextensions_dev/03-cloudwatch-agent.config
+++ b/.ebextensions_dev/03-cloudwatch-agent.config
@@ -1,0 +1,33 @@
+commands:
+  01_download_cloudwatch_agent:
+    command: |
+      wget -q https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm -O /tmp/amazon-cloudwatch-agent.rpm
+    test: test ! -f /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent
+  
+  02_install_cloudwatch_agent:
+    command: |
+      rpm -U /tmp/amazon-cloudwatch-agent.rpm
+      rm -f /tmp/amazon-cloudwatch-agent.rpm
+    test: test ! -f /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent
+  
+  03_copy_config:
+    command: |
+      mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
+      cp /var/app/current/.platform/cloudwatch/cloudwatch-config.json /opt/aws/amazon-cloudwatch-agent/etc/config.json
+    test: test -f /var/app/current/.platform/cloudwatch/cloudwatch-config.json
+  
+  04_start_cloudwatch_agent:
+    command: |
+      /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+        -a fetch-config \
+        -m ec2 \
+        -s \
+        -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json
+    test: test -f /opt/aws/amazon-cloudwatch-agent/etc/config.json
+  
+  05_enable_cloudwatch_agent:
+    command: |
+      # Ensure agent starts on reboot
+      /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+        -a start
+

--- a/.platform/cloudwatch/cloudwatch-config.json
+++ b/.platform/cloudwatch/cloudwatch-config.json
@@ -1,0 +1,107 @@
+{
+  "agent": {
+    "metrics_collection_interval": 60,
+    "run_as_user": "root"
+  },
+  "metrics": {
+    "namespace": "Melissa/Backend",
+    "metrics_collected": {
+      "mem": {
+        "measurement": [
+          {
+            "name": "mem_used_percent",
+            "rename": "MemoryUsedPercent",
+            "unit": "Percent"
+          },
+          {
+            "name": "mem_available",
+            "rename": "MemoryAvailable",
+            "unit": "Megabytes"
+          },
+          {
+            "name": "mem_used",
+            "rename": "MemoryUsed",
+            "unit": "Megabytes"
+          },
+          {
+            "name": "mem_total",
+            "rename": "MemoryTotal",
+            "unit": "Megabytes"
+          }
+        ],
+        "metrics_collection_interval": 60
+      },
+      "swap": {
+        "measurement": [
+          {
+            "name": "swap_used_percent",
+            "rename": "SwapUsedPercent",
+            "unit": "Percent"
+          },
+          {
+            "name": "swap_free",
+            "rename": "SwapFree",
+            "unit": "Megabytes"
+          },
+          {
+            "name": "swap_used",
+            "rename": "SwapUsed",
+            "unit": "Megabytes"
+          }
+        ],
+        "metrics_collection_interval": 60
+      },
+      "disk": {
+        "measurement": [
+          {
+            "name": "used_percent",
+            "rename": "DiskUsedPercent",
+            "unit": "Percent"
+          },
+          {
+            "name": "free",
+            "rename": "DiskFree",
+            "unit": "Gigabytes"
+          },
+          {
+            "name": "used",
+            "rename": "DiskUsed",
+            "unit": "Gigabytes"
+          }
+        ],
+        "metrics_collection_interval": 60,
+        "resources": {
+          "*": {
+            "measurement": [
+              {
+                "name": "used_percent",
+                "unit": "Percent"
+              }
+            ]
+          }
+        }
+      },
+      "cpu": {
+        "measurement": [
+          {
+            "name": "cpu_usage_idle",
+            "rename": "CPUIdlePercent",
+            "unit": "Percent"
+          },
+          {
+            "name": "cpu_usage_iowait",
+            "rename": "CPUIOWaitPercent",
+            "unit": "Percent"
+          }
+        ],
+        "metrics_collection_interval": 60,
+        "totalcpu": false
+      }
+    },
+    "append_dimensions": {
+      "InstanceId": "${aws:InstanceId}",
+      "InstanceType": "${aws:InstanceType}",
+      "AutoScalingGroupName": "${aws:AutoScalingGroupName}"
+    }
+  }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
Elastic Beanstalk 환경에서 기본 CloudWatch 메트릭으로는 메모리 사용률을 확인할 수 없어,
운영 중 서버 상태를 정확히 모니터링하기 위해 CloudWatch Agent를 자동 설치 및 실행하는 설정을 추가했습니다.

이를 통해 메모리/스왑/디스크/CPU 등 주요 리소스가 CloudWatch로 전송되며, 향후 운영 모니터링에 활용할 수 있습니다.

## 📋 변경 사항

### ✔ EB 초기화 시 CloudWatch Agent 자동 설치 처리

`.ebextensions_dev/03-cloudwatch-agent.config` 파일을 새로 추가하여 다음 동작을 수행하도록 설정했습니다:

- CloudWatch Agent 설치 패키지 다운로드 및 설치
- Agent 설정 파일을 EB 배포 경로에서 시스템 경로로 복사
- CloudWatch Agent 설정 적용(fetch-config) 및 서비스 실행
- 인스턴스 재기동 시 자동 실행 보장

### ✔ CloudWatch 커스텀 메트릭 설정 파일 추가

`.platform/cloudwatch/cloudwatch-config.json` 파일을 통해 아래 메트릭을 CloudWatch로 지속적으로 전송하도록 구성했습니다:

- **Memory**
    - MemoryUsedPercent
    - MemoryAvailable
    - MemoryUsed
    - MemoryTotal
- **Swap**
    - SwapUsedPercent
    - SwapFree
    - SwapUsed
- **Disk**
    - DiskUsedPercent
    - DiskFree
    - DiskUsed
- **CPU**
    - CPUIdlePercent
    - CPUIOWaitPercent

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
