### PR TITLE
feat: UserSetting API 타입 안정성 및 시간 포맷 통일

### DIFF
--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -22,6 +22,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // Setting
     SETTING_NOT_FOUND(HttpStatus.NOT_FOUND, "SETTING4001", "해당 유저의 셋팅을 찾을 수 없습니다."),
     SETTING_ALREADY_ENROLL(HttpStatus.BAD_REQUEST, "SETTING4002", "해당 유저의 셋팅값이 이미 존재합니다."),
+    SETTING_INVALID_TIME_FORMAT(HttpStatus.BAD_REQUEST, "SETTING4003", "유효하지 않은 시간 형식입니다. HH:mm 또는 HH:mm:ss로 전달해주세요."),
 
     // AI
     PARSING_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "AI5001", "llm 파싱 도중 실패했습니다."),

--- a/src/main/java/com/melissa/diary/converter/UserSettingConverter.java
+++ b/src/main/java/com/melissa/diary/converter/UserSettingConverter.java
@@ -5,23 +5,44 @@ import com.melissa.diary.web.dto.UserSettingRequestDTO;
 import com.melissa.diary.web.dto.UserSettingResponseDTO;
 
 import java.sql.Time;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 public class UserSettingConverter {
+    private static final DateTimeFormatter REQUEST_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    private static final DateTimeFormatter RESPONSE_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
     // 유저 셋팅 객체 -> 응답으로 변환하는 컨버터
     public static UserSettingResponseDTO.UserSettingResponse toResponse(UserSetting userSetting) {
         return UserSettingResponseDTO.UserSettingResponse.builder()
-                .sleepTime(userSetting.getSleepTime().toString())
-                .notificationTime(userSetting.getNotificationTime().toString())
-                .notificationSummary(userSetting.isNotificationSummary())
+                .sleepTime(formatTime(userSetting.getSleepTime()))
+                .notificationTime(formatTime(userSetting.getNotificationTime()))
+                .notificationEnabled(userSetting.isNotificationEnabled())
                 .build();
     }
 
     // 기존의 유저 셋팅 객체와 request로 업데이트하는 컨버터
     public static UserSetting updateEntity(UserSettingRequestDTO.UserSettingRequest request, UserSetting existing) {
-        existing.setSleepTime(Time.valueOf(request.getSleepTime()));
-        existing.setNotificationTime(Time.valueOf(request.getNotificationTime()));
-        existing.setNotificationSummary(request.isNotificationSummary());
+        existing.setSleepTime(parseTime(request.getSleepTime()));
+        existing.setNotificationTime(parseTime(request.getNotificationTime()));
+        existing.setNotificationEnabled(Boolean.TRUE.equals(request.getNotificationEnabled()));
         return existing;
     }
 
+    private static Time parseTime(String value) {
+        try {
+            LocalTime localTime = LocalTime.parse(value, REQUEST_TIME_FORMATTER).withSecond(0);
+            return Time.valueOf(localTime);
+        } catch (DateTimeParseException e) {
+            throw new com.melissa.diary.apiPayload.exception.handler.ErrorHandler(
+                    com.melissa.diary.apiPayload.code.status.ErrorStatus.SETTING_INVALID_TIME_FORMAT
+            );
+        }
+    }
+
+    private static String formatTime(Time time) {
+        return time.toLocalTime().format(RESPONSE_TIME_FORMATTER);
+    }
 }

