### PR TITLE
feat: Diary 응답에 AI Profile ID 추가

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/melissa-diary-assistant.main.iml" filepath="$PROJECT_DIR$/.idea/modules/melissa-diary-assistant.main.iml" />
+    </modules>
+  </component>
+</project>

--- a/src/main/java/com/melissa/diary/converter/DiaryConverter.java
+++ b/src/main/java/com/melissa/diary/converter/DiaryConverter.java
@@ -16,10 +16,11 @@ public class DiaryConverter {
     public static CalendarResponseDTO.DiaryDetailDTO toDiaryDetailDTO(Diary diary) {
         return CalendarResponseDTO.DiaryDetailDTO.builder()
                 .diaryId(diary.getId())
+                .aiProfileId(diary.getThread().getAiProfile().getId())
                 .title(diary.getTitle())
                 .content(diary.getContent())
                 .mood(diary.getMood() != null ? diary.getMood().name() : null)
-                .type(diary.getType().name())  // 일기 생성 타입 추가
+                .type(diary.getType().name())
                 .hashtag1(diary.getHashtag1())
                 .hashtag2(diary.getHashtag2())
                 .imageUrl(diary.getImageUrl())
@@ -34,7 +35,8 @@ public class DiaryConverter {
     public static CalendarResponseDTO.DiaryPreviewDTO toDiaryPreviewDTO(Diary diary) {
         return CalendarResponseDTO.DiaryPreviewDTO.builder()
                 .diaryId(diary.getId())
-                .type(diary.getType().name())  // 일기 생성 타입 추가
+                .aiProfileId(diary.getThread().getAiProfile().getId())
+                .type(diary.getType().name())
                 .hashtag1(diary.getHashtag1())
                 .hashtag2(diary.getHashtag2())
                 .imageUrl(diary.getImageUrl())

--- a/src/main/java/com/melissa/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/melissa/diary/repository/DiaryRepository.java
@@ -2,22 +2,55 @@ package com.melissa.diary.repository;
 
 import com.melissa.diary.domain.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     
     /**
      * 특정 날짜의 활성화된 일기 전부 조회 (최대 3개)
+     * FETCH JOIN으로 Thread, AiProfile 한번에 로딩 (N+1 방지)
      */
+    @Query("""
+        SELECT d FROM Diary d
+        INNER JOIN FETCH d.thread t
+        INNER JOIN FETCH t.aiProfile ap
+        WHERE d.user.id = :userId
+        AND d.year = :year
+        AND d.month = :month
+        AND d.day = :day
+        AND d.isActive = :isActive
+        ORDER BY d.createdAt DESC
+        """)
     List<Diary> findAllByUserIdAndYearAndMonthAndDayAndIsActiveOrderByCreatedAtDesc(
-            Long userId, int year, int month, int day, boolean isActive);
+            @Param("userId") Long userId,
+            @Param("year") int year,
+            @Param("month") int month,
+            @Param("day") int day,
+            @Param("isActive") boolean isActive);
     
     /**
      * 특정 월의 활성화된 일기 전부 조회
+     * FETCH JOIN으로 Thread, AiProfile 한번에 로딩 (N+1 방지)
      */
+    @Query("""
+        SELECT d FROM Diary d
+        INNER JOIN FETCH d.thread t
+        INNER JOIN FETCH t.aiProfile ap
+        WHERE d.user.id = :userId
+        AND d.year = :year
+        AND d.month = :month
+        AND d.isActive = :isActive
+        ORDER BY d.day ASC, d.createdAt DESC
+        """)
     List<Diary> findAllByUserIdAndYearAndMonthAndIsActiveOrderByDayAscCreatedAtDesc(
-            Long userId, int year, int month, boolean isActive);
+            @Param("userId") Long userId,
+            @Param("year") int year,
+            @Param("month") int month,
+            @Param("isActive") boolean isActive);
     
     /**
      * 특정 날짜의 모든 사용자의 활성화된 일기 조회 (스케줄러용)
@@ -33,8 +66,30 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     
     /**
      * Thread에 속한 모든 활성화된 일기 조회
+     * FETCH JOIN으로 Thread, AiProfile 한번에 로딩 (N+1 방지)
      */
-    List<Diary> findAllByThreadIdAndIsActiveOrderByCreatedAtDesc(Long threadId, boolean isActive);
+    @Query("""
+        SELECT d FROM Diary d
+        INNER JOIN FETCH d.thread t
+        INNER JOIN FETCH t.aiProfile ap
+        WHERE d.thread.id = :threadId
+        AND d.isActive = :isActive
+        ORDER BY d.createdAt DESC
+        """)
+    List<Diary> findAllByThreadIdAndIsActiveOrderByCreatedAtDesc(
+            @Param("threadId") Long threadId,
+            @Param("isActive") boolean isActive);
+    
+    /**
+     * Diary 단건 조회 (Thread, AiProfile FETCH JOIN)
+     */
+    @Query("""
+        SELECT d FROM Diary d
+        INNER JOIN FETCH d.thread t
+        INNER JOIN FETCH t.aiProfile ap
+        WHERE d.id = :id
+        """)
+    Optional<Diary> findByIdWithThreadAndProfile(@Param("id") Long id);
     
     /**
      * 회원 탈퇴시 삭제

--- a/src/main/java/com/melissa/diary/service/DiaryService.java
+++ b/src/main/java/com/melissa/diary/service/DiaryService.java
@@ -281,8 +281,8 @@ public class DiaryService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
         
-        // 일기 조회
-        Diary diary = diaryRepository.findById(diaryId)
+        // 일기 조회 (Thread, AiProfile FETCH JOIN)
+        Diary diary = diaryRepository.findByIdWithThreadAndProfile(diaryId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.DIARY_NOT_FOUND));
         
         // 권한 검증: 본인의 일기인지 확인
@@ -346,8 +346,8 @@ public class DiaryService {
         userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
         
-        // 일기 조회
-        Diary diary = diaryRepository.findById(diaryId)
+        // 일기 조회 (Thread, AiProfile FETCH JOIN) - 삭제 시에는 불필요하지만 일관성 유지
+        Diary diary = diaryRepository.findByIdWithThreadAndProfile(diaryId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.DIARY_NOT_FOUND));
         
         // 권한 검증: 본인의 일기인지 확인
@@ -379,13 +379,14 @@ public class DiaryService {
         return DiaryResponseDTO.DiaryResponse.builder()
                 .diaryId(diary.getId())
                 .threadId(diary.getThread().getId())
+                .aiProfileId(diary.getThread().getAiProfile().getId())
                 .year(diary.getYear())
                 .month(diary.getMonth())
                 .day(diary.getDay())
                 .title(diary.getTitle())
                 .content(diary.getContent())
                 .mood(diary.getMood() != null ? diary.getMood().name() : null)
-                .type(diary.getType().name())  // 일기 생성 타입 추가
+                .type(diary.getType().name())
                 .hashtag1(diary.getHashtag1())
                 .hashtag2(diary.getHashtag2())
                 .imageUrl(diary.getImageUrl())

--- a/src/main/java/com/melissa/diary/web/dto/CalendarResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/CalendarResponseDTO.java
@@ -26,6 +26,9 @@ public class CalendarResponseDTO {
         @Schema(description = "일기 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long diaryId;
         
+        @Schema(description = "AI 프로필 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        private Long aiProfileId;
+        
         @Schema(description = "일기 제목", example = "오늘의 일기", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String title;
         
@@ -71,6 +74,9 @@ public class CalendarResponseDTO {
         
         @Schema(description = "일기 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long diaryId;
+        
+        @Schema(description = "AI 프로필 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        private Long aiProfileId;
         
         @Schema(description = "일기 생성 타입 (MANUAL: 수동 작성, CHAT_BASED: 채팅 기반 자동 생성)", 
                 example = "MANUAL", 

--- a/src/main/java/com/melissa/diary/web/dto/DiaryResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/DiaryResponseDTO.java
@@ -43,6 +43,9 @@ public class DiaryResponseDTO {
         @Schema(description = "스레드 ID (항상 존재)", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long threadId;
         
+        @Schema(description = "AI 프로필 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        private Long aiProfileId;
+        
         @Schema(description = "년도", example = "2025", requiredMode = Schema.RequiredMode.REQUIRED)
         private int year;
         


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
Diary 응답 DTO에 `aiProfileId` 필드를 추가하고, 해당 값을 조회 시 N+1 문제가 발생하지 않도록 `DiaryRepository`의 조회 로직을 **fetch join** 기반으로 개선했습니다.  

또한 Calendar 관련 API에서도 aiProfileId를 제공하도록 DTO 및 Converter를 수정했습니다. *(v1.3.0 update)*

## 📋 변경 사항
- Diary 조회 응답 DTO에 `aiProfileId` 필드 추가
- Calendar API 응답 구조에 `aiProfileId` 포함
- Diary → Thread → AiProfile 관계 조회 시 **fetch join** 적용 (N+1 해결)
- DiaryConverter / CalendarConverter 내부 매핑 로직 수정
- 관련 API 총 6개 응답 구조 변경


## 🔍 Code Review

## 📸 ScreenShot
