### PR TITLE
feat: 유저 기본정보(email/nickname/provider/usage) 조회 API 추가

### DIFF
--- a/src/main/java/com/melissa/diary/converter/UserConverter.java
+++ b/src/main/java/com/melissa/diary/converter/UserConverter.java
@@ -34,4 +34,20 @@ public class UserConverter {
                 .providerId(user.getProviderId())
                 .build();
     }
+
+    public UserResponseDTO.MeResponseDTO toGetMe(User user){
+        return UserResponseDTO.MeResponseDTO.builder()
+                .userId(user.getId())
+                .oauthProvider(user.getProvider())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .usage(UserResponseDTO.MeResponseDTO.UsageDTO.builder()
+                        .dailyQuotaLimit(100)
+                        .dailyQuotaRemaining(user.getDailyQuota())
+                        .dailyQuotaUsed(100-user.getDailyQuota())
+                        .quotaDate(user.getQuotaDate())
+                        .build())
+                .build();
+    }
+
 }

--- a/src/main/java/com/melissa/diary/service/UserService.java
+++ b/src/main/java/com/melissa/diary/service/UserService.java
@@ -183,4 +183,12 @@ public class UserService {
         return deleteDTO;
     }
 
+    @Transactional(readOnly = true)
+    public UserResponseDTO.MeResponseDTO getMe(Long userId){
+        // 유저 정보 조회
+        User user = userRepository.findById(userId).orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        return UserConverter.toGetMe(user);
+    }
+
 }

