### PR TITLE
feat: Streak API 추가 (KST 기준 current streak 계산)

### DIFF
--- a/src/main/java/com/melissa/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/melissa/diary/repository/DiaryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 
+import java.sql.Date;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -124,5 +125,31 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
      * 회원 탈퇴시 삭제
      */
     void deleteAllByUserId(Long userId);
+
+    /**
+     * 스트릭 계산용: 활성 일기 작성 날짜(중복 제거) 최신순 조회 (KST 기준 오늘까지)
+     *
+     * - year/month/day를 DATE로 변환하여 DISTINCT
+     * - 반환 타입은 java.sql.Date로 두고 서비스에서 LocalDate로 변환
+     */
+    @Query(value = """
+        SELECT DISTINCT STR_TO_DATE(
+            CONCAT(d.year, '-', LPAD(d.month, 2, '0'), '-', LPAD(d.day, 2, '0')),
+            '%Y-%m-%d'
+        ) AS diary_date
+        FROM diary d
+        WHERE d.user_id = :userId
+          AND d.is_active = 1
+          AND STR_TO_DATE(
+                CONCAT(d.year, '-', LPAD(d.month, 2, '0'), '-', LPAD(d.day, 2, '0')),
+                '%Y-%m-%d'
+              ) <= :endDate
+        ORDER BY diary_date DESC
+        LIMIT :limit
+        """, nativeQuery = true)
+    List<Date> findRecentActiveDiaryDatesDesc(
+            @Param("userId") Long userId,
+            @Param("endDate") Date endDate,
+            @Param("limit") int limit);
 }
 

--- a/src/main/java/com/melissa/diary/service/StreakService.java
+++ b/src/main/java/com/melissa/diary/service/StreakService.java
@@ -1,0 +1,62 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.repository.DiaryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StreakService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final int RECENT_DAYS_LIMIT = 400; // 충분히 크게 잡고, 실제 계산은 첫 gap에서 즉시 종료
+
+    private final DiaryRepository diaryRepository;
+
+    public int getCurrentStreakDays(Long userId) {
+        LocalDate todayKst = LocalDate.now(KST);
+        return getCurrentStreakDays(userId, todayKst);
+    }
+
+    /**
+     * 테스트 용이성을 위해 today를 외부에서 주입할 수 있게 분리
+     */
+    int getCurrentStreakDays(Long userId, LocalDate today) {
+        List<Date> recentDates = diaryRepository.findRecentActiveDiaryDatesDesc(
+                userId,
+                Date.valueOf(today),
+                RECENT_DAYS_LIMIT
+        );
+
+        if (recentDates.isEmpty()) {
+            return 0;
+        }
+
+        LocalDate first = recentDates.get(0).toLocalDate();
+        if (!first.equals(today)) {
+            return 0; // 오늘 작성이 없으면 스트릭 0
+        }
+
+        int streak = 1;
+        LocalDate expected = today.minusDays(1);
+
+        for (int i = 1; i < recentDates.size(); i++) {
+            LocalDate d = recentDates.get(i).toLocalDate();
+            if (d.equals(expected)) {
+                streak++;
+                expected = expected.minusDays(1);
+            } else {
+                break;
+            }
+        }
+
+        return streak;
+    }
+}
+
+

--- a/src/main/java/com/melissa/diary/web/controller/StreakController.java
+++ b/src/main/java/com/melissa/diary/web/controller/StreakController.java
@@ -1,0 +1,52 @@
+package com.melissa.diary.web.controller;
+
+import com.melissa.diary.apiPayload.ApiResponse;
+import com.melissa.diary.service.StreakService;
+import com.melissa.diary.web.dto.StreakResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+/**
+ * [v1.3.0+] 스트릭 API
+ */
+@RestController
+@Tag(name = "StreakAPI", description = "Streak 관련 API")
+@RequestMapping("/api/v1/streak")
+@RequiredArgsConstructor
+public class StreakController {
+
+    private final StreakService streakService;
+
+    @Operation(
+            summary = "현재 스트릭 조회",
+            description = """
+                [v1.3.0+] 오늘(KST) 일기 작성 여부를 기준으로 연속 작성 일수를 반환합니다.
+                - 쿼리 파라미터 없음 (서버가 KST 기준 '오늘'로 계산)
+                - 오늘 작성이 없으면 streakDays=0
+                - 하루에 여러 개 작성해도 그 날은 +1로만 계산
+                """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음")
+    })
+    @GetMapping
+    public ApiResponse<StreakResponseDTO.CurrentStreakResponse> getCurrentStreak(Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+        int streakDays = streakService.getCurrentStreakDays(userId);
+        return ApiResponse.onSuccess(
+                StreakResponseDTO.CurrentStreakResponse.builder()
+                        .streakDays(streakDays)
+                        .build()
+        );
+    }
+}
+
+

