### PR TITLE
fix: CloudWatch Agent 설정 JSON 스키마 수정

### DIFF
--- a/.platform/cloudwatch/cloudwatch-config.json
+++ b/.platform/cloudwatch/cloudwatch-config.json
@@ -70,16 +70,7 @@
           }
         ],
         "metrics_collection_interval": 60,
-        "resources": {
-          "*": {
-            "measurement": [
-              {
-                "name": "used_percent",
-                "unit": "Percent"
-              }
-            ]
-          }
-        }
+        "resources": ["/", "/home"]
       },
       "cpu": {
         "measurement": [


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
CloudWatch Agent가 기동하지 않는 원인은 `cloudwatch-config.json`의 JSON 스키마가 CloudWatch Agent v1 스펙과 맞지 않았기 때문이다

## 📋 변경 사항

`disk.resources` 타입을 **object → array**로 변경

### Before
"disk": {
  "resources": {
    "*": {
      "measurement": [...]
    }
  }
}### After
"disk": {
  "resources": [
    "/",
    "/home"
  ]
}

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