--- a/src/main/java/com/melissa/diary/domain/UserSetting.java
+++ b/src/main/java/com/melissa/diary/domain/UserSetting.java
@@ -20,9 +20,7 @@ public class UserSetting {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private boolean notificationSummary;
-
-    private boolean notificationQna;
+    private boolean notificationEnabled;
 
     private Time sleepTime;
 

--- a/src/main/java/com/melissa/diary/repository/UserSettingRepository.java
+++ b/src/main/java/com/melissa/diary/repository/UserSettingRepository.java
@@ -26,7 +26,7 @@ public interface UserSettingRepository extends JpaRepository<UserSetting, Long> 
         INNER JOIN FETCH us.user u
         INNER JOIN FETCH u.expoPushTokenList ept
         WHERE us.notificationTime = :notificationTime
-        AND (us.notificationSummary = true OR us.notificationQna = true)
+        AND us.notificationEnabled = true
         AND (us.lastSentDate IS NULL OR us.lastSentDate < :today)
         AND ept.invalid = false
         """)

--- a/src/main/java/com/melissa/diary/service/NotificationService.java
+++ b/src/main/java/com/melissa/diary/service/NotificationService.java
@@ -249,24 +249,12 @@ public class NotificationService {
     
     // 알림 제목 생성
     private String buildNotificationTitle(UserSetting userSetting) {
-        if (userSetting.isNotificationSummary() && userSetting.isNotificationQna()) {
-            return "📝 오늘의 일기를 작성해보세요!";
-        } else if (userSetting.isNotificationSummary()) {
-            return "📝 오늘 하루를 정리해보세요";
-        } else {
-            return "💬 AI와 대화를 시작해보세요";
-        }
+        return "📝 오늘의 일기를 작성해보세요!";
     }
     
     // 알림 본문 생성
     private String buildNotificationBody(UserSetting userSetting) {
-        if (userSetting.isNotificationSummary() && userSetting.isNotificationQna()) {
-            return "오늘 하루는 어땠나요? AI와 대화하며 일기를 작성해보세요.";
-        } else if (userSetting.isNotificationSummary()) {
-            return "오늘의 기억을 일기로 남겨보세요.";
-        } else {
-            return "오늘 하루에 대해 이야기해보세요.";
-        }
+        return "오늘 하루는 어땠나요? 멜리사와 대화하며 일기를 작성해보세요.";
     }
     
     public static class InvalidTokenException extends RuntimeException {

--- a/src/main/java/com/melissa/diary/service/UserSettingService.java
+++ b/src/main/java/com/melissa/diary/service/UserSettingService.java
@@ -5,7 +5,6 @@ import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
 import com.melissa.diary.converter.UserSettingConverter;
 import com.melissa.diary.domain.User;
 import com.melissa.diary.domain.UserSetting;
-import com.melissa.diary.repository.AiProfileRepository;
 import com.melissa.diary.repository.UserRepository;
 import com.melissa.diary.repository.UserSettingRepository;
 import com.melissa.diary.web.dto.UserSettingRequestDTO;
@@ -15,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Time;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,7 +26,7 @@ public class UserSettingService {
     @Transactional(readOnly = true)
     public UserSettingResponseDTO.UserSettingResponse getUserSettings(Long userId) {
         // db에 해당 유저 없으면 에러던지기(탈퇴 보호)
-        User user = userRepository.findById(userId).orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+        userRepository.findById(userId).orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
         UserSetting userSetting = userSettingRepository.findByUserId(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.SETTING_NOT_FOUND));
@@ -41,7 +39,7 @@ public class UserSettingService {
     @Transactional
     public UserSettingResponseDTO.UserSettingResponse updateUserSettings(Long userId, UserSettingRequestDTO.UserSettingRequest request) {
         // db에 해당 유저 없으면 에러던지기(탈퇴 보호)
-        User user = userRepository.findById(userId).orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+        userRepository.findById(userId).orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
         UserSetting existingSetting = userSettingRepository.findByUserId(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.SETTING_NOT_FOUND));
@@ -58,10 +56,9 @@ public class UserSettingService {
         // db에 해당 유저 없으면 에러던지기(탈퇴 보호)
         User user = userRepository.findById(userId).orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
-        // 이미 존재하면 등록하지 않음
-        Optional<UserSetting> optional = userSettingRepository.findByUserId(userId);
-        if (optional.isPresent()) {
-            throw new ErrorHandler(ErrorStatus.SETTING_ALREADY_ENROLL);
+        // 이미 존재하면 조용히 리턴 (멱등성 보장)
+        if (userSettingRepository.existsByUserId(userId)) {
+            return;
         }
 
         // 기본값 설정
@@ -69,23 +66,22 @@ public class UserSettingService {
                 .user(user)
                 .sleepTime(Time.valueOf("04:30:00"))
                 .notificationTime(Time.valueOf("23:00:00"))
-                .notificationSummary(true)
-                .notificationQna(true)
+                .notificationEnabled(true)
                 .build();
 
-        // 예외 처리를 위해 try-catch로 감쌈
+        // 동시 요청으로 인한 중복 생성 방지
         try {
             userSettingRepository.save(defaultSetting);
         } catch (org.springframework.dao.DataIntegrityViolationException e) {
-            // DB 유니크 제약 에러가 터지면, 우리가 원하는 커스텀 예외로 던진다.
-            throw new ErrorHandler(ErrorStatus.SETTING_ALREADY_ENROLL);
+            // 동시 요청으로 이미 생성됨 - 조용히 무시
+            return;
         }
     }
 
     @Transactional(readOnly = true)
     public boolean isNewUser(Long userId) {
         // db에 해당 유저 없으면 에러던지기(탈퇴 보호)
-        User user = userRepository.findById(userId).orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+        userRepository.findById(userId).orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
         // 설정값이 있으면 신규가입이 아님 (기본값이라도 있으면, 기존유저)
         return !userSettingRepository.existsByUserId(userId);

--- a/src/main/java/com/melissa/diary/web/dto/UserSettingRequestDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/UserSettingRequestDTO.java
@@ -1,6 +1,9 @@
 package com.melissa.diary.web.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.*;
 
 public class UserSettingRequestDTO {
@@ -12,13 +15,18 @@ public class UserSettingRequestDTO {
     @Schema(description = "사용자 설정 수정 요청")
     public static class UserSettingRequest {
 
-        @Schema(description = "수면 시간 (HH:mm 형식)", example = "23:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        @NotBlank(message = "수면 시간은 필수입니다.")
+        @Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "수면 시간은 HH:mm 형식이어야 합니다.")
+        @Schema(description = "수면 시간 (HH:mm)", example = "23:00", requiredMode = Schema.RequiredMode.REQUIRED)
         private String sleepTime;
 
-        @Schema(description = "알림 시간 (HH:mm 형식)", example = "21:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        @NotBlank(message = "알림 시간은 필수입니다.")
+        @Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "알림 시간은 HH:mm 형식이어야 합니다.")
+        @Schema(description = "알림 시간 (HH:mm)", example = "21:00", requiredMode = Schema.RequiredMode.REQUIRED)
         private String notificationTime;
 
-        @Schema(description = "요약 알림 활성화 여부", example = "true", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-        private boolean notificationSummary;
+        @NotNull(message = "알림 활성화 여부는 필수입니다.")
+        @Schema(description = "알림 활성화 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+        private Boolean notificationEnabled;
     }
 }

--- a/src/main/java/com/melissa/diary/web/dto/UserSettingResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/UserSettingResponseDTO.java
@@ -17,7 +17,7 @@ public class UserSettingResponseDTO {
         @Schema(description = "알림 시간 (기본값: 23:00)", example = "23:00", requiredMode = Schema.RequiredMode.REQUIRED)
         private String notificationTime;
 
-        @Schema(description = "요약 알림 활성화 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
-        private boolean notificationSummary;
+        @Schema(description = "알림 활성화 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+        private boolean notificationEnabled;
     }
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- UserSetting API 타입 안정성 및 시간 포맷 통일
- 알림 플래그 통합: notificationSummary, notificationQna → notificationEnabled
- GET/PUT 시간 형식 HH:mm으로 통일 (내부만 HH:mm:00 강제)
- 요청 DTO 모든 필드 required + 정규식 검증
- 시간 파싱 실패 시 400 (SETTING_INVALID_TIME_FORMAT)
- /register 멱등성 개선 (중복 시 200 OK)
- 프론트 시간 파싱/역파싱 제거

## 📋 변경 사항
### 1. 알림 플래그 통합

- 기존 boolean 2개(`notificationSummary`, `notificationQna`) → `notificationEnabled`
- 도메인/DTO/쿼리/발송 로직 전반 반영

### 2. 시간 포맷 통일

- GET/PUT 모두 `HH:mm` 형식
- 내부 저장은 초 `00` 고정
- 10분 단위 스케줄러 매칭

### 3. 요청 DTO required 처리

- `@NotBlank/@NotNull` + `@Pattern(HH:mm)`
- 잘못된 형식 → 400 Bad Request

### 4. 에러 처리 추가

- `SETTING_INVALID_TIME_FORMAT`(400)
- 기존 500 → 명확한 400 반환

### 5. `/register` 멱등성

- 기존: 중복 시 400
- 변경: 조용히 200 반환

### 6. 기타

- 불필요한 시간 파싱/포맷팅 제거
- 스케줄러 쿼리 조건 단순화

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
