### PR TITLE
feat: 사용자 설정 알람 시간에 expo 토큰 기반 알람 전송10분주기(스케줄러, 배치처리, 로깅)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ dependencies {
 	// S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
-	// webFlux
-	//implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	// webFlux (Expo Push Notification 발송용 WebClient)
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	// 애플 jwt 토큰 검증용
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.37.2'

--- a/src/main/java/com/melissa/diary/config/AsyncConfig.java
+++ b/src/main/java/com/melissa/diary/config/AsyncConfig.java
@@ -3,16 +3,33 @@ package com.melissa.diary.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 @Configuration
 @EnableAsync
-
 public class AsyncConfig {
+    
     @Bean(name = "asyncTaskExecutor")
     public Executor taskExecutor() {
         return Executors.newFixedThreadPool(4);
+    }
+    
+    /**
+     * 알림 발송용 비동기 Executor
+     */
+    @Bean(name = "notificationExecutor")
+    public Executor notificationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("notification-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return executor;
     }
 }

--- a/src/main/java/com/melissa/diary/config/NotificationConfig.java
+++ b/src/main/java/com/melissa/diary/config/NotificationConfig.java
@@ -1,0 +1,39 @@
+package com.melissa.diary.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+
+@Configuration
+public class NotificationConfig {
+    
+    /**
+     * Expo Push Notification API 호출용 WebClient
+     * - Connection Timeout: 5초
+     * - Read/Write Timeout: 10초
+     * - Response Timeout: 10초
+     */
+    @Bean(name = "expoWebClient")
+    public WebClient expoWebClient() {
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                .responseTimeout(Duration.ofSeconds(10))
+                .doOnConnected(conn -> 
+                    conn.addHandlerLast(new ReadTimeoutHandler(10))
+                        .addHandlerLast(new WriteTimeoutHandler(10))
+                );
+        
+        return WebClient.builder()
+                .baseUrl("https://exp.host/--/api/v2/push/send")
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}
+

--- a/src/main/java/com/melissa/diary/converter/DiaryConverter.java
+++ b/src/main/java/com/melissa/diary/converter/DiaryConverter.java
@@ -1,7 +1,7 @@
 package com.melissa.diary.converter;
 
 import com.melissa.diary.domain.Diary;
-import com.melissa.diary.web.dto.CalenderResponseDTO;
+import com.melissa.diary.web.dto.CalendarResponseDTO;
 import org.springframework.stereotype.Component;
 
 /**
@@ -13,8 +13,8 @@ public class DiaryConverter {
     /**
      * Diary -> DiaryDetailDTO 변환 (상세 정보)
      */
-    public static CalenderResponseDTO.DiaryDetailDTO toDiaryDetailDTO(Diary diary) {
-        return CalenderResponseDTO.DiaryDetailDTO.builder()
+    public static CalendarResponseDTO.DiaryDetailDTO toDiaryDetailDTO(Diary diary) {
+        return CalendarResponseDTO.DiaryDetailDTO.builder()
                 .diaryId(diary.getId())
                 .title(diary.getTitle())
                 .content(diary.getContent())
@@ -31,8 +31,8 @@ public class DiaryConverter {
     /**
      * Diary -> DiaryPreviewDTO 변환 (미리보기)
      */
-    public static CalenderResponseDTO.DiaryPreviewDTO toDiaryPreviewDTO(Diary diary) {
-        return CalenderResponseDTO.DiaryPreviewDTO.builder()
+    public static CalendarResponseDTO.DiaryPreviewDTO toDiaryPreviewDTO(Diary diary) {
+        return CalendarResponseDTO.DiaryPreviewDTO.builder()
                 .diaryId(diary.getId())
                 .type(diary.getType().name())  // 일기 생성 타입 추가
                 .hashtag1(diary.getHashtag1())

--- a/src/main/java/com/melissa/diary/domain/UserSetting.java
+++ b/src/main/java/com/melissa/diary/domain/UserSetting.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.sql.Time;
+import java.time.LocalDate;
 
 @Getter
 @Builder
@@ -26,6 +27,9 @@ public class UserSetting {
     private Time sleepTime;
 
     private Time notificationTime;
+
+    @Column(name = "last_sent_date")
+    private LocalDate lastSentDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/melissa/diary/repository/UserSettingRepository.java
+++ b/src/main/java/com/melissa/diary/repository/UserSettingRepository.java
@@ -2,7 +2,12 @@ package com.melissa.diary.repository;
 
 import com.melissa.diary.domain.UserSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.sql.Time;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserSettingRepository extends JpaRepository<UserSetting, Long> {
@@ -11,5 +16,26 @@ public interface UserSettingRepository extends JpaRepository<UserSetting, Long> 
     boolean existsByUserId(Long userId);
 
     void deleteByUserId(Long userId);
+
+    /**
+     * 알림 발송 대상 사용자 설정 조회
+     * - notificationTime이 정확히 일치 (프론트에서 10분 단위로 제한)
+     * - 최소 하나의 알림 유형 활성화
+     * - 오늘 아직 발송되지 않음
+     * - 유효한 푸시 토큰 보유
+     */
+    @Query("""
+        SELECT DISTINCT us FROM UserSetting us
+        INNER JOIN us.user u
+        INNER JOIN u.expoPushTokenList ept
+        WHERE us.notificationTime = :notificationTime
+        AND (us.notificationSummary = true OR us.notificationQna = true)
+        AND (us.lastSentDate IS NULL OR us.lastSentDate < :today)
+        AND ept.invalid = false
+        """)
+    List<UserSetting> findNotificationTargets(
+            @Param("notificationTime") Time notificationTime,
+            @Param("today") LocalDate today
+    );
 
 }

--- a/src/main/java/com/melissa/diary/repository/UserSettingRepository.java
+++ b/src/main/java/com/melissa/diary/repository/UserSettingRepository.java
@@ -18,11 +18,7 @@ public interface UserSettingRepository extends JpaRepository<UserSetting, Long> 
     void deleteByUserId(Long userId);
 
     /**
-     * 알림 발송 대상 사용자 설정 조회
-     * - notificationTime이 정확히 일치 (프론트에서 10분 단위로 제한)
-     * - 최소 하나의 알림 유형 활성화
-     * - 오늘 아직 발송되지 않음
-     * - 유효한 푸시 토큰 보유
+     * 알림 발송 대상 조회 (시간 일치, 알림 활성화, 미발송, 유효 토큰)
      */
     @Query("""
         SELECT DISTINCT us FROM UserSetting us

--- a/src/main/java/com/melissa/diary/repository/UserSettingRepository.java
+++ b/src/main/java/com/melissa/diary/repository/UserSettingRepository.java
@@ -19,11 +19,12 @@ public interface UserSettingRepository extends JpaRepository<UserSetting, Long> 
 
     /**
      * 알림 발송 대상 조회 (시간 일치, 알림 활성화, 미발송, 유효 토큰)
+     * FETCH JOIN으로 N+1 문제 방지
      */
     @Query("""
         SELECT DISTINCT us FROM UserSetting us
-        INNER JOIN us.user u
-        INNER JOIN u.expoPushTokenList ept
+        INNER JOIN FETCH us.user u
+        INNER JOIN FETCH u.expoPushTokenList ept
         WHERE us.notificationTime = :notificationTime
         AND (us.notificationSummary = true OR us.notificationQna = true)
         AND (us.lastSentDate IS NULL OR us.lastSentDate < :today)

--- a/src/main/java/com/melissa/diary/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/melissa/diary/scheduler/NotificationScheduler.java
@@ -1,0 +1,73 @@
+package com.melissa.diary.scheduler;
+
+import com.melissa.diary.domain.UserSetting;
+import com.melissa.diary.repository.UserSettingRepository;
+import com.melissa.diary.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.sql.Time;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+/**
+ * 푸시 알림 스케줄러
+ * - 매 10분마다 실행 (00, 10, 20, 30, 40, 50분)
+ * - 해당 시간에 알림 받을 사용자에게 푸시 발송
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationScheduler {
+    
+    private final UserSettingRepository userSettingRepository;
+    private final NotificationService notificationService;
+    
+    /**
+     * 10분 단위 알림 발송
+     * - 00, 10, 20, 30, 40, 50분에 실행
+     * - 해당 시간에 notificationTime이 설정된 사용자에게 알림 발송
+     */
+    @Scheduled(cron = "0 */10 * * * *", zone = "Asia/Seoul")
+    public void sendDailyNotifications() {
+        long startTime = System.currentTimeMillis();
+        LocalTime now = LocalTime.now();
+        
+        // 현재 시각을 10분 단위로 내림 (예: 23:03 → 23:00, 23:17 → 23:10)
+        int currentMinute = (now.getMinute() / 10) * 10;
+        LocalTime targetTime = LocalTime.of(now.getHour(), currentMinute, 0);
+        Time notificationTime = Time.valueOf(targetTime);
+        
+        log.info("[NotificationScheduler] 알림 스케줄러 시작. 대상 시간: {}", targetTime);
+        
+        try {
+            // 발송 대상 조회
+            List<UserSetting> targets = userSettingRepository.findNotificationTargets(
+                    notificationTime, 
+                    LocalDate.now()
+            );
+            
+            if (targets.isEmpty()) {
+                log.info("[NotificationScheduler] 발송 대상 없음. 시간: {}", targetTime);
+                return;
+            }
+            
+            log.info("[NotificationScheduler] 발송 대상 조회 완료. 대상: {}명", targets.size());
+            
+            // 배치 발송
+            notificationService.sendBatchNotifications(targets);
+            
+            long elapsedTime = System.currentTimeMillis() - startTime;
+            log.info("[NotificationScheduler] 알림 스케줄러 완료. 대상: {}명, 소요 시간: {}ms", 
+                    targets.size(), elapsedTime);
+            
+        } catch (Exception e) {
+            long elapsedTime = System.currentTimeMillis() - startTime;
+            log.error("[NotificationScheduler] 알림 스케줄러 실행 중 오류 발생. 소요 시간: {}ms", elapsedTime, e);
+        }
+    }
+}
+

--- a/src/main/java/com/melissa/diary/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/melissa/diary/scheduler/NotificationScheduler.java
@@ -15,8 +15,7 @@ import java.util.List;
 
 /**
  * 푸시 알림 스케줄러
- * - 매 10분마다 실행 (00, 10, 20, 30, 40, 50분)
- * - 해당 시간에 알림 받을 사용자에게 푸시 발송
+ * 매 10분마다 실행하여 해당 시간 알림 설정 사용자에게 발송
  */
 @Component
 @RequiredArgsConstructor
@@ -27,9 +26,7 @@ public class NotificationScheduler {
     private final NotificationService notificationService;
     
     /**
-     * 10분 단위 알림 발송
-     * - 00, 10, 20, 30, 40, 50분에 실행
-     * - 해당 시간에 notificationTime이 설정된 사용자에게 알림 발송
+     * 10분 단위 알림 발송 (00, 10, 20, 30, 40, 50분)
      */
     @Scheduled(cron = "0 */10 * * * *", zone = "Asia/Seoul")
     public void sendDailyNotifications() {
@@ -57,11 +54,11 @@ public class NotificationScheduler {
             
             log.info("[NotificationScheduler] 발송 대상 조회 완료. 대상: {}명", targets.size());
             
-            // 배치 발송
+            // 배치 순차 발송 (비동기 시작, 100명씩 분할하여 안정적으로 순차 처리)
             notificationService.sendBatchNotifications(targets);
             
             long elapsedTime = System.currentTimeMillis() - startTime;
-            log.info("[NotificationScheduler] 알림 스케줄러 완료. 대상: {}명, 소요 시간: {}ms", 
+            log.info("[NotificationScheduler] 알림 스케줄러 완료 (배치 순차 발송 시작). 대상: {}명, 조회 시간: {}ms", 
                     targets.size(), elapsedTime);
             
         } catch (Exception e) {

--- a/src/main/java/com/melissa/diary/service/CalendarService.java
+++ b/src/main/java/com/melissa/diary/service/CalendarService.java
@@ -7,7 +7,7 @@ import com.melissa.diary.domain.Diary;
 import com.melissa.diary.domain.User;
 import com.melissa.diary.repository.DiaryRepository;
 import com.melissa.diary.repository.UserRepository;
-import com.melissa.diary.web.dto.CalenderResponseDTO;
+import com.melissa.diary.web.dto.CalendarResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class CalenderService {
+public class CalendarService {
 
     private final DiaryRepository diaryRepository;
     private final UserRepository userRepository;
@@ -33,7 +33,7 @@ public class CalenderService {
      * 특정 날짜의 일기 상세 조회 (최대 3개)
      */
     @Transactional(readOnly = true)
-    public CalenderResponseDTO.DailySummaryResponseDTO getDailySummary(Long userId, int year, int month, int day) {
+    public CalendarResponseDTO.DailySummaryResponseDTO getDailySummary(Long userId, int year, int month, int day) {
         // 유저 검증
         getUser(userId);
 
@@ -46,12 +46,12 @@ public class CalenderService {
                 userId, year, month, day, true);
 
         // 일기가 없어도 빈 배열로 반환 (에러 발생하지 않음)
-        List<CalenderResponseDTO.DiaryDetailDTO> diaryDetails = diaries.stream()
+        List<CalendarResponseDTO.DiaryDetailDTO> diaryDetails = diaries.stream()
                 .limit(3) // 최대 3개로 제한
                 .map(DiaryConverter::toDiaryDetailDTO)
                 .collect(Collectors.toList());
 
-        return CalenderResponseDTO.DailySummaryResponseDTO.builder()
+        return CalendarResponseDTO.DailySummaryResponseDTO.builder()
                 .year(year)
                 .month(month)
                 .day(day)
@@ -63,7 +63,7 @@ public class CalenderService {
      * 월간 미리보기 조회 (날짜별 그룹화)
      */
     @Transactional(readOnly = true)
-    public List<CalenderResponseDTO.DailyPreviewResponseDTO> getMonthlySummary(Long userId, int year, int month) {
+    public List<CalendarResponseDTO.DailyPreviewResponseDTO> getMonthlySummary(Long userId, int year, int month) {
         // 유저 검증
         getUser(userId);
 
@@ -90,12 +90,12 @@ public class CalenderService {
                     List<Diary> dayDiaries = entry.getValue();
                     
                     // 최대 3개로 제한하고 DiaryPreviewDTO로 변환
-                    List<CalenderResponseDTO.DiaryPreviewDTO> previews = dayDiaries.stream()
+                    List<CalendarResponseDTO.DiaryPreviewDTO> previews = dayDiaries.stream()
                             .limit(3)
                             .map(DiaryConverter::toDiaryPreviewDTO)
                             .collect(Collectors.toList());
 
-                    return CalenderResponseDTO.DailyPreviewResponseDTO.builder()
+                    return CalendarResponseDTO.DailyPreviewResponseDTO.builder()
                             .year(year)
                             .month(month)
                             .day(day)
@@ -109,7 +109,7 @@ public class CalenderService {
      * 월간 전체 조회 (날짜별 상세 정보 포함)
      */
     @Transactional(readOnly = true)
-    public List<CalenderResponseDTO.DailySummaryResponseDTO> getMonthlyView(Long userId, int year, int month) {
+    public List<CalendarResponseDTO.DailySummaryResponseDTO> getMonthlyView(Long userId, int year, int month) {
         // 유저 검증
         getUser(userId);
 
@@ -136,12 +136,12 @@ public class CalenderService {
                     List<Diary> dayDiaries = entry.getValue();
                     
                     // 최대 3개로 제한하고 DiaryDetailDTO로 변환
-                    List<CalenderResponseDTO.DiaryDetailDTO> details = dayDiaries.stream()
+                    List<CalendarResponseDTO.DiaryDetailDTO> details = dayDiaries.stream()
                             .limit(3)
                             .map(DiaryConverter::toDiaryDetailDTO)
                             .collect(Collectors.toList());
 
-                    return CalenderResponseDTO.DailySummaryResponseDTO.builder()
+                    return CalendarResponseDTO.DailySummaryResponseDTO.builder()
                             .year(year)
                             .month(month)
                             .day(day)

--- a/src/main/java/com/melissa/diary/service/NotificationService.java
+++ b/src/main/java/com/melissa/diary/service/NotificationService.java
@@ -93,11 +93,18 @@ public class NotificationService {
     
     /**
      * 개별 사용자 알림 발송
-     * 유효한 토큰 모두에게 발송, 하나라도 성공하면 lastSentDate 갱신
+     * 중복 발송 방지를 위해 발송 전 lastSentDate 먼저 갱신
      * 트랜잭션 없음 (읽기는 FETCH JOIN으로 이미 로딩, 쓰기는 하위 메서드에서 독립 처리)
      */
     public void sendNotificationToUser(UserSetting userSetting) {
         Long userId = userSetting.getUser().getId();
+        
+        // 중복 발송 방지: 발송 전에 먼저 lastSentDate 갱신
+        boolean updated = updateLastSentDateIfNotToday(userSetting.getId());
+        if (!updated) {
+            log.debug("[Notification] 이미 오늘 발송됨. userId={}", userId);
+            return;
+        }
         
         // 유효한 토큰 목록 조회
         List<ExpoPushToken> validTokens = userSetting.getUser().getExpoPushTokenList().stream()
@@ -111,7 +118,6 @@ public class NotificationService {
         
         log.info("[Notification] 사용자 알림 발송 시작. userId={}, 토큰 수={}", userId, validTokens.size());
         
-        boolean anySuccess = false;
         int tokenSuccessCount = 0;
         int tokenFailCount = 0;
         
@@ -123,7 +129,6 @@ public class NotificationService {
         for (ExpoPushToken token : validTokens) {
             try {
                 sendPushNotification(token.getExpoPushToken(), title, body);
-                anySuccess = true;
                 tokenSuccessCount++;
                 log.info("[Notification] 토큰 발송 성공. userId={}, tokenId={}", userId, token.getId());
             } catch (InvalidTokenException e) {
@@ -137,14 +142,8 @@ public class NotificationService {
             }
         }
         
-        // 하나라도 성공하면 lastSentDate 갱신
-        if (anySuccess) {
-            updateLastSentDate(userSetting.getId());
-            log.info("[Notification] 사용자 알림 발송 완료. userId={}, 토큰 성공: {}, 실패: {}", 
-                    userId, tokenSuccessCount, tokenFailCount);
-        } else {
-            log.error("[Notification] 모든 토큰 발송 실패. userId={}", userId);
-        }
+        log.info("[Notification] 사용자 알림 발송 완료. userId={}, 토큰 성공: {}, 실패: {}", 
+                userId, tokenSuccessCount, tokenFailCount);
     }
     
     /**
@@ -212,20 +211,36 @@ public class NotificationService {
     }
     
     /**
-     * 발송 완료 날짜 갱신
-     * 독립적인 트랜잭션으로 처리
+     * 발송 전 lastSentDate 갱신 (중복 발송 방지)
+     * 오늘 날짜가 아닐 때만 갱신하고 true 반환
+     * @return 갱신 성공 여부 (true: 갱신됨, false: 이미 오늘 날짜)
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void updateLastSentDate(Long userSettingId) {
+    public boolean updateLastSentDateIfNotToday(Long userSettingId) {
         try {
-            userSettingRepository.findById(userSettingId).ifPresent(setting -> {
-                setting.setLastSentDate(LocalDate.now());
-                userSettingRepository.save(setting);
-                log.debug("[Notification] lastSentDate 갱신 완료. userSettingId={}, date={}", 
-                        userSettingId, LocalDate.now());
-            });
+            UserSetting setting = userSettingRepository.findById(userSettingId).orElse(null);
+            if (setting == null) {
+                log.warn("[Notification] UserSetting not found. id={}", userSettingId);
+                return false;
+            }
+            
+            LocalDate today = LocalDate.now();
+            
+            // 이미 오늘 발송했으면 false 반환
+            if (today.equals(setting.getLastSentDate())) {
+                return false;
+            }
+            
+            // 오늘 날짜로 갱신
+            setting.setLastSentDate(today);
+            userSettingRepository.save(setting);
+            log.debug("[Notification] lastSentDate 갱신 완료. userSettingId={}, date={}", 
+                    userSettingId, today);
+            return true;
+            
         } catch (Exception e) {
             log.error("[Notification] lastSentDate 갱신 실패. userSettingId={}", userSettingId, e);
+            return false;
         }
     }
     

--- a/src/main/java/com/melissa/diary/service/NotificationService.java
+++ b/src/main/java/com/melissa/diary/service/NotificationService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -93,8 +94,9 @@ public class NotificationService {
     /**
      * 개별 사용자 알림 발송
      * 유효한 토큰 모두에게 발송, 하나라도 성공하면 lastSentDate 갱신
+     * 비동기 컨텍스트에서 독립적인 트랜잭션 생성
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void sendNotificationToUser(UserSetting userSetting) {
         Long userId = userSetting.getUser().getId();
         
@@ -195,27 +197,37 @@ public class NotificationService {
     
     /**
      * Invalid 토큰 비활성화
+     * 독립적인 트랜잭션으로 처리
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void markTokenAsInvalid(Long tokenId) {
-        expoPushTokenRepository.findById(tokenId).ifPresent(token -> {
-            token.setInvalid(true);
-            expoPushTokenRepository.save(token);
-            log.info("[Notification] 토큰 비활성화 완료. tokenId={}", tokenId);
-        });
+        try {
+            expoPushTokenRepository.findById(tokenId).ifPresent(token -> {
+                token.setInvalid(true);
+                expoPushTokenRepository.save(token);
+                log.info("[Notification] 토큰 비활성화 완료. tokenId={}", tokenId);
+            });
+        } catch (Exception e) {
+            log.error("[Notification] 토큰 비활성화 실패. tokenId={}", tokenId, e);
+        }
     }
     
     /**
      * 발송 완료 날짜 갱신
+     * 독립적인 트랜잭션으로 처리
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void updateLastSentDate(Long userSettingId) {
-        userSettingRepository.findById(userSettingId).ifPresent(setting -> {
-            setting.setLastSentDate(LocalDate.now());
-            userSettingRepository.save(setting);
-            log.debug("[Notification] lastSentDate 갱신 완료. userSettingId={}, date={}", 
-                    userSettingId, LocalDate.now());
-        });
+        try {
+            userSettingRepository.findById(userSettingId).ifPresent(setting -> {
+                setting.setLastSentDate(LocalDate.now());
+                userSettingRepository.save(setting);
+                log.debug("[Notification] lastSentDate 갱신 완료. userSettingId={}, date={}", 
+                        userSettingId, LocalDate.now());
+            });
+        } catch (Exception e) {
+            log.error("[Notification] lastSentDate 갱신 실패. userSettingId={}", userSettingId, e);
+        }
     }
     
     // 알림 제목 생성

--- a/src/main/java/com/melissa/diary/service/NotificationService.java
+++ b/src/main/java/com/melissa/diary/service/NotificationService.java
@@ -40,7 +40,7 @@ public class NotificationService {
     
     /**
      * 배치 순차 발송
-     * 비동기 시작으로 스케줄러 블로킹 방지, 내부는 순차 처리로 안정성 확보
+     * 비동기 시작으로 스케줄러 블로킹 방지, 100명씩 배치 트랜잭션으로 I/O 최적화
      */
     @Async("notificationExecutor")
     public void sendBatchNotifications(List<UserSetting> userSettings) {
@@ -59,31 +59,15 @@ public class NotificationService {
             List<UserSetting> batch = userSettings.subList(i, endIndex);
             int batchNumber = (i / BATCH_SIZE) + 1;
             
-            long batchStartTime = System.currentTimeMillis();
-            int successCount = 0;
-            int failCount = 0;
-            
-            log.info("[Notification] 배치 {}/{} 발송 시작. 대상: {}명", 
-                    batchNumber, batchCount, batch.size());
-            
-            // 배치 내 사용자 순차 처리
-            for (UserSetting userSetting : batch) {
-                try {
-                    sendNotificationToUser(userSetting);
-                    successCount++;
-                } catch (Exception e) {
-                    log.error("[Notification] 사용자 알림 발송 실패. userId={}", 
-                            userSetting.getUser().getId(), e);
-                    failCount++;
-                }
+            // 배치 단위 트랜잭션 처리
+            try {
+                int[] result = processBatchWithTransaction(batch, batchNumber, batchCount);
+                totalSuccess += result[0];
+                totalFail += result[1];
+            } catch (Exception e) {
+                log.error("[Notification] 배치 {}/{} 처리 실패", batchNumber, batchCount, e);
+                totalFail += batch.size();
             }
-            
-            totalSuccess += successCount;
-            totalFail += failCount;
-            long batchElapsedTime = System.currentTimeMillis() - batchStartTime;
-            
-            log.info("[Notification] 배치 {}/{} 발송 완료. 성공: {}, 실패: {}, 소요: {}ms", 
-                    batchNumber, batchCount, successCount, failCount, batchElapsedTime);
         }
         
         long totalElapsedTime = System.currentTimeMillis() - totalStartTime;
@@ -92,15 +76,46 @@ public class NotificationService {
     }
     
     /**
+     * 배치 단위 트랜잭션 처리 (100명씩)
+     * DB I/O 최적화를 위해 배치를 하나의 트랜잭션으로 처리
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public int[] processBatchWithTransaction(List<UserSetting> batch, int batchNumber, int totalBatches) {
+        long batchStartTime = System.currentTimeMillis();
+        int successCount = 0;
+        int failCount = 0;
+        
+        log.info("[Notification] 배치 {}/{} 발송 시작. 대상: {}명", 
+                batchNumber, totalBatches, batch.size());
+        
+        for (UserSetting userSetting : batch) {
+            try {
+                sendNotificationToUser(userSetting);
+                successCount++;
+            } catch (Exception e) {
+                log.error("[Notification] 사용자 알림 발송 실패. userId={}", 
+                        userSetting.getUser().getId(), e);
+                failCount++;
+            }
+        }
+        
+        long batchElapsedTime = System.currentTimeMillis() - batchStartTime;
+        log.info("[Notification] 배치 {}/{} 발송 완료. 성공: {}, 실패: {}, 소요: {}ms", 
+                batchNumber, totalBatches, successCount, failCount, batchElapsedTime);
+        
+        return new int[]{successCount, failCount};
+    }
+    
+    /**
      * 개별 사용자 알림 발송
      * 중복 발송 방지를 위해 발송 전 lastSentDate 먼저 갱신
-     * 트랜잭션 없음 (읽기는 FETCH JOIN으로 이미 로딩, 쓰기는 하위 메서드에서 독립 처리)
+     * 배치 트랜잭션 내에서 실행됨
      */
     public void sendNotificationToUser(UserSetting userSetting) {
         Long userId = userSetting.getUser().getId();
         
-        // 중복 발송 방지: 발송 전에 먼저 lastSentDate 갱신
-        boolean updated = updateLastSentDateIfNotToday(userSetting.getId());
+        // 중복 발송 방지: 발송 전에 먼저 lastSentDate 갱신 (같은 트랜잭션 내)
+        boolean updated = updateLastSentDateIfNotTodayInternal(userSetting);
         if (!updated) {
             log.debug("[Notification] 이미 오늘 발송됨. userId={}", userId);
             return;
@@ -132,8 +147,8 @@ public class NotificationService {
                 tokenSuccessCount++;
                 log.info("[Notification] 토큰 발송 성공. userId={}, tokenId={}", userId, token.getId());
             } catch (InvalidTokenException e) {
-                // Invalid 토큰은 비활성화
-                markTokenAsInvalid(token.getId());
+                // Invalid 토큰은 비활성화 (같은 트랜잭션 내)
+                markTokenAsInvalidInternal(token);
                 tokenFailCount++;
                 log.warn("[Notification] Invalid 토큰 비활성화. userId={}, tokenId={}", userId, token.getId());
             } catch (Exception e) {
@@ -194,36 +209,24 @@ public class NotificationService {
     }
     
     /**
-     * Invalid 토큰 비활성화
-     * 독립적인 트랜잭션으로 처리
+     * Invalid 토큰 비활성화 (배치 트랜잭션 내에서 실행)
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void markTokenAsInvalid(Long tokenId) {
+    private void markTokenAsInvalidInternal(ExpoPushToken token) {
         try {
-            expoPushTokenRepository.findById(tokenId).ifPresent(token -> {
-                token.setInvalid(true);
-                expoPushTokenRepository.save(token);
-                log.info("[Notification] 토큰 비활성화 완료. tokenId={}", tokenId);
-            });
+            token.setInvalid(true);
+            expoPushTokenRepository.save(token);
+            log.info("[Notification] 토큰 비활성화 완료. tokenId={}", token.getId());
         } catch (Exception e) {
-            log.error("[Notification] 토큰 비활성화 실패. tokenId={}", tokenId, e);
+            log.error("[Notification] 토큰 비활성화 실패. tokenId={}", token.getId(), e);
         }
     }
     
     /**
-     * 발송 전 lastSentDate 갱신 (중복 발송 방지)
-     * 오늘 날짜가 아닐 때만 갱신하고 true 반환
+     * 발송 전 lastSentDate 갱신 (배치 트랜잭션 내에서 실행)
      * @return 갱신 성공 여부 (true: 갱신됨, false: 이미 오늘 날짜)
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public boolean updateLastSentDateIfNotToday(Long userSettingId) {
+    private boolean updateLastSentDateIfNotTodayInternal(UserSetting setting) {
         try {
-            UserSetting setting = userSettingRepository.findById(userSettingId).orElse(null);
-            if (setting == null) {
-                log.warn("[Notification] UserSetting not found. id={}", userSettingId);
-                return false;
-            }
-            
             LocalDate today = LocalDate.now();
             
             // 이미 오늘 발송했으면 false 반환
@@ -235,11 +238,11 @@ public class NotificationService {
             setting.setLastSentDate(today);
             userSettingRepository.save(setting);
             log.debug("[Notification] lastSentDate 갱신 완료. userSettingId={}, date={}", 
-                    userSettingId, today);
+                    setting.getId(), today);
             return true;
             
         } catch (Exception e) {
-            log.error("[Notification] lastSentDate 갱신 실패. userSettingId={}", userSettingId, e);
+            log.error("[Notification] lastSentDate 갱신 실패. userSettingId={}", setting.getId(), e);
             return false;
         }
     }

--- a/src/main/java/com/melissa/diary/service/NotificationService.java
+++ b/src/main/java/com/melissa/diary/service/NotificationService.java
@@ -94,9 +94,8 @@ public class NotificationService {
     /**
      * 개별 사용자 알림 발송
      * 유효한 토큰 모두에게 발송, 하나라도 성공하면 lastSentDate 갱신
-     * 비동기 컨텍스트에서 독립적인 트랜잭션 생성
+     * 트랜잭션 없음 (읽기는 FETCH JOIN으로 이미 로딩, 쓰기는 하위 메서드에서 독립 처리)
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void sendNotificationToUser(UserSetting userSetting) {
         Long userId = userSetting.getUser().getId();
         

--- a/src/main/java/com/melissa/diary/service/NotificationService.java
+++ b/src/main/java/com/melissa/diary/service/NotificationService.java
@@ -7,6 +7,7 @@ import com.melissa.diary.repository.UserSettingRepository;
 import com.melissa.diary.web.dto.ExpoPushNotificationDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -22,6 +23,8 @@ import java.util.List;
 @Service
 public class NotificationService {
     
+    private static final int BATCH_SIZE = 100;  // 배치당 처리 인원
+    
     private final UserSettingRepository userSettingRepository;
     private final ExpoPushTokenRepository expoPushTokenRepository;
     private final WebClient expoWebClient;
@@ -35,34 +38,61 @@ public class NotificationService {
     }
     
     /**
-     * 배치 단위로 알림 발송
-     * - 각 사용자별로 독립적인 트랜잭션
-     * - 개별 실패가 전체에 영향 없음
+     * 배치 순차 발송
+     * 비동기 시작으로 스케줄러 블로킹 방지, 내부는 순차 처리로 안정성 확보
      */
+    @Async("notificationExecutor")
     public void sendBatchNotifications(List<UserSetting> userSettings) {
-        int successCount = 0;
-        int failCount = 0;
+        int totalCount = userSettings.size();
+        int batchCount = (int) Math.ceil((double) totalCount / BATCH_SIZE);
+        long totalStartTime = System.currentTimeMillis();
         
-        log.info("[Notification] 배치 알림 발송 시작. 대상: {}명", userSettings.size());
+        int totalSuccess = 0;
+        int totalFail = 0;
         
-        for (UserSetting userSetting : userSettings) {
-            try {
-                sendNotificationToUser(userSetting);
-                successCount++;
-            } catch (Exception e) {
-                log.error("[Notification] 사용자 알림 발송 실패. userId={}", 
-                        userSetting.getUser().getId(), e);
-                failCount++;
+        log.info("[Notification] 배치 순차 발송 시작. 전체: {}명, 배치 수: {}, 스레드: {}", 
+                totalCount, batchCount, Thread.currentThread().getName());
+        
+        for (int i = 0; i < totalCount; i += BATCH_SIZE) {
+            int endIndex = Math.min(i + BATCH_SIZE, totalCount);
+            List<UserSetting> batch = userSettings.subList(i, endIndex);
+            int batchNumber = (i / BATCH_SIZE) + 1;
+            
+            long batchStartTime = System.currentTimeMillis();
+            int successCount = 0;
+            int failCount = 0;
+            
+            log.info("[Notification] 배치 {}/{} 발송 시작. 대상: {}명", 
+                    batchNumber, batchCount, batch.size());
+            
+            // 배치 내 사용자 순차 처리
+            for (UserSetting userSetting : batch) {
+                try {
+                    sendNotificationToUser(userSetting);
+                    successCount++;
+                } catch (Exception e) {
+                    log.error("[Notification] 사용자 알림 발송 실패. userId={}", 
+                            userSetting.getUser().getId(), e);
+                    failCount++;
+                }
             }
+            
+            totalSuccess += successCount;
+            totalFail += failCount;
+            long batchElapsedTime = System.currentTimeMillis() - batchStartTime;
+            
+            log.info("[Notification] 배치 {}/{} 발송 완료. 성공: {}, 실패: {}, 소요: {}ms", 
+                    batchNumber, batchCount, successCount, failCount, batchElapsedTime);
         }
         
-        log.info("[Notification] 배치 알림 발송 완료. 성공: {}, 실패: {}", successCount, failCount);
+        long totalElapsedTime = System.currentTimeMillis() - totalStartTime;
+        log.info("[Notification] 전체 발송 완료. 전체: {}명, 성공: {}, 실패: {}, 총 소요: {}ms, 스레드: {}", 
+                totalCount, totalSuccess, totalFail, totalElapsedTime, Thread.currentThread().getName());
     }
     
     /**
-     * 개별 사용자에게 알림 발송
-     * - 해당 사용자의 모든 유효한 토큰에 발송
-     * - 하나라도 성공하면 lastSentDate 갱신
+     * 개별 사용자 알림 발송
+     * 유효한 토큰 모두에게 발송, 하나라도 성공하면 lastSentDate 갱신
      */
     @Transactional
     public void sendNotificationToUser(UserSetting userSetting) {
@@ -118,8 +148,6 @@ public class NotificationService {
     
     /**
      * Expo Push API 호출
-     * @throws InvalidTokenException Invalid 토큰인 경우
-     * @throws RuntimeException 기타 오류
      */
     private void sendPushNotification(String token, String title, String body) {
         ExpoPushNotificationDTO.PushRequest request = ExpoPushNotificationDTO.PushRequest.builder()
@@ -166,7 +194,7 @@ public class NotificationService {
     }
     
     /**
-     * 토큰을 Invalid로 표시
+     * Invalid 토큰 비활성화
      */
     @Transactional
     public void markTokenAsInvalid(Long tokenId) {
@@ -178,7 +206,7 @@ public class NotificationService {
     }
     
     /**
-     * lastSentDate 갱신
+     * 발송 완료 날짜 갱신
      */
     @Transactional
     public void updateLastSentDate(Long userSettingId) {
@@ -190,9 +218,7 @@ public class NotificationService {
         });
     }
     
-    /**
-     * 알림 제목 생성
-     */
+    // 알림 제목 생성
     private String buildNotificationTitle(UserSetting userSetting) {
         if (userSetting.isNotificationSummary() && userSetting.isNotificationQna()) {
             return "📝 오늘의 일기를 작성해보세요!";
@@ -203,9 +229,7 @@ public class NotificationService {
         }
     }
     
-    /**
-     * 알림 본문 생성
-     */
+    // 알림 본문 생성
     private String buildNotificationBody(UserSetting userSetting) {
         if (userSetting.isNotificationSummary() && userSetting.isNotificationQna()) {
             return "오늘 하루는 어땠나요? AI와 대화하며 일기를 작성해보세요.";
@@ -216,9 +240,6 @@ public class NotificationService {
         }
     }
     
-    /**
-     * Invalid 토큰 예외
-     */
     public static class InvalidTokenException extends RuntimeException {
         public InvalidTokenException(String message) {
             super(message);

--- a/src/main/java/com/melissa/diary/service/NotificationService.java
+++ b/src/main/java/com/melissa/diary/service/NotificationService.java
@@ -1,0 +1,228 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.domain.ExpoPushToken;
+import com.melissa.diary.domain.UserSetting;
+import com.melissa.diary.repository.ExpoPushTokenRepository;
+import com.melissa.diary.repository.UserSettingRepository;
+import com.melissa.diary.web.dto.ExpoPushNotificationDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 푸시 알림 발송 서비스
+ */
+@Slf4j
+@Service
+public class NotificationService {
+    
+    private final UserSettingRepository userSettingRepository;
+    private final ExpoPushTokenRepository expoPushTokenRepository;
+    private final WebClient expoWebClient;
+    
+    public NotificationService(UserSettingRepository userSettingRepository,
+                              ExpoPushTokenRepository expoPushTokenRepository,
+                              @Qualifier("expoWebClient") WebClient expoWebClient) {
+        this.userSettingRepository = userSettingRepository;
+        this.expoPushTokenRepository = expoPushTokenRepository;
+        this.expoWebClient = expoWebClient;
+    }
+    
+    /**
+     * 배치 단위로 알림 발송
+     * - 각 사용자별로 독립적인 트랜잭션
+     * - 개별 실패가 전체에 영향 없음
+     */
+    public void sendBatchNotifications(List<UserSetting> userSettings) {
+        int successCount = 0;
+        int failCount = 0;
+        
+        log.info("[Notification] 배치 알림 발송 시작. 대상: {}명", userSettings.size());
+        
+        for (UserSetting userSetting : userSettings) {
+            try {
+                sendNotificationToUser(userSetting);
+                successCount++;
+            } catch (Exception e) {
+                log.error("[Notification] 사용자 알림 발송 실패. userId={}", 
+                        userSetting.getUser().getId(), e);
+                failCount++;
+            }
+        }
+        
+        log.info("[Notification] 배치 알림 발송 완료. 성공: {}, 실패: {}", successCount, failCount);
+    }
+    
+    /**
+     * 개별 사용자에게 알림 발송
+     * - 해당 사용자의 모든 유효한 토큰에 발송
+     * - 하나라도 성공하면 lastSentDate 갱신
+     */
+    @Transactional
+    public void sendNotificationToUser(UserSetting userSetting) {
+        Long userId = userSetting.getUser().getId();
+        
+        // 유효한 토큰 목록 조회
+        List<ExpoPushToken> validTokens = userSetting.getUser().getExpoPushTokenList().stream()
+                .filter(token -> !token.getInvalid())
+                .toList();
+        
+        if (validTokens.isEmpty()) {
+            log.warn("[Notification] 유효한 토큰 없음. userId={}", userId);
+            return;
+        }
+        
+        log.info("[Notification] 사용자 알림 발송 시작. userId={}, 토큰 수={}", userId, validTokens.size());
+        
+        boolean anySuccess = false;
+        int tokenSuccessCount = 0;
+        int tokenFailCount = 0;
+        
+        // 알림 메시지 구성
+        String title = buildNotificationTitle(userSetting);
+        String body = buildNotificationBody(userSetting);
+        
+        // 각 토큰에 발송
+        for (ExpoPushToken token : validTokens) {
+            try {
+                sendPushNotification(token.getExpoPushToken(), title, body);
+                anySuccess = true;
+                tokenSuccessCount++;
+                log.info("[Notification] 토큰 발송 성공. userId={}, tokenId={}", userId, token.getId());
+            } catch (InvalidTokenException e) {
+                // Invalid 토큰은 비활성화
+                markTokenAsInvalid(token.getId());
+                tokenFailCount++;
+                log.warn("[Notification] Invalid 토큰 비활성화. userId={}, tokenId={}", userId, token.getId());
+            } catch (Exception e) {
+                tokenFailCount++;
+                log.error("[Notification] 토큰 발송 실패. userId={}, tokenId={}", userId, token.getId(), e);
+            }
+        }
+        
+        // 하나라도 성공하면 lastSentDate 갱신
+        if (anySuccess) {
+            updateLastSentDate(userSetting.getId());
+            log.info("[Notification] 사용자 알림 발송 완료. userId={}, 토큰 성공: {}, 실패: {}", 
+                    userId, tokenSuccessCount, tokenFailCount);
+        } else {
+            log.error("[Notification] 모든 토큰 발송 실패. userId={}", userId);
+        }
+    }
+    
+    /**
+     * Expo Push API 호출
+     * @throws InvalidTokenException Invalid 토큰인 경우
+     * @throws RuntimeException 기타 오류
+     */
+    private void sendPushNotification(String token, String title, String body) {
+        ExpoPushNotificationDTO.PushRequest request = ExpoPushNotificationDTO.PushRequest.builder()
+                .to(token)
+                .title(title)
+                .body(body)
+                .sound("default")
+                .priority("high")
+                .build();
+        
+        try {
+            ExpoPushNotificationDTO.PushResponse response = expoWebClient.post()
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(ExpoPushNotificationDTO.PushResponse.class)
+                    .onErrorResume(e -> {
+                        log.error("[Notification] Expo API 호출 실패. token={}", token, e);
+                        return Mono.error(new RuntimeException("Expo API 호출 실패", e));
+                    })
+                    .block();
+            
+            // 응답 검증
+            if (response != null && response.getData() != null && !response.getData().isEmpty()) {
+                ExpoPushNotificationDTO.PushTicket ticket = response.getData().get(0);
+                
+                if ("error".equals(ticket.getStatus())) {
+                    String errorType = ticket.getDetails() != null ? ticket.getDetails().getError() : "Unknown";
+                    
+                    // DeviceNotRegistered는 Invalid 토큰으로 처리
+                    if ("DeviceNotRegistered".equals(errorType) || "InvalidCredentials".equals(errorType)) {
+                        throw new InvalidTokenException(ticket.getMessage());
+                    }
+                    
+                    throw new RuntimeException("Expo Push 실패: " + ticket.getMessage());
+                }
+            }
+            
+        } catch (InvalidTokenException e) {
+            throw e;  // 상위로 전파
+        } catch (Exception e) {
+            log.error("[Notification] 알림 발송 중 예외 발생. token={}", token, e);
+            throw new RuntimeException("알림 발송 실패", e);
+        }
+    }
+    
+    /**
+     * 토큰을 Invalid로 표시
+     */
+    @Transactional
+    public void markTokenAsInvalid(Long tokenId) {
+        expoPushTokenRepository.findById(tokenId).ifPresent(token -> {
+            token.setInvalid(true);
+            expoPushTokenRepository.save(token);
+            log.info("[Notification] 토큰 비활성화 완료. tokenId={}", tokenId);
+        });
+    }
+    
+    /**
+     * lastSentDate 갱신
+     */
+    @Transactional
+    public void updateLastSentDate(Long userSettingId) {
+        userSettingRepository.findById(userSettingId).ifPresent(setting -> {
+            setting.setLastSentDate(LocalDate.now());
+            userSettingRepository.save(setting);
+            log.debug("[Notification] lastSentDate 갱신 완료. userSettingId={}, date={}", 
+                    userSettingId, LocalDate.now());
+        });
+    }
+    
+    /**
+     * 알림 제목 생성
+     */
+    private String buildNotificationTitle(UserSetting userSetting) {
+        if (userSetting.isNotificationSummary() && userSetting.isNotificationQna()) {
+            return "📝 오늘의 일기를 작성해보세요!";
+        } else if (userSetting.isNotificationSummary()) {
+            return "📝 오늘 하루를 정리해보세요";
+        } else {
+            return "💬 AI와 대화를 시작해보세요";
+        }
+    }
+    
+    /**
+     * 알림 본문 생성
+     */
+    private String buildNotificationBody(UserSetting userSetting) {
+        if (userSetting.isNotificationSummary() && userSetting.isNotificationQna()) {
+            return "오늘 하루는 어땠나요? AI와 대화하며 일기를 작성해보세요.";
+        } else if (userSetting.isNotificationSummary()) {
+            return "오늘의 기억을 일기로 남겨보세요.";
+        } else {
+            return "오늘 하루에 대해 이야기해보세요.";
+        }
+    }
+    
+    /**
+     * Invalid 토큰 예외
+     */
+    public static class InvalidTokenException extends RuntimeException {
+        public InvalidTokenException(String message) {
+            super(message);
+        }
+    }
+}
+

--- a/src/main/java/com/melissa/diary/web/controller/CalendarController.java
+++ b/src/main/java/com/melissa/diary/web/controller/CalendarController.java
@@ -1,8 +1,8 @@
 package com.melissa.diary.web.controller;
 
 import com.melissa.diary.apiPayload.ApiResponse;
-import com.melissa.diary.service.CalenderService;
-import com.melissa.diary.web.dto.CalenderResponseDTO;
+import com.melissa.diary.service.CalendarService;
+import com.melissa.diary.web.dto.CalendarResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -17,12 +17,12 @@ import java.util.List;
  * [v1.3.0] Diary 기반 달력 API
  */
 @RestController
-@Tag(name = "CalenderAPI", description = "Calender 관련 API")
-@RequestMapping("/api/v1/calender")
+@Tag(name = "CalendarAPI", description = "Calendar 관련 API")
+@RequestMapping("/api/v1/calendar")
 @RequiredArgsConstructor
-public class CalenderController {
+public class CalendarController {
 
-    private final CalenderService calenderService;
+    private final CalendarService calendarService;
 
     @Operation(summary = "특정 날짜 일기 조회",
                description = "[v1.3.0] 특정 날짜의 일기를 상세 조회합니다. (최대 3개)")
@@ -32,7 +32,7 @@ public class CalenderController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음")
     })
     @GetMapping("/day")
-    public ApiResponse<CalenderResponseDTO.DailySummaryResponseDTO> getDailySummary(
+    public ApiResponse<CalendarResponseDTO.DailySummaryResponseDTO> getDailySummary(
             @Parameter(description = "년도", required = true, example = "2025")
             @RequestParam(name = "year") int year,
             @Parameter(description = "월", required = true, example = "1")
@@ -42,7 +42,7 @@ public class CalenderController {
             Principal principal) {
 
         Long userId = Long.parseLong(principal.getName());
-        CalenderResponseDTO.DailySummaryResponseDTO response = calenderService.getDailySummary(userId, year, month, day);
+        CalendarResponseDTO.DailySummaryResponseDTO response = calendarService.getDailySummary(userId, year, month, day);
 
         return ApiResponse.onSuccess(response);
     }
@@ -55,7 +55,7 @@ public class CalenderController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음")
     })
     @GetMapping("/month")
-    public ApiResponse<List<CalenderResponseDTO.DailyPreviewResponseDTO>> getCalenderPreview(
+    public ApiResponse<List<CalendarResponseDTO.DailyPreviewResponseDTO>> getCalendarPreview(
             @Parameter(description = "년도", required = true, example = "2025")
             @RequestParam(name = "year") int year,
             @Parameter(description = "월", required = true, example = "1")
@@ -63,7 +63,7 @@ public class CalenderController {
             Principal principal) {
 
         Long userId = Long.parseLong(principal.getName());
-        List<CalenderResponseDTO.DailyPreviewResponseDTO> response = calenderService.getMonthlySummary(userId, year, month);
+        List<CalendarResponseDTO.DailyPreviewResponseDTO> response = calendarService.getMonthlySummary(userId, year, month);
 
         return ApiResponse.onSuccess(response);
     }
@@ -76,7 +76,7 @@ public class CalenderController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음")
     })
     @GetMapping("/month/summary")
-    public ApiResponse<List<CalenderResponseDTO.DailySummaryResponseDTO>> getCalenderView(
+    public ApiResponse<List<CalendarResponseDTO.DailySummaryResponseDTO>> getCalendarView(
             @Parameter(description = "년도", required = true, example = "2025")
             @RequestParam(name = "year") int year,
             @Parameter(description = "월", required = true, example = "1")
@@ -84,7 +84,7 @@ public class CalenderController {
             Principal principal) {
 
         Long userId = Long.parseLong(principal.getName());
-        List<CalenderResponseDTO.DailySummaryResponseDTO> response = calenderService.getMonthlyView(userId, year, month);
+        List<CalendarResponseDTO.DailySummaryResponseDTO> response = calendarService.getMonthlyView(userId, year, month);
 
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/melissa/diary/web/dto/CalendarResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/CalendarResponseDTO.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public class CalenderResponseDTO {
+public class CalendarResponseDTO {
     
     // ============== [v1.3.0] 새로운 DTO 구조 ==============
     

--- a/src/main/java/com/melissa/diary/web/dto/ExpoPushNotificationDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/ExpoPushNotificationDTO.java
@@ -1,0 +1,91 @@
+package com.melissa.diary.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Expo Push Notification API 통신용 DTO
+ */
+public class ExpoPushNotificationDTO {
+    
+    /**
+     * Expo Push API 요청 DTO
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PushRequest {
+        
+        @JsonProperty("to")
+        private String to;  // ExponentPushToken[xxx]
+        
+        @JsonProperty("title")
+        private String title;
+        
+        @JsonProperty("body")
+        private String body;
+        
+        @JsonProperty("data")
+        private Object data;  // 추가 데이터 (optional)
+        
+        @JsonProperty("sound")
+        @Builder.Default
+        private String sound = "default";
+        
+        @JsonProperty("priority")
+        @Builder.Default
+        private String priority = "high";
+    }
+    
+    /**
+     * Expo Push API 응답 DTO
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PushResponse {
+        
+        @JsonProperty("data")
+        private List<PushTicket> data;
+    }
+    
+    /**
+     * Expo Push Ticket (개별 발송 결과)
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PushTicket {
+        
+        @JsonProperty("status")
+        private String status;  // "ok" or "error"
+        
+        @JsonProperty("id")
+        private String id;  // Ticket ID (status가 "ok"인 경우)
+        
+        @JsonProperty("message")
+        private String message;  // 에러 메시지 (status가 "error"인 경우)
+        
+        @JsonProperty("details")
+        private PushErrorDetail details;  // 에러 상세 (status가 "error"인 경우)
+    }
+    
+    /**
+     * Expo Push Error 상세 정보
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PushErrorDetail {
+        
+        @JsonProperty("error")
+        private String error;  // "DeviceNotRegistered", "InvalidCredentials", "MessageTooBig" 등
+    }
+}
+


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
사용자가 설정한 `notificationTime`에 맞춰 매일 정기적으로 푸시 알림을 발송하는 스케줄링 시스템을 구현했습니다.

10분 단위로 스케줄러가 실행되며, 배치 트랜잭션 처리와 비동기 구조로 성능과 안정성을 확보했습니다.

## 📋 변경 사항

### 1. Domain & Repository
- `UserSetting.lastSentDate` 필드 추가 (하루 1회 발송 보장)
- `UserSettingRepository.findNotificationTargets()` 추가
  - FETCH JOIN으로 N+1 문제 해결 (201번 쿼리 → 1번)
  - 시간 일치, 알림 활성화, 미발송, 유효 토큰 조건 쿼리

### 2. Configuration
- `build.gradle`: WebFlux 의존성 추가
- `NotificationConfig`: Expo API용 WebClient 설정 (타임아웃 5초/10초)
- `AsyncConfig`: 알림 발송용 스레드 풀 (Core: 5, Max: 10)

### 3. Notification Service
- `NotificationService`: 알림 발송 핵심 로직
  - **배치 트랜잭션 처리** (100명당 1개 트랜잭션)
  - 중복 발송 방지 (발송 전 lastSentDate 갱신)
  - Invalid 토큰 자동 비활성화
  - 부분 실패 허용 구조 (유저별 try-catch)

### 4. Scheduler
- `NotificationScheduler`: 10분 단위 실행 (00, 10, 20, 30, 40, 50분)
  - 현재 시각 기반 알림 대상 조회
  - 비동기 발송으로 스케줄러 블로킹 방지
  - 상세 로그 (시작/완료/소요시간/성공실패)

### 5. DTO
- `ExpoPushNotificationDTO`: Expo API 통신용
  - PushRequest, PushResponse, PushTicket, PushErrorDetail

## 🔍 Code Review

### 주요 확인 사항

#### 1. 성능 최적화
- **N+1 쿼리 고려**: FETCH JOIN으로 User, ExpoPushToken 한번에 로딩
- **배치 트랜잭션**: 100명당 1개 트랜잭션으로 DB I/O 최적화
  - Before: 1000명 → 1000개 트랜잭션
  - After: 1000명 → 10개 트랜잭션 (1/100 감소)
- **비동기 구조**: 스케줄러는 조회만, 발송은 별도 스레드

#### 2. 안정성
- **배치 단위 트랜잭션**: `REQUIRES_NEW`로 100명씩 독립 트랜잭션
- **부분 실패 허용**: 배치 내 유저별 try-catch, A 사용자 실패가 B에 영향 없음
- **중복 발송 방지**: 발송 전 lastSentDate 갱신 (동시성 문제 해결)
- **Invalid 토큰 처리**: DeviceNotRegistered 자동 비활성화

#### 3. 멱등성
- `lastSentDate` 기반 하루 1회 발송 보장

#### 4. 확장성
- 배치 크기 조정 가능 (상수 BATCH_SIZE)
- 스레드 풀 크기 설정 가능
- 순차 처리로 Expo API Rate Limit 안전

## 📸 ScreenShot

## etc
### 오타 수정
- `Calender` → `Calendar` 전체 수정
  - 파일명: CalendarResponseDTO, CalendarController, CalendarService
  - API 경로: `/api/v1/calender` → `/api/v1/calendar`
  - 변수명, 메서드명 전체 수정

⚠️ **프론트엔드 수정 필요**: Calendar API 경로 변경으로 인해 프론트엔드에서 API 호출 경로 수정 필요