### PR TITLE
feat: Streak(연속 일기 작성일 수) 계산 로직 with TDD

### DIFF
--- a/src/main/java/com/melissa/diary/service/StreakService.java
+++ b/src/main/java/com/melissa/diary/service/StreakService.java
@@ -37,13 +37,17 @@ public class StreakService {
             return 0;
         }
 
-        LocalDate first = recentDates.get(0).toLocalDate();
-        if (!first.equals(today)) {
-            return 0; // 오늘 작성이 없으면 스트릭 0
+        LocalDate lastActiveDate = recentDates.get(0).toLocalDate();
+
+        // 개선 규칙:
+        // - 오늘 작성이 없더라도 "어제까지의 연속 기록"은 오늘 하루 동안 유지
+        // - 단, 마지막 작성일이 어제보다 이전이면 이미 끊긴 것으로 간주하여 0
+        if (lastActiveDate.isBefore(today.minusDays(1))) {
+            return 0;
         }
 
         int streak = 1;
-        LocalDate expected = today.minusDays(1);
+        LocalDate expected = lastActiveDate.minusDays(1);
 
         for (int i = 1; i < recentDates.size(); i++) {
             LocalDate d = recentDates.get(i).toLocalDate();

--- a/src/main/java/com/melissa/diary/web/controller/StreakController.java
+++ b/src/main/java/com/melissa/diary/web/controller/StreakController.java
@@ -27,9 +27,10 @@ public class StreakController {
     @Operation(
             summary = "현재 스트릭 조회",
             description = """
-                [v1.3.0+] 오늘(KST) 일기 작성 여부를 기준으로 연속 작성 일수를 반환합니다.
+                [v1.3.0+] KST 기준 연속 작성 일수를 반환합니다.
                 - 쿼리 파라미터 없음 (서버가 KST 기준 '오늘'로 계산)
-                - 오늘 작성이 없으면 streakDays=0
+                - 오늘 미작성이어도 마지막 작성일이 '어제'라면 streakDays는 유지됩니다.
+                - 마지막 작성일이 '어제'보다 이전이면 streakDays=0 입니다. (이미 끊김)
                 - 하루에 여러 개 작성해도 그 날은 +1로만 계산
                 """
     )

--- a/src/test/java/com/melissa/diary/service/StreakServiceTest.java
+++ b/src/test/java/com/melissa/diary/service/StreakServiceTest.java
@@ -27,12 +27,24 @@ class StreakServiceTest {
     StreakService streakService;
 
     @Test
-    void 오늘작성없으면_0() {
+    void 오늘작성없어도_어제작성있으면_유지() {
         Long userId = 1L;
         LocalDate today = LocalDate.of(2026, 1, 10);
 
         when(diaryRepository.findRecentActiveDiaryDatesDesc(eq(userId), eq(Date.valueOf(today)), anyInt()))
                 .thenReturn(List.of(Date.valueOf(today.minusDays(1))));
+
+        int streak = streakService.getCurrentStreakDays(userId, today);
+        assertThat(streak).isEqualTo(1);
+    }
+
+    @Test
+    void 오늘작성없고_어제도없으면_0() {
+        Long userId = 1L;
+        LocalDate today = LocalDate.of(2026, 1, 10);
+
+        when(diaryRepository.findRecentActiveDiaryDatesDesc(eq(userId), eq(Date.valueOf(today)), anyInt()))
+                .thenReturn(List.of(Date.valueOf(today.minusDays(2))));
 
         int streak = streakService.getCurrentStreakDays(userId, today);
         assertThat(streak).isEqualTo(0);


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
이번 PR에서는 Streak(연속 일기 작성일 수) 계산 로직을 TDD 방식으로 정리/개선했습니다.
먼저 요구되는 UX(오늘 미작성이어도 어제까지의 streak 유지)를 테스트로 명확히 정의한 뒤, 서비스 코드를 개선했습니다. 이후 해당 테스트를 만족하도록 구현/문서(Swagger)를 보완했습니다.

## 📋 변경 사항
- Streak 핵심 케이스를 테스트로 선정의(TDD)
    - 오늘 미작성 + 어제 작성 O → streak 유지
    - 오늘 미작성 + 그저께 작성 O → 0
    - 오늘 작성 O + 연속 작성 → 정상 계산(회귀)
- 테스트를 통과하도록 Streak 계산 로직 개선
- 변경된 규칙을 Swagger 설명에 반영


## 🔍 Code Review
TDD 기준 충족 여부
- 테스트가 요구사항(UX)을 정확히 대표하는지
- 테스트가 실패/성공을 명확히 구분하는지(애매한 기대값 없음)

경계 조건
- KST 자정 전후에서 “어제까지 유지” 규칙이 의도대로 동작하는지

## 📸 ScreenShot
