### PR TITLE
fix: CloudWatch Agent 설치/기동 로직 개선 및 EB 배포 안정성 향상

### DIFF
--- a/.ebextensions_dev/03-cloudwatch-agent.config
+++ b/.ebextensions_dev/03-cloudwatch-agent.config
@@ -1,27 +1,50 @@
 commands:
   01_download_cloudwatch_agent:
     command: |
-      wget -q https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm -O /tmp/amazon-cloudwatch-agent.rpm
-    test: test ! -f /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent
+      if [ ! -f /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent ]; then
+        echo "Downloading CloudWatch Agent..."
+        wget https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm -O /tmp/amazon-cloudwatch-agent.rpm
+      else
+        echo "CloudWatch Agent already installed, skipping download"
+      fi
+    ignoreErrors: true
 
   02_install_cloudwatch_agent:
     command: |
-      rpm -U /tmp/amazon-cloudwatch-agent.rpm
-      rm -f /tmp/amazon-cloudwatch-agent.rpm
-    test: test ! -f /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent
+      if [ -f /tmp/amazon-cloudwatch-agent.rpm ] && [ ! -f /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent ]; then
+        echo "Installing CloudWatch Agent..."
+        rpm -U /tmp/amazon-cloudwatch-agent.rpm || echo "RPM install failed, may already be installed"
+        rm -f /tmp/amazon-cloudwatch-agent.rpm
+      else
+        echo "CloudWatch Agent installation skipped"
+      fi
+    ignoreErrors: true
 
 container_commands:
   01_copy_cloudwatch_config:
     command: |
+      echo "Copying CloudWatch config..."
       mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
-      # container_commands는 /var/app/staging에서 실행됨 → 상대경로 사용
-      cp .platform/cloudwatch/cloudwatch-config.json /opt/aws/amazon-cloudwatch-agent/etc/config.json
+      if [ -f .platform/cloudwatch/cloudwatch-config.json ]; then
+        cp .platform/cloudwatch/cloudwatch-config.json /opt/aws/amazon-cloudwatch-agent/etc/config.json
+        echo "Config copied successfully"
+      else
+        echo "ERROR: cloudwatch-config.json not found"
+        exit 1
+      fi
 
   02_start_cloudwatch_agent:
     command: |
-      /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
-        -a fetch-config \
-        -m ec2 \
-        -s \
-        -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json
+      if [ -f /opt/aws/amazon-cloudwatch-agent/etc/config.json ]; then
+        echo "Starting CloudWatch Agent..."
+        /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+          -a fetch-config \
+          -m ec2 \
+          -s \
+          -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json
+        echo "CloudWatch Agent started"
+      else
+        echo "ERROR: Config file not found, skipping agent start"
+        exit 1
+      fi
 

--- a/.ebextensions_dev/03-cloudwatch-agent.config
+++ b/.ebextensions_dev/03-cloudwatch-agent.config
@@ -35,16 +35,30 @@ container_commands:
 
   02_start_cloudwatch_agent:
     command: |
-      if [ -f /opt/aws/amazon-cloudwatch-agent/etc/config.json ]; then
-        echo "Starting CloudWatch Agent..."
-        /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
-          -a fetch-config \
-          -m ec2 \
-          -s \
-          -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json
-        echo "CloudWatch Agent started"
-      else
-        echo "ERROR: Config file not found, skipping agent start"
-        exit 1
+      # Agent 설치 여부 확인
+      if [ ! -f /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl ]; then
+        echo "WARNING: CloudWatch Agent is not installed. Skipping agent start."
+        exit 0
       fi
+      
+      # Config 파일 존재 확인
+      if [ ! -f /opt/aws/amazon-cloudwatch-agent/etc/config.json ]; then
+        echo "WARNING: Config file not found. Skipping agent start."
+        exit 0
+      fi
+      
+      echo "Starting CloudWatch Agent with custom config..."
+      # 기존 Agent 중지 후 재시작
+      /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a stop || true
+      /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+        -a fetch-config \
+        -m ec2 \
+        -s \
+        -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json || {
+          echo "WARNING: CloudWatch Agent failed to start. This may be due to IAM role permissions."
+          echo "Please ensure the instance role has CloudWatchAgentServerPolicy attached."
+          exit 0
+        }
+      
+      echo "CloudWatch Agent started successfully"
 


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
Elastic Beanstalk 배포 과정에서 CloudWatch Agent가 설치/기동 실패할 경우
애플리케이션 배포가 중단되는 문제가 발생해 배포 안정성을 저해하고 있었습니다.

이번 PR에서는 CloudWatch Agent 설치 로직과 에러 처리 흐름을 개선하여,
권한 부족(IAM), RPM 설치 실패, Config 적용 실패 등 다양한 상황에서도
서비스 배포가 정상적으로 진행되도록 처리했습니다.

또한 기존 Agent가 동작 중일 때 중지 후 재시작하도록 하여 커스텀 메트릭이
정상 반영되도록 안정성을 높였습니다.

## 📋 변경 사항

### 주요 개선 사항
| 항목 | 이전 | 수정 후 |
|------|------|---------|
| Agent 존재 확인 | 없음 | Agent 미설치 시 경고 출력 후 계속 진행 |
| 기존 Agent 처리 | 바로 start만 시도 | 먼저 stop 후 fetch-config → restart |
| 오류 처리 | 실패 시 `exit 1`로 배포 중단 | 경고 메시지 출력 후 배포 계속 (`exit 0`) |
| IAM 권한 안내 | 없음 | 권한 부족 시 명확한 안내 메시지 출력 |
| Config 복사 | 실패 시 원인 표시 미흡 | 파일 존재 확인 후 실패 시 명확한 에러 표시 |

## 🎯 개선 후 동작 시나리오

### 시나리오 1: IAM 권한이 없는 경우
- 앱 배포: **성공**
- CloudWatch Agent: **경고 출력 후 skip**
- 기본 EB 메트릭: **정상 수집**
- 커스텀 메모리/디스크 메트릭: **수집되지 않음**

### 시나리오 2: IAM 권한이 있는 경우
- 앱 배포: **성공**
- CloudWatch Agent 설치 및 재시작: **정상 실행**
- Custom namespace(`Melissa/Backend`) 메트릭: **2~3분 내 생성**

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
