### PR TITLE
feat: 일기 생성 타입 추적 로직 추가 및 관련 API 수정 + S3 일기 저장 폴더 변경

### DIFF
--- a/src/main/java/com/melissa/diary/ai/ImageGenerator.java
+++ b/src/main/java/com/melissa/diary/ai/ImageGenerator.java
@@ -48,12 +48,26 @@ public class ImageGenerator {
     public String genProfileImage(String prompt) {
         String base64Img = generateB64(prompt);
 
-        // keyName 생성 (ex. "profile/1679999999999.png")
+        // keyName 생성 (ex. "ai-profile/1679999999999.png")
         String uuid = UUID.randomUUID().toString();
         Uuid savedUuid = uuidRepository.save(Uuid.builder()
                 .uuid(uuid).build());
 
         String keyName = amazonS3Manager.generateAiProfileKeyName(savedUuid);
+
+        // S3 업로드
+        return amazonS3Manager.uploadFileFromBase64(keyName, base64Img, "image/png");
+    }
+
+    public String genDiaryImage(String prompt) {
+        String base64Img = generateB64(prompt);
+
+        // keyName 생성 (ex. "diary/1679999999999.png")
+        String uuid = UUID.randomUUID().toString();
+        Uuid savedUuid = uuidRepository.save(Uuid.builder()
+                .uuid(uuid).build());
+
+        String keyName = amazonS3Manager.generateDiaryKeyName(savedUuid);
 
         // S3 업로드
         return amazonS3Manager.uploadFileFromBase64(keyName, base64Img, "image/png");

--- a/src/main/java/com/melissa/diary/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/melissa/diary/aws/s3/AmazonS3Manager.java
@@ -5,13 +5,11 @@ package com.melissa.diary.aws.s3;
         import com.amazonaws.services.s3.model.PutObjectRequest;
         import com.melissa.diary.config.AmazonConfig;
         import com.melissa.diary.domain.Uuid;
-        import com.melissa.diary.repository.UuidRepository;
         import lombok.RequiredArgsConstructor;
         import lombok.extern.slf4j.Slf4j;
         import org.springframework.stereotype.Component;
         import org.springframework.web.multipart.MultipartFile;
 
-        import java.io.ByteArrayInputStream;
         import java.io.IOException;
         import java.util.Base64;
 
@@ -60,5 +58,8 @@ public class AmazonS3Manager{
     }
     public String generateAiProfileKeyName(Uuid uuid) {
         return amazonConfig.getAiProfile() + '/' + uuid.getUuid();
+    }
+    public String generateDiaryKeyName(Uuid uuid) {
+        return amazonConfig.getDiary() + '/' + uuid.getUuid();
     }
 }

--- a/src/main/java/com/melissa/diary/config/AmazonConfig.java
+++ b/src/main/java/com/melissa/diary/config/AmazonConfig.java
@@ -40,6 +40,9 @@ public class AmazonConfig {
     @Value("${cloud.aws.path.month-summary}")
     private String monthSummary;
 
+    @Value("${cloud.aws.path.diary}")
+    private String diary;
+
     @PostConstruct
     public void init() {
         this.awsCredentials = new BasicAWSCredentials(accessKey, secretKey);

--- a/src/main/java/com/melissa/diary/converter/DiaryConverter.java
+++ b/src/main/java/com/melissa/diary/converter/DiaryConverter.java
@@ -19,6 +19,7 @@ public class DiaryConverter {
                 .title(diary.getTitle())
                 .content(diary.getContent())
                 .mood(diary.getMood() != null ? diary.getMood().name() : null)
+                .type(diary.getType().name())  // 일기 생성 타입 추가
                 .hashtag1(diary.getHashtag1())
                 .hashtag2(diary.getHashtag2())
                 .imageUrl(diary.getImageUrl())
@@ -33,6 +34,7 @@ public class DiaryConverter {
     public static CalenderResponseDTO.DiaryPreviewDTO toDiaryPreviewDTO(Diary diary) {
         return CalenderResponseDTO.DiaryPreviewDTO.builder()
                 .diaryId(diary.getId())
+                .type(diary.getType().name())  // 일기 생성 타입 추가
                 .hashtag1(diary.getHashtag1())
                 .hashtag2(diary.getHashtag2())
                 .imageUrl(diary.getImageUrl())

--- a/src/main/java/com/melissa/diary/domain/Diary.java
+++ b/src/main/java/com/melissa/diary/domain/Diary.java
@@ -2,6 +2,7 @@ package com.melissa.diary.domain;
 
 import com.melissa.diary.converter.EncryptionAttributeConverter;
 import com.melissa.diary.domain.common.BaseEntity;
+import com.melissa.diary.domain.enums.DiaryType;
 import com.melissa.diary.domain.enums.Mood;
 import jakarta.persistence.*;
 import lombok.*;
@@ -51,6 +52,11 @@ public class Diary extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(length = 40)
     private Mood mood;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private DiaryType type = DiaryType.MANUAL;
     
     @Column(length = 30)
     private String hashtag1;

--- a/src/main/java/com/melissa/diary/domain/enums/DiaryType.java
+++ b/src/main/java/com/melissa/diary/domain/enums/DiaryType.java
@@ -1,0 +1,12 @@
+package com.melissa.diary.domain.enums;
+
+/**
+ * 일기 생성 방식 구분
+ * - MANUAL: 사용자가 직접 작성한 일기
+ * - CHAT_BASED: 채팅 로그 기반 자동 생성 일기
+ */
+public enum DiaryType {
+    MANUAL,        // 수동 작성
+    CHAT_BASED     // 채팅 기반 자동 생성
+}
+

--- a/src/main/java/com/melissa/diary/service/DiaryImageService.java
+++ b/src/main/java/com/melissa/diary/service/DiaryImageService.java
@@ -44,8 +44,8 @@ public class DiaryImageService {
         String finalPrompt = refiner.refine(rawPrompt);
         
         try {
-            // DALL-E로 이미지 생성 → S3 업로드
-            String url = imageGenerator.genProfileImage(finalPrompt);
+            // DALL-E로 이미지 생성 → S3 diary 폴더에 업로드
+            String url = imageGenerator.genDiaryImage(finalPrompt);
             updateDiaryImage(diary, url);
             log.info("[Async-DiaryImage] 이미지 생성 완료. diaryId={}, url={}", diaryId, url);
         } catch (Exception e) {

--- a/src/main/java/com/melissa/diary/service/DiaryService.java
+++ b/src/main/java/com/melissa/diary/service/DiaryService.java
@@ -9,6 +9,7 @@ import com.melissa.diary.domain.DailyChatLog;
 import com.melissa.diary.domain.Diary;
 import com.melissa.diary.domain.Thread;
 import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.enums.DiaryType;
 import com.melissa.diary.domain.enums.Mood;
 import com.melissa.diary.domain.enums.Role;
 import com.melissa.diary.domain.enums.UsageCost;
@@ -134,6 +135,7 @@ public class DiaryService {
                 .title(request.getTitle())
                 .content(request.getContent())
                 .mood(mood)
+                .type(DiaryType.MANUAL)  // 수동 작성
                 .hashtag1(hashtagData.getHashTag1())  // LLM 생성
                 .hashtag2(hashtagData.getHashTag2())  // LLM 생성
                 .imageUrl(null)  // 초기에는 null, 비동기로 생성
@@ -224,6 +226,7 @@ public class DiaryService {
                 .title(diaryData.getTitle())
                 .content(diaryData.getStory())
                 .mood(diaryData.getMood())
+                .type(DiaryType.CHAT_BASED)  // 채팅 기반 자동 생성
                 .hashtag1(diaryData.getHashTag1())
                 .hashtag2(diaryData.getHashTag2())
                 .imageUrl(null)  // 초기에는 null, 비동기로 생성
@@ -382,6 +385,7 @@ public class DiaryService {
                 .title(diary.getTitle())
                 .content(diary.getContent())
                 .mood(diary.getMood() != null ? diary.getMood().name() : null)
+                .type(diary.getType().name())  // 일기 생성 타입 추가
                 .hashtag1(diary.getHashtag1())
                 .hashtag2(diary.getHashtag2())
                 .imageUrl(diary.getImageUrl())

--- a/src/main/java/com/melissa/diary/web/dto/CalenderResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/CalenderResponseDTO.java
@@ -37,6 +37,12 @@ public class CalenderResponseDTO {
                 requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String mood;
         
+        @Schema(description = "일기 생성 타입 (MANUAL: 수동 작성, CHAT_BASED: 채팅 기반 자동 생성)", 
+                example = "MANUAL", 
+                allowableValues = {"MANUAL", "CHAT_BASED"},
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        private String type;
+        
         @Schema(description = "해시태그 1", example = "#좋은하루", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String hashtag1;
         
@@ -65,6 +71,12 @@ public class CalenderResponseDTO {
         
         @Schema(description = "일기 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long diaryId;
+        
+        @Schema(description = "일기 생성 타입 (MANUAL: 수동 작성, CHAT_BASED: 채팅 기반 자동 생성)", 
+                example = "MANUAL", 
+                allowableValues = {"MANUAL", "CHAT_BASED"},
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        private String type;
         
         @Schema(description = "해시태그 1", example = "#좋은하루", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String hashtag1;

--- a/src/main/java/com/melissa/diary/web/dto/DiaryResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/DiaryResponseDTO.java
@@ -63,6 +63,12 @@ public class DiaryResponseDTO {
                 requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String mood;
         
+        @Schema(description = "일기 생성 타입 (MANUAL: 수동 작성, CHAT_BASED: 채팅 기반 자동 생성)", 
+                example = "MANUAL", 
+                allowableValues = {"MANUAL", "CHAT_BASED"},
+                requiredMode = Schema.RequiredMode.REQUIRED)
+        private String type;
+        
         @Schema(description = "해시태그 1", example = "#좋은하루", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String hashtag1;
         

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,7 @@ cloud:
       day-summary: day-summary
       month-summary: month-summary
       ai-profile: ai-profile
+      diary: diary
     region:
       static: ap-northeast-2
     stack:


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
일기 생성 방식 추적 기능 추가 및 일기 이미지 S3 저장 경로 개선

## 📋 변경 사항
1. 일기 생성 타입 구분 기능 추가
수동 작성(MANUAL)과 채팅 기반 자동 생성(CHAT_BASED)을 구분할 수 있도록 enum 추가
DB에 일기 생성 타입 저장 (기본값: MANUAL)
모든 일기 관련 API 응답에 생성 타입 정보 포함

2. API 응답 개선
일기 생성/수정 API에 type 필드 추가
캘린더 조회 API(일간/월간)에 type 필드 추가
일기 미리보기 DTO에도 type 필드 포함

3. S3 저장 경로 분리
일기 이미지 전용 폴더 diary/로 이전
일기 이미지 생성 전용 메서드 추가

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
