### PR TITLE
fix: CloudWatch Agent 설정 적용 단계 수정 (commands → container_commands)

### DIFF
--- a/.ebextensions_dev/03-cloudwatch-agent.config
+++ b/.ebextensions_dev/03-cloudwatch-agent.config
@@ -3,31 +3,25 @@ commands:
     command: |
       wget -q https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm -O /tmp/amazon-cloudwatch-agent.rpm
     test: test ! -f /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent
-  
+
   02_install_cloudwatch_agent:
     command: |
       rpm -U /tmp/amazon-cloudwatch-agent.rpm
       rm -f /tmp/amazon-cloudwatch-agent.rpm
     test: test ! -f /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent
-  
-  03_copy_config:
+
+container_commands:
+  01_copy_cloudwatch_config:
     command: |
       mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
-      cp /var/app/current/.platform/cloudwatch/cloudwatch-config.json /opt/aws/amazon-cloudwatch-agent/etc/config.json
-    test: test -f /var/app/current/.platform/cloudwatch/cloudwatch-config.json
-  
-  04_start_cloudwatch_agent:
+      # container_commands는 /var/app/staging에서 실행됨 → 상대경로 사용
+      cp .platform/cloudwatch/cloudwatch-config.json /opt/aws/amazon-cloudwatch-agent/etc/config.json
+
+  02_start_cloudwatch_agent:
     command: |
       /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
         -a fetch-config \
         -m ec2 \
         -s \
         -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json
-    test: test -f /opt/aws/amazon-cloudwatch-agent/etc/config.json
-  
-  05_enable_cloudwatch_agent:
-    command: |
-      # Ensure agent starts on reboot
-      /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
-        -a start
 


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
Elastic Beanstalk 배포 시 CloudWatch Agent가 올바른 config.json을 로드하지 못하던 문제를 해결했습니다.
기존에는 `.ebextensions/commands` 단계에서 config를 복사하고 Agent를 기동했으나, 해당 시점에는 `/var/app/current`가 존재하지 않아 config 복사가 실패하고 기본 설정으로 에이전트가 실행되고 있었습니다.

이번 수정에서는 CloudWatch Agent 설치는 `commands` 단계에 유지하되,
config 복사 및 Agent 기동을 `container_commands`로 이동하여 정상적으로 config가 반영되도록 변경했습니다.

## 📋 변경 사항

### 주요 변경점
- CloudWatch Agent 설치 로직은 기존대로 유지
- config 복사 및 agent 시작 로직을 `commands` → `container_commands`로 이동
- 상대 경로(`.platform/cloudwatch/...`)로 변경하여 EB staging 단계와 동기화
- 배포 후 CloudWatch 커스텀 네임스페이스가 정상적으로 관측 가능하도록 수정

### 수정된 `.ebextensions/03-cloudwatch-agent.config`
- 정상적인 적용을 위한 블록 분리
- fetch-config 방식으로 agent 재기동하도록 개선

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