--- a/src/main/java/com/melissa/diary/web/dto/StreakResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/StreakResponseDTO.java
@@ -1,0 +1,23 @@
+package com.melissa.diary.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class StreakResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "스트릭 조회 응답")
+    public static class CurrentStreakResponse {
+
+        @Schema(description = "현재 스트릭(연속 작성 일수). 오늘 작성이 없으면 0", example = "7", requiredMode = Schema.RequiredMode.REQUIRED)
+        private int streakDays;
+    }
+}
+
+

--- a/src/test/java/com/melissa/diary/service/StreakServiceTest.java
+++ b/src/test/java/com/melissa/diary/service/StreakServiceTest.java
@@ -1,0 +1,71 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.repository.DiaryRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StreakServiceTest {
+
+    @Mock
+    DiaryRepository diaryRepository;
+
+    @InjectMocks
+    StreakService streakService;
+
+    @Test
+    void 오늘작성없으면_0() {
+        Long userId = 1L;
+        LocalDate today = LocalDate.of(2026, 1, 10);
+
+        when(diaryRepository.findRecentActiveDiaryDatesDesc(eq(userId), eq(Date.valueOf(today)), anyInt()))
+                .thenReturn(List.of(Date.valueOf(today.minusDays(1))));
+
+        int streak = streakService.getCurrentStreakDays(userId, today);
+        assertThat(streak).isEqualTo(0);
+    }
+
+    @Test
+    void 오늘부터연속이면_연속길이() {
+        Long userId = 1L;
+        LocalDate today = LocalDate.of(2026, 1, 10);
+
+        when(diaryRepository.findRecentActiveDiaryDatesDesc(eq(userId), eq(Date.valueOf(today)), anyInt()))
+                .thenReturn(List.of(
+                        Date.valueOf(today),
+                        Date.valueOf(today.minusDays(1)),
+                        Date.valueOf(today.minusDays(2)),
+                        Date.valueOf(today.minusDays(4)) // gap -> 여기서 끊김
+                ));
+
+        int streak = streakService.getCurrentStreakDays(userId, today);
+        assertThat(streak).isEqualTo(3);
+    }
+
+    @Test
+    void 기록없으면_0() {
+        Long userId = 1L;
+        LocalDate today = LocalDate.of(2026, 1, 10);
+
+        when(diaryRepository.findRecentActiveDiaryDatesDesc(eq(userId), any(), anyInt()))
+                .thenReturn(List.of());
+
+        int streak = streakService.getCurrentStreakDays(userId, today);
+        assertThat(streak).isEqualTo(0);
+    }
+}
+
+


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
연속 일기 작성일 수(Current Streak) 를 조회할 수 있는 API를 추가했습니다.
한국 서비스 운영을 전제로 KST(Asia/Seoul) 기준 “오늘” 을 사용하며, 하루에 여러 번 작성하더라도 해당 일자는 1회 활동으로만 카운트되도록 설계했습니다.

## 📋 변경 사항
- **Streak 조회 API 신규 추가**
  - GET /api/v1/streak
  - 응답: streakDays (오늘 작성이 없으면 0)

- **Streak 계산 로직 추가**
  - 활성 일기(isActive=true)를 기준으로 날짜 단위로 연속 여부를 계산
  - 서버에서 KST 기준 오늘을 사용(프론트 날짜 파라미터 없음)

- **Swagger(OpenAPI) 문서 설명 보강**
- **단위 테스트 추가(서비스 로직 중심 - 오늘작성없으면_0, 오늘부터연속이면_연속길이, 기록없으면_0)**
<img width="1330" height="398" alt="image" src="https://github.com/user-attachments/assets/8c0bc0f5-c268-4295-9ead-9371aa84c78c" />

## 🔍 Code Review
정확성
> “오늘 작성이 없으면 0” 규칙이 의도대로 동작하는지
하루 다건 작성 시에도 1일로만 카운트되는지
삭제(soft delete, isActive=false)가 streak에 반영되는지

성능/쿼리
> 날짜 DISTINCT 조회가 과도한 풀스캔으로 이어지지 않는지(데이터 증가 시)
최근 데이터만 읽고 연속 구간에서 조기 종료되는지

## 📸 ScreenShot