--- a/src/main/java/com/melissa/diary/web/controller/AuthController.java
+++ b/src/main/java/com/melissa/diary/web/controller/AuthController.java
@@ -9,12 +9,11 @@ import com.melissa.diary.service.UserService;
 import com.melissa.diary.web.dto.UserRequestDTO;
 import com.melissa.diary.web.dto.UserResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,7 +31,15 @@ public class AuthController {
 
     // 구글 로그인
     @PostMapping("/google")
-    @Operation(description = "구글로그인으로, id토큰을 입력해주세요")
+    @Operation(
+            summary = "구글 로그인",
+            description = "구글 idToken을 검증하고, Access/Refresh 토큰을 발급합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "COMMON400: 잘못된 요청(요청 바디 검증 실패 등)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUTH4001: 소셜 로그인 인증 실패")
+    })
     public ApiResponse<UserResponseDTO.OAuthLoginResultDTO> googleLogin(
             @RequestBody @Valid UserRequestDTO.GoogleOAuthDTO request
     ) {
@@ -52,7 +59,15 @@ public class AuthController {
 
     // 카카오 로그인
     @PostMapping("/kakao")
-    @Operation(description = "카카오로그인으로, 액세스토큰을 입력해주세요")
+    @Operation(
+            summary = "카카오 로그인",
+            description = "카카오 accessToken을 검증하고, Access/Refresh 토큰을 발급합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "COMMON400: 잘못된 요청(요청 바디 검증 실패 등)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUTH4001: 소셜 로그인 인증 실패")
+    })
     public ApiResponse<UserResponseDTO.OAuthLoginResultDTO> kakaoLogin(
             @RequestBody @Valid UserRequestDTO.KakaoOAuthDTO request
     ) {
@@ -66,7 +81,15 @@ public class AuthController {
 
     // --- Apple 로그인 ---
     @PostMapping("/apple")
-    @Operation(description = "애플 로그인 (idToken 입력)")
+    @Operation(
+            summary = "애플 로그인",
+            description = "애플 idToken을 검증하고, Access/Refresh 토큰을 발급합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "COMMON400: 잘못된 요청(요청 바디 검증 실패 등)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUTH4001: 소셜 로그인 인증 실패")
+    })
     public ApiResponse<UserResponseDTO.OAuthLoginResultDTO> appleLogin(
             @RequestBody @Valid UserRequestDTO.AppleOAuthDTO request
     ) {
@@ -80,7 +103,17 @@ public class AuthController {
 
     // Refresh Token 재발급
     @PostMapping("/refresh")
-    @Operation(description = "Authorization 헤더에 Refresh토큰을 입력해, AccessToken 재생성합니다.")
+    @Operation(
+            summary = "토큰 재발급(Refresh)",
+            description = """
+                Authorization 헤더에 Refresh Token(Bearer)을 전달하여 Access/Refresh 토큰을 재발급합니다.
+                - 예: Authorization: Bearer {refreshToken}
+                """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUTH4002/AUTH4003/AUTH4005: 토큰이 유효하지 않음/만료/검증 실패")
+    })
     public ApiResponse<UserResponseDTO.OAuthLoginResultDTO> refreshToken(
             HttpServletRequest request
     ) {
@@ -115,7 +148,14 @@ public class AuthController {
 
     // 로그아웃
     @PostMapping("/logout")
-    @Operation(description = "로그아웃 기능으로, 서버의 토큰을 지웁니다.")
+    @Operation(
+            summary = "로그아웃",
+            description = "현재 로그인 사용자의 서버 저장 Refresh Token을 제거합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "AUTH4002/AUTH4003/AUTH4005: 토큰이 유효하지 않음/만료/검증 실패")
+    })
     public ApiResponse<Void> logout(Principal principal) {
 
         userService.logout(Long.parseLong(principal.getName()));

--- a/src/main/java/com/melissa/diary/web/controller/UserController.java
+++ b/src/main/java/com/melissa/diary/web/controller/UserController.java
@@ -4,9 +4,11 @@ import com.melissa.diary.apiPayload.ApiResponse;
 import com.melissa.diary.service.UserService;
 import com.melissa.diary.web.dto.UserResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,4 +32,25 @@ public class UserController {
         return ApiResponse.onSuccess(response);
     }
 
+    @Operation(
+            summary = "내 유저 정보 조회",
+            description = """
+                현재 로그인한 사용자의 기본 정보(이메일/닉네임/OAuth 제공자)와 사용량(쿼터) 정보를 반환합니다.
+                - 인증 필요 (Bearer JWT)
+                - userId는 토큰(subject) 기반으로 서버에서 결정
+                """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패(토큰 누락/만료/위조)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음")
+    })
+    @GetMapping("/me")
+    public ApiResponse<UserResponseDTO.MeResponseDTO> getUser(Principal principal){
+        Long userId = Long.parseLong(principal.getName());
+
+        UserResponseDTO.MeResponseDTO response = userService.getMe(userId);
+
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/com/melissa/diary/web/controller/UserSettingController.java
+++ b/src/main/java/com/melissa/diary/web/controller/UserSettingController.java
@@ -1,11 +1,11 @@
 package com.melissa.diary.web.controller;
 
 import com.melissa.diary.apiPayload.ApiResponse;
-import com.melissa.diary.domain.UserSetting;
 import com.melissa.diary.service.UserSettingService;
 import com.melissa.diary.web.dto.UserSettingRequestDTO;
 import com.melissa.diary.web.dto.UserSettingResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +21,15 @@ import java.security.Principal;
 public class UserSettingController {
 
     private final UserSettingService userSettingService;
-    @Operation(description = "현재 로그인한 유저의 설정 정보를 조회합니다.")
+    @Operation(
+            summary = "유저 설정 조회",
+            description = "현재 로그인한 사용자의 설정 정보를 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패(토큰 누락/만료/위조)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 유저 없음 / SETTING4001: 설정 없음")
+    })
     @GetMapping
     public ApiResponse<UserSettingResponseDTO.UserSettingResponse> getUserSetting(Principal principal) {
         Long userId = Long.parseLong(principal.getName());
@@ -32,7 +40,16 @@ public class UserSettingController {
         return ApiResponse.onSuccess(response); //  "사용자 설정 조회 성공"
     }
 
-    @Operation(description = "유저의 설정정보를 수정합니다.")
+    @Operation(
+            summary = "유저 설정 수정",
+            description = "현재 로그인한 사용자의 설정 정보를 수정합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "SETTING4003: 유효하지 않은 시간 형식"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패(토큰 누락/만료/위조)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 유저 없음 / SETTING4001: 설정 없음")
+    })
     @PutMapping
     public ApiResponse<UserSettingResponseDTO.UserSettingResponse> updateUserSetting(
             Principal principal,
@@ -45,7 +62,18 @@ public class UserSettingController {
         return ApiResponse.onSuccess(response);
     }
 
-    @Operation(description = "유저의 설정정보를 기본값으로 등록합니다.")
+    @Operation(
+            summary = "유저 설정 기본값 등록(멱등)",
+            description = """
+                현재 로그인한 사용자의 설정 정보를 기본값으로 등록합니다.
+                - 이미 설정이 존재하면 아무 동작 없이 성공 응답을 반환합니다(멱등).
+                """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패(토큰 누락/만료/위조)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 유저 없음")
+    })
     @PostMapping("/register")
     public ApiResponse<Void> createDefaultUserSetting(Principal principal) {
         Long userId = Long.parseLong(principal.getName());
@@ -54,7 +82,15 @@ public class UserSettingController {
         return ApiResponse.onSuccess(null);
     }
 
-    @Operation(description = "신규유저인지 체크합니다.")
+    @Operation(
+            summary = "신규 유저 여부 체크",
+            description = "현재 로그인한 사용자가 설정값을 보유하고 있는지로 신규 유저 여부를 판단합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패(토큰 누락/만료/위조)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 유저 없음")
+    })
     @GetMapping("/check-new")
     public ApiResponse<Boolean> checkNewUser(Principal principal) {
         Long userId = Long.parseLong(principal.getName());

--- a/src/main/java/com/melissa/diary/web/dto/UserResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/UserResponseDTO.java
@@ -68,4 +68,44 @@ public class UserResponseDTO {
         @Schema(description = "닉네임", example = "홍길동", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String nickname;
     }
+
+    @Getter
+    @Builder
+    @Schema(description = "유저 정보 조회 응답")
+    public static class MeResponseDTO{
+
+        @Schema(description = "사용자 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        private Long userId;
+
+        @Schema(description = "이메일", example = "user@example.com", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        private String email;
+
+        @Schema(description = "닉네임", example = "홍길동", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        private String nickname;
+
+        @Schema(description = "OAuth 제공자", example = "GOOGLE", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        private String oauthProvider;
+
+        @Schema(description = "사용량(쿼터) 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+        private UsageDTO usage;
+
+        @Getter
+        @Builder
+        @Schema(description = "일일 사용량(쿼터) 정보")
+        public static class UsageDTO {
+
+            @Schema(description = "오늘 남은 쿼터", example = "97", requiredMode = Schema.RequiredMode.REQUIRED)
+            private Integer dailyQuotaRemaining;
+
+            @Schema(description = "일일 쿼터 제한(고정값 - 서버 상수)", example = "100", requiredMode = Schema.RequiredMode.REQUIRED)
+            private Integer dailyQuotaLimit;
+
+            @Schema(description = "오늘 사용한 쿼터", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
+            private Integer dailyQuotaUsed;
+
+            @Schema(description = "사용량 기준 날짜(DB 저장값 그대로)", example = "2026-01-10", requiredMode = Schema.RequiredMode.REQUIRED)
+            private java.time.LocalDate quotaDate;
+        }
+
+    }
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
프론트에서 필요한 현재 로그인 유저 기본정보(email/nickname/provider) + 사용량(usage) 조회를 위한 API를 추가했습니다.
일부 컨트롤러의 Swagger(OpenAPI) 문서가 부족해 @Operation/@ApiResponses를 보강했습니다.

## 📋 변경 사항
- **GET /api/v1/user/me** 엔드포인트 추가
  - JWT 인증 기반으로 Principal.getName()에서 userId를 추출하여 **내 정보만 조회**
  - 응답: ApiResponse<UserResponseDTO.MeResponseDTO>
  - usage: dailyQuotaRemaining, dailyQuotaUsed, dailyQuotaLimit(100), quotaDate

- **Swagger 명세 보강**
  - AuthController: 소셜 로그인/refresh/logout에 summary/description, @ApiResponses(200/400/401) 추가
  - UserSettingController: 조회/수정/기본값등록/신규체크에 summary/description, @ApiResponses(200/400/401/404) 추가
  - unused import 정리
 
## 🔍 Code Review
권한/보안: /me가 요청자 본인 정보만 내려주는지(Principal 기반 userId 사용) 확인
쿼터 계산: dailyQuotaRemaining = User.dailyQuota / dailyQuotaUsed = 100 - remaining 매핑이 맞는지 확인
null 안전성: email nullable 처리 및 dailyQuota/quotaDate가 null일 가능성(레거시 데이터) 점검
Swagger 정확성: 응답 코드/에러 코드(AUTH400x, SETTING400x)가 실제 예외 흐름과 일치하는지 확인

## 📸 ScreenShot
