### PR TITLE
feat: 피드 조회 api 커서 기반 페이지네이션무한 페이징 추가

### DIFF
--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -35,6 +35,8 @@ public enum ErrorStatus implements BaseErrorCode {
     CALENDAR_NOT_FOUND(HttpStatus.NOT_FOUND, "CALENDAR4001", "해당 날짜 또는 월의 데이터가 존재하지 않습니다."),
     CALENDAR_FORBIDDEN(HttpStatus.FORBIDDEN, "CALENDAR4002", "해당 캘린더 데이터를 조회할 권한이 없습니다."),
     CALENDAR_INVALID_DATE(HttpStatus.BAD_REQUEST, "CALENDAR4003", "유효하지 않은 날짜입니다."),
+    CALENDAR_INVALID_CURSOR(HttpStatus.BAD_REQUEST, "CALENDAR4004", "유효하지 않은 커서입니다."),
+    CALENDAR_INVALID_LIMIT(HttpStatus.BAD_REQUEST, "CALENDAR4005", "유효하지 않은 limit 값입니다."),
     CALENDAR_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CALENDAR5001", "캘린더 데이터를 처리하는 중 오류가 발생했습니다."),
     THREAD_ALREADY_ENROLL(HttpStatus.BAD_REQUEST, "THREAD4001", "해당 날짜의 스레드가 이미 존재합니다."),
     THREAD_LATEST_NOT_FOUND(HttpStatus.NOT_FOUND, "THREAD4002", "최근 스레드를 찾을 수 없습니다."),

--- a/src/main/java/com/melissa/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/melissa/diary/repository/DiaryRepository.java
@@ -3,8 +3,10 @@ package com.melissa.diary.repository;
 import com.melissa.diary.domain.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -90,6 +92,33 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
         WHERE d.id = :id
         """)
     Optional<Diary> findByIdWithThreadAndProfile(@Param("id") Long id);
+
+    /**
+     * 피드 전용 조회 (최신순, 커서 기반 페이지네이션)
+     * - createdAt DESC, id DESC 정렬
+     * - 커서 조건: (createdAt < cursorCreatedAt) OR (createdAt = cursorCreatedAt AND id < cursorDiaryId)
+     * - FETCH JOIN으로 Thread, AiProfile 한번에 로딩 (N+1 방지)
+     *
+     * 주의: Pageable은 limit 용도로만 사용 (page=0 고정)
+     */
+    @Query("""
+        SELECT d FROM Diary d
+        INNER JOIN FETCH d.thread t
+        INNER JOIN FETCH t.aiProfile ap
+        WHERE d.user.id = :userId
+          AND d.isActive = true
+          AND (
+            :cursorCreatedAt IS NULL
+            OR d.createdAt < :cursorCreatedAt
+            OR (d.createdAt = :cursorCreatedAt AND d.id < :cursorDiaryId)
+          )
+        ORDER BY d.createdAt DESC, d.id DESC
+        """)
+    List<Diary> findFeedPage(
+            @Param("userId") Long userId,
+            @Param("cursorCreatedAt") LocalDateTime cursorCreatedAt,
+            @Param("cursorDiaryId") Long cursorDiaryId,
+            Pageable pageable);
     
     /**
      * 회원 탈퇴시 삭제

--- a/src/main/java/com/melissa/diary/service/CalendarService.java
+++ b/src/main/java/com/melissa/diary/service/CalendarService.java
@@ -9,10 +9,14 @@ import com.melissa.diary.repository.DiaryRepository;
 import com.melissa.diary.repository.UserRepository;
 import com.melissa.diary.web.dto.CalendarResponseDTO;
 import lombok.RequiredArgsConstructor;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -151,6 +155,91 @@ public class CalendarService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 최신순 피드 조회 (커서 기반 무한 페이징)
+     * - 월간 전체조회(DailySummaryResponseDTO) 구조를 재사용하기 위해 "일자별 그룹"으로 반환
+     * - 정렬 안정성: createdAt DESC, diaryId DESC
+     */
+    @Transactional(readOnly = true)
+    public CalendarResponseDTO.FeedResponseDTO getFeed(Long userId, Integer limit, String cursorCreatedAt, Long cursorDiaryId) {
+        // 유저 검증
+        getUser(userId);
+
+        int resolvedLimit = (limit == null ? 20 : limit);
+        if (resolvedLimit < 1 || resolvedLimit > 50) {
+            throw new ErrorHandler(ErrorStatus.CALENDAR_INVALID_LIMIT);
+        }
+
+        // 커서 짝 검증 (2필드 커서)
+        boolean hasCreatedAt = cursorCreatedAt != null && !cursorCreatedAt.isBlank();
+        boolean hasDiaryId = cursorDiaryId != null;
+        if (hasCreatedAt != hasDiaryId) {
+            throw new ErrorHandler(ErrorStatus.CALENDAR_INVALID_CURSOR);
+        }
+
+        LocalDateTime parsedCursorCreatedAt = null;
+        if (hasCreatedAt) {
+            try {
+                parsedCursorCreatedAt = LocalDateTime.parse(cursorCreatedAt);
+            } catch (DateTimeParseException e) {
+                throw new ErrorHandler(ErrorStatus.CALENDAR_INVALID_CURSOR);
+            }
+        }
+
+        // limit+1로 가져와서 hasNext 판단
+        List<Diary> diaries = diaryRepository.findFeedPage(
+                userId,
+                parsedCursorCreatedAt,
+                cursorDiaryId,
+                PageRequest.of(0, resolvedLimit + 1)
+        );
+
+        boolean hasNext = diaries.size() > resolvedLimit;
+        if (hasNext) {
+            diaries = diaries.subList(0, resolvedLimit);
+        }
+
+        // 일자별 그룹핑 (최신순 피드 흐름을 유지하기 위해 LinkedHashMap 사용)
+        Map<String, List<CalendarResponseDTO.DiaryDetailDTO>> byDayKey = new LinkedHashMap<>();
+        Map<String, int[]> dayParts = new LinkedHashMap<>(); // year, month, day 저장
+
+        for (Diary diary : diaries) {
+            String key = diary.getYear() + "-" + diary.getMonth() + "-" + diary.getDay();
+            byDayKey.computeIfAbsent(key, k -> new ArrayList<>()).add(DiaryConverter.toDiaryDetailDTO(diary));
+            dayParts.putIfAbsent(key, new int[]{diary.getYear(), diary.getMonth(), diary.getDay()});
+        }
+
+        List<CalendarResponseDTO.DailySummaryResponseDTO> days = byDayKey.entrySet().stream()
+                .map(entry -> {
+                    String key = entry.getKey();
+                    int[] parts = dayParts.get(key);
+                    return CalendarResponseDTO.DailySummaryResponseDTO.builder()
+                            .year(parts[0])
+                            .month(parts[1])
+                            .day(parts[2])
+                            .diaries(entry.getValue())
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        CalendarResponseDTO.FeedNextCursorDTO nextCursor = null;
+        if (hasNext && !diaries.isEmpty()) {
+            Diary last = diaries.get(diaries.size() - 1);
+            nextCursor = CalendarResponseDTO.FeedNextCursorDTO.builder()
+                    .cursorCreatedAt(last.getCreatedAt())
+                    .cursorDiaryId(last.getId())
+                    .build();
+        }
+
+        return CalendarResponseDTO.FeedResponseDTO.builder()
+                .days(days)
+                .pageInfo(CalendarResponseDTO.FeedPageInfoDTO.builder()
+                        .hasNext(hasNext)
+                        .nextCursor(nextCursor)
+                        .build())
+                .build();
+    }
+
     private boolean isValidDate(int year, int month, int day) {
         if (month < 1 || month > 12) return false;
         if (day < 1 || day > 31) return false;
@@ -170,7 +259,7 @@ public class CalendarService {
     }
 
     @Transactional(readOnly = true)
-    public User getUser(Long userId) {
+    public User getUser(@NonNull Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
     }

--- a/src/main/java/com/melissa/diary/service/ThreadService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadService.java
@@ -434,7 +434,7 @@ public class ThreadService {
     
     /**
      * v2: UserMemory 통합 프롬프트 생성
-     * 주제 변경 감지 시 사용자 장기 기억 포함
+     * 사용자 장기 기억 포함
      */
     private String buildAiChatPromptV2(Long userId, String userMessage, List<DailyChatLog> chatHistory, AiProfile aiProfile) {
         StringBuilder prompt = new StringBuilder();

--- a/src/main/java/com/melissa/diary/web/controller/CalendarController.java
+++ b/src/main/java/com/melissa/diary/web/controller/CalendarController.java
@@ -88,4 +88,27 @@ public class CalendarController {
 
         return ApiResponse.onSuccess(response);
     }
+
+    @Operation(summary = "피드 전용 최신순 조회 (커서 기반 무한 페이징)",
+               description = "[v1.3.0+] 피드 전용 최신순 정렬을 보장하며, 커서 기반 무한 페이징을 제공합니다. (days 구조는 월간 전체조회와 유사)")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "CALENDAR4004: 유효하지 않은 커서 / CALENDAR4005: 유효하지 않은 limit"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음")
+    })
+    @GetMapping("/feed")
+    public ApiResponse<CalendarResponseDTO.FeedResponseDTO> getFeed(
+            @Parameter(description = "조회 개수 (기본 20, 최대 50)", example = "20")
+            @RequestParam(name = "limit", required = false) Integer limit,
+            @Parameter(description = "커서 createdAt (ISO-8601, nextCursor로 받은 값을 그대로 재전송)", example = "2025-12-30T21:15:10.123456")
+            @RequestParam(name = "cursorCreatedAt", required = false) String cursorCreatedAt,
+            @Parameter(description = "커서 diaryId (nextCursor로 받은 값을 그대로 재전송)", example = "401")
+            @RequestParam(name = "cursorDiaryId", required = false) Long cursorDiaryId,
+            Principal principal) {
+
+        Long userId = Long.parseLong(principal.getName());
+        CalendarResponseDTO.FeedResponseDTO response = calendarService.getFeed(userId, limit, cursorCreatedAt, cursorDiaryId);
+
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/com/melissa/diary/web/dto/CalendarResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/CalendarResponseDTO.java
@@ -139,4 +139,55 @@ public class CalendarResponseDTO {
         @Schema(description = "일기 미리보기 목록 (최대 3개)", requiredMode = Schema.RequiredMode.REQUIRED)
         private List<DiaryPreviewDTO> diaries;
     }
+
+    /**
+     * 커서 기반 페이지 정보
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "피드 페이지 정보")
+    public static class FeedPageInfoDTO {
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+        private boolean hasNext;
+
+        @Schema(description = "다음 커서 (없으면 null)", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        private FeedNextCursorDTO nextCursor;
+    }
+
+    /**
+     * 다음 커서
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "피드 다음 커서")
+    public static class FeedNextCursorDTO {
+
+        @Schema(description = "커서 createdAt (ISO-8601, 서버가 내려준 값을 그대로 재전송)", example = "2025-12-30T21:15:10.123456", requiredMode = Schema.RequiredMode.REQUIRED)
+        private LocalDateTime cursorCreatedAt;
+
+        @Schema(description = "커서 diaryId", example = "401", requiredMode = Schema.RequiredMode.REQUIRED)
+        private Long cursorDiaryId;
+    }
+
+    /**
+     * 응답 (월간 전체조회(DailySummaryResponseDTO) 구조 재사용)
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "피드 조회 응답")
+    public static class FeedResponseDTO {
+
+        @Schema(description = "일자별 일기 목록 (최신순 피드)", requiredMode = Schema.RequiredMode.REQUIRED)
+        private List<DailySummaryResponseDTO> days;
+
+        @Schema(description = "페이지 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+        private FeedPageInfoDTO pageInfo;
+    }
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- 피드 화면 전용으로 최신순 정렬을 보장하는 조회 API를 추가했습니다.

- 커서 기반 페이지네이션(무한 페이징) 방식으로 월 경계 없이 자연스럽게 이어지는 탐색이 가능하도록 했습니다.

- 기존 월간 전체조회 DTO 구조를 최대한 재사용해 프론트 수정 범위를 최소화했습니다.

## 📋 변경 사항
- **신규 API**
  - GET /api/v1/calendar/feed
  - Query: limit(기본 20, 최대 50), cursorCreatedAt, cursorDiaryId
  - Response: days(월간 전체조회와 유사한 day 그룹 구조) + pageInfo(hasNext, nextCursor)
- **정렬/커서 규칙**
  - 정렬: createdAt DESC, diaryId DESC
  - 커서 조건: (createdAt < cursorCreatedAt) OR (createdAt = cursorCreatedAt AND diaryId < cursorDiaryId)
  - 커서는 **2필드 커서(A안)**로 진행 (createdAt + diaryId)
- **Repository**
  - Fetch Join으로 Diary -> Thread -> AiProfile을 함께 로딩하여 **N+1 방지**
  - limit+1 조회로 hasNext 계산
- **에러 코드 추가**
  - CALENDAR4004: 유효하지 않은 커서
  - CALENDAR4005: 유효하지 않은 limit


## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
