### PR TITLE
feat: JWT 보안 하드닝(typ claim, refresh 해시 저장, 구 토큰 무력화)

### DIFF
--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -59,6 +59,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4002", "토큰이 유효하지 않습니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4003", "토큰이 만료되었습니다."),
     TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH4004", "토큰이 일치하지 않습니다."),
+    TOKEN_TYPE_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH4007", "토큰 타입이 올바르지 않습니다."),
     TOKEN_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5001", "토큰 생성에 실패했습니다."),
     TOKEN_VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH4005", "토큰 검증에 실패했습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH4006", "해당 유저가 존재하지 않습니다."),

--- a/src/main/java/com/melissa/diary/config/SecurityConfig.java
+++ b/src/main/java/com/melissa/diary/config/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig {
     private final AuthenticationEntryPoint unauthorizedEntryPoint =
             (request, response, authException) -> {
 
-                ApiResponse<?> apiResponse = new ApiResponse(false,"401","인증이 필요합니다.",null);
+                ApiResponse<?> apiResponse = ApiResponse.onFailure("401", "인증이 필요합니다.", null);
                 response.setCharacterEncoding("UTF-8");
                 response.setStatus(HttpStatus.UNAUTHORIZED.value());
                 response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/com/melissa/diary/domain/User.java
+++ b/src/main/java/com/melissa/diary/domain/User.java
@@ -34,6 +34,11 @@ public class User {
     @Column(nullable = false, length = 50)
     private String nickname;
 
+    /**
+     * Refresh 토큰 저장 (실제로는 SHA-256 해시값을 저장함)
+     * - 보안: 평문 대신 해시를 저장하여 DB 유출 시 토큰 재사용 방지
+     * - 마이그레이션: 평문 -> 해시값으로 변경되었지만, 재로그인 강제하여 문제 없음.
+     */
     @Column(nullable = true, length = 255)
     private String refreshToken;
 

--- a/src/main/java/com/melissa/diary/repository/UserRepository.java
+++ b/src/main/java/com/melissa/diary/repository/UserRepository.java
@@ -15,8 +15,10 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByProviderAndProviderId(String provider, String providerId);
 
-    // Refresh 토큰으로 유저 찾기 (간단 예시 - 실제론 해시 등 보안처리)
-    Optional<User> findByRefreshToken(String refreshToken);
+    /**
+     * Refresh 토큰 해시로 유저 찾기
+     */
+    Optional<User> findByRefreshToken(String refreshTokenHash);
 
     @Modifying
     @Query("""

--- a/src/main/java/com/melissa/diary/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/melissa/diary/security/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -21,31 +22,44 @@ import java.io.IOException;
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    public static final String AUTH_ERROR_ATTR = "AUTH_ERROR_CODE";
+
     @Autowired
     private JwtProvider jwtProvider;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain chain)
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain chain)
             throws ServletException, IOException {
 
         String token = resolveToken(request);
-        if (token != null && jwtProvider.validateToken(token)) {
-            // userId 추출
-            Long userId = jwtProvider.getUserId(token);
+        if (token != null) {
+            TokenValidationResult validation = jwtProvider.validateTokenResult(token);
+            if (validation == TokenValidationResult.EXPIRED) {
+                request.setAttribute(AUTH_ERROR_ATTR, "EXPIRED_TOKEN");
+            } else if (validation == TokenValidationResult.INVALID) {
+                request.setAttribute(AUTH_ERROR_ATTR, "INVALID_TOKEN");
+            } else {
+                // VALID 이더라도 access 토큰만 인증 필터에서 허용
+                if (!jwtProvider.isAccessToken(token)) {
+                    request.setAttribute(AUTH_ERROR_ATTR, "TOKEN_TYPE_MISMATCH");
+                } else {
+                    // userId 추출
+                    Long userId = jwtProvider.getUserId(token);
 
-            AbstractAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
-                    userId,
-                    null,
-                    AuthorityUtils.NO_AUTHORITIES
-            );
-            authentication.setDetails(new WebAuthenticationDetailsSource()
-                    .buildDetails(request));
-            SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-            securityContext.setAuthentication(authentication);
-            SecurityContextHolder.setContext(securityContext);
-
+                    AbstractAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                            userId,
+                            null,
+                            AuthorityUtils.NO_AUTHORITIES
+                    );
+                    authentication.setDetails(new WebAuthenticationDetailsSource()
+                            .buildDetails(request));
+                    SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+                    securityContext.setAuthentication(authentication);
+                    SecurityContextHolder.setContext(securityContext);
+                }
+            }
         }
         chain.doFilter(request, response);
     }

--- a/src/main/java/com/melissa/diary/security/JwtProvider.java
+++ b/src/main/java/com/melissa/diary/security/JwtProvider.java
@@ -1,12 +1,16 @@
 package com.melissa.diary.security;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
 import java.util.Date;
 
 @Component
@@ -15,38 +19,48 @@ public class JwtProvider {
     @Value("${security.jwt.secret-key}")
     private String secretKey;
 
+    private static final String CLAIM_TOKEN_TYPE = "typ";
+    private static final String TOKEN_TYPE_ACCESS = "access";
+    private static final String TOKEN_TYPE_REFRESH = "refresh";
+
+    private Key signingKey() {
+        return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
     // 유효 기간
     private final long ACCESS_TOKEN_VALID_MILLIS = 1000L * 60 * 60 * 24;       // 1일
     private final long REFRESH_TOKEN_VALID_MILLIS = 1000L * 60 * 60 * 24 * 15; // 15일
 
     // Access Token 생성
     public String createAccessToken(Long userId, String provider) {
-        return createToken(userId, provider, ACCESS_TOKEN_VALID_MILLIS);
+        return createToken(userId, provider, ACCESS_TOKEN_VALID_MILLIS, JwtTokenType.ACCESS);
     }
 
     // Refresh Token 생성
     public String createRefreshToken(Long userId, String provider) {
-        return createToken(userId, provider, REFRESH_TOKEN_VALID_MILLIS);
+        return createToken(userId, provider, REFRESH_TOKEN_VALID_MILLIS, JwtTokenType.REFRESH);
     }
 
-    private String createToken(Long userId, String provider, long validMillis) {
+    private String createToken(Long userId, String provider, long validMillis, JwtTokenType tokenType) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + validMillis);
 
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
                 .claim("provider", provider)
+                .claim(CLAIM_TOKEN_TYPE, tokenType == JwtTokenType.ACCESS ? TOKEN_TYPE_ACCESS : TOKEN_TYPE_REFRESH)
                 .setIssuedAt(now)
                 .setExpiration(expiry)
-                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .signWith(signingKey(), SignatureAlgorithm.HS256)
                 .compact();
     }
 
     // JWT 유효성 검증
     public boolean validateToken(String token) {
         try {
-            Jwts.parser()
-                    .setSigningKey(secretKey)
+            Jwts.parserBuilder()
+                    .setSigningKey(signingKey())
+                    .build()
                     .parseClaimsJws(token);
             return true;
         } catch (JwtException e) {
@@ -55,13 +69,50 @@ public class JwtProvider {
         }
     }
 
+    public TokenValidationResult validateTokenResult(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(signingKey())
+                    .build()
+                    .parseClaimsJws(token);
+            return TokenValidationResult.VALID;
+        } catch (ExpiredJwtException e) {
+            return TokenValidationResult.EXPIRED;
+        } catch (JwtException | IllegalArgumentException e) {
+            return TokenValidationResult.INVALID;
+        }
+    }
+
     // JWT에서 userId 추출
     public Long getUserId(String token) {
-        Claims claims = Jwts.parser()
-                .setSigningKey(secretKey)
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(signingKey())
+                .build()
                 .parseClaimsJws(token)
                 .getBody();
         return Long.valueOf(claims.getSubject());
+    }
+
+    public JwtTokenType getTokenTypeOrNull(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(signingKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        Object typ = claims.get(CLAIM_TOKEN_TYPE);
+        if (!(typ instanceof String)) return null;
+        String v = (String) typ;
+        if (TOKEN_TYPE_ACCESS.equalsIgnoreCase(v)) return JwtTokenType.ACCESS;
+        if (TOKEN_TYPE_REFRESH.equalsIgnoreCase(v)) return JwtTokenType.REFRESH;
+        return null;
+    }
+
+    public boolean isAccessToken(String token) {
+        return getTokenTypeOrNull(token) == JwtTokenType.ACCESS;
+    }
+
+    public boolean isRefreshToken(String token) {
+        return getTokenTypeOrNull(token) == JwtTokenType.REFRESH;
     }
 
 }

--- a/src/main/java/com/melissa/diary/security/JwtProvider.java
+++ b/src/main/java/com/melissa/diary/security/JwtProvider.java
@@ -28,7 +28,7 @@ public class JwtProvider {
     }
 
     // 유효 기간
-    private final long ACCESS_TOKEN_VALID_MILLIS = 1000L * 60 * 60 * 24;       // 1일
+    private final long ACCESS_TOKEN_VALID_MILLIS = 1000L * 60 * 60 * 2;        // 2시간
     private final long REFRESH_TOKEN_VALID_MILLIS = 1000L * 60 * 60 * 24 * 15; // 15일
 
     // Access Token 생성

--- a/src/main/java/com/melissa/diary/security/JwtTokenType.java
+++ b/src/main/java/com/melissa/diary/security/JwtTokenType.java
@@ -1,0 +1,7 @@
+package com.melissa.diary.security;
+
+public enum JwtTokenType {
+    ACCESS,
+    REFRESH
+}
+

--- a/src/main/java/com/melissa/diary/security/RefreshTokenHasher.java
+++ b/src/main/java/com/melissa/diary/security/RefreshTokenHasher.java
@@ -1,0 +1,34 @@
+package com.melissa.diary.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@Component
+public class RefreshTokenHasher {
+
+    @Value("${security.jwt.refresh-token-pepper}")
+    private String pepper;
+
+    public String sha256Hex(String refreshToken) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest((pepper + ":" + refreshToken).getBytes(StandardCharsets.UTF_8));
+            return toHex(bytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}
+

--- a/src/main/java/com/melissa/diary/security/TokenValidationResult.java
+++ b/src/main/java/com/melissa/diary/security/TokenValidationResult.java
@@ -1,0 +1,8 @@
+package com.melissa.diary.security;
+
+public enum TokenValidationResult {
+    VALID,
+    EXPIRED,
+    INVALID
+}
+

--- a/src/main/java/com/melissa/diary/service/SocialAuthService.java
+++ b/src/main/java/com/melissa/diary/service/SocialAuthService.java
@@ -14,10 +14,8 @@ import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
-import java.security.interfaces.RSAKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Date;
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -31,7 +29,6 @@ public class SocialAuthService {
     // Google (ID Token 검증)
     public GooglePayload verifyGoogleToken(String idToken) {
         String url = "https://oauth2.googleapis.com/tokeninfo?id_token=" + idToken;
-        log.info(idToken);
         try {
             RestTemplate restTemplate = new RestTemplate();
             GoogleIdTokenResponse response =

--- a/src/main/java/com/melissa/diary/service/UserService.java
+++ b/src/main/java/com/melissa/diary/service/UserService.java
@@ -8,6 +8,7 @@ import com.melissa.diary.repository.ThreadRepository;
 import com.melissa.diary.repository.UserRepository;
 import com.melissa.diary.repository.UserSettingRepository;
 import com.melissa.diary.security.JwtProvider;
+import com.melissa.diary.security.JwtTokenType;
 import com.melissa.diary.web.dto.UserRequestDTO;
 import com.melissa.diary.web.dto.UserResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -141,10 +142,19 @@ public class UserService {
             throw new ErrorHandler(ErrorStatus.EXPIRED_TOKEN);
         }
 
-        // Refresh 토큰 자체가 JWT라면 validate
-        if (!jwtProvider.validateToken(refreshToken)) {
-            // -> 위조된 토큰
-            throw new ErrorHandler(ErrorStatus.TOKEN_VERIFICATION_FAILED);
+        // Refresh 토큰(JWT) 자체의 유효성(만료/위조 등) 먼저 검증
+        // - 타입(typ) 파싱 과정에서 예외가 발생할 수 있으므로, 순서를 앞당겨 500을 방지합니다.
+        switch (jwtProvider.validateTokenResult(refreshToken)) {
+            case EXPIRED -> throw new ErrorHandler(ErrorStatus.EXPIRED_TOKEN);
+            case INVALID -> throw new ErrorHandler(ErrorStatus.TOKEN_VERIFICATION_FAILED);
+            case VALID -> {
+            }
+        }
+
+        // Refresh 토큰 타입 검증 (access 토큰으로 refresh 호출 방지)
+        JwtTokenType tokenType = jwtProvider.getTokenTypeOrNull(refreshToken);
+        if (tokenType != JwtTokenType.REFRESH) {
+            throw new ErrorHandler(ErrorStatus.TOKEN_TYPE_MISMATCH);
         }
         // [4] Access Token 재발급시 필요한 사용자 반환
         return user;

--- a/src/main/java/com/melissa/diary/service/UserService.java
+++ b/src/main/java/com/melissa/diary/service/UserService.java
@@ -9,6 +9,8 @@ import com.melissa.diary.repository.UserRepository;
 import com.melissa.diary.repository.UserSettingRepository;
 import com.melissa.diary.security.JwtProvider;
 import com.melissa.diary.security.JwtTokenType;
+import com.melissa.diary.security.RefreshTokenHasher;
+import com.melissa.diary.security.TokenValidationResult;
 import com.melissa.diary.web.dto.UserRequestDTO;
 import com.melissa.diary.web.dto.UserResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +26,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final SocialAuthService socialAuthService;
     private final JwtProvider jwtProvider;
+    private final RefreshTokenHasher refreshTokenHasher;
     private final ThreadRepository threadRepository;
     private final UserSettingRepository userSettingRepository;
 
@@ -122,7 +125,8 @@ public class UserService {
     @Transactional
     public String createRefreshToken(User user) {
         String token = jwtProvider.createRefreshToken(user.getId(), user.getProvider());
-        user.setRefreshToken(token);
+        // refreshToken 컬럼에 해시값 저장
+        user.setRefreshToken(refreshTokenHasher.sha256Hex(token));
         user.setRefreshTokenExpiry(LocalDateTime.now().plusDays(15));
         userRepository.save(user);
         return token;
@@ -130,8 +134,19 @@ public class UserService {
 
     @Transactional
     public User refreshAccessToken(String refreshToken) {
-        // DB에서 refreshToken으로 유저 찾기
-        User user = userRepository.findByRefreshToken(refreshToken)
+        // Refresh 토큰(JWT) 자체의 유효성(만료/위조 등) 먼저 검증
+        // - 타입(typ) 파싱 과정에서 예외가 발생할 수 있으므로, 순서를 앞당겨 500을 방지
+        TokenValidationResult validation = jwtProvider.validateTokenResult(refreshToken);
+        if (validation == TokenValidationResult.EXPIRED) {
+            throw new ErrorHandler(ErrorStatus.EXPIRED_TOKEN);
+        }
+        if (validation == TokenValidationResult.INVALID) {
+            throw new ErrorHandler(ErrorStatus.TOKEN_VERIFICATION_FAILED);
+        }
+
+        // DB에서 refreshToken 해시로 유저 찾기
+        String refreshTokenHash = refreshTokenHasher.sha256Hex(refreshToken);
+        User user = userRepository.findByRefreshToken(refreshTokenHash)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.INVALID_TOKEN));
         // -> "Refresh Token이 유효하지 않습니다." 의미로 INVALID_TOKEN 사용
 
@@ -140,15 +155,6 @@ public class UserService {
                 || user.getRefreshTokenExpiry().isBefore(LocalDateTime.now())) {
             // -> Refresh Token이 만료된 경우
             throw new ErrorHandler(ErrorStatus.EXPIRED_TOKEN);
-        }
-
-        // Refresh 토큰(JWT) 자체의 유효성(만료/위조 등) 먼저 검증
-        // - 타입(typ) 파싱 과정에서 예외가 발생할 수 있으므로, 순서를 앞당겨 500을 방지합니다.
-        switch (jwtProvider.validateTokenResult(refreshToken)) {
-            case EXPIRED -> throw new ErrorHandler(ErrorStatus.EXPIRED_TOKEN);
-            case INVALID -> throw new ErrorHandler(ErrorStatus.TOKEN_VERIFICATION_FAILED);
-            case VALID -> {
-            }
         }
 
         // Refresh 토큰 타입 검증 (access 토큰으로 refresh 호출 방지)
@@ -166,9 +172,8 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.INVALID_TOKEN));
 
-        // Refresh Token 삭제
+        // Refresh Token 해시 삭제
         user.setRefreshToken(null);
-        // 만료 시각도 null
         user.setRefreshTokenExpiry(null);
 
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,5 +61,6 @@ cloud:
 security:
   jwt:
     secret-key: ${MELISSA_JWT_SECRET_KEY}
+    refresh-token-pepper: ${MELISSA_REFRESH_TOKEN_PEPPER}
   encrypt:
     secret-key: ${ENC_SECRET_KEY}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
JWT/세션 보안 점검 결과 발견된 취약점을 개선하여 토큰 탈취 시 피해를 최소화하고, 홍보/배포 전 필수 보안 조치를 완료했습니다.

- **구 토큰 전부 무력화**: JWT에 `typ` claim 추가하여 기존 토큰 재로그인 강제
- **Access/Refresh 역할 분리**: 인증 필터는 Access만, `/auth/refresh`는 Refresh만 허용
- **Refresh 토큰 해시 저장**: DB 유출 대비 SHA-256(pepper:token) 해시로 저장
- **민감 정보 로깅 제거**: Google 소셜 로그인 idToken 평문 로깅 삭제
- **Access 토큰 만료 단축**: 1일 → 2시간 (탈취 피해 최소화)

## 📋 변경 사항

### 1. JWT 토큰 타입(`typ`) claim 추가
- Access/Refresh 토큰 발급 시 `typ` claim 포함 (`access`/`refresh`)
- **인증 필터**: `typ=access`만 허용, refresh/기타는 401
- **Refresh API**: `typ=refresh`만 허용, access로 호출 시 `TOKEN_TYPE_MISMATCH` 에러
- **구 토큰(typ 없음)**: 전부 401로 재로그인 강제

### 2. Refresh 토큰 해시 저장
- **DB 저장 방식**: 평문 → `SHA-256(pepper:token)` 해시
- **컬럼 재사용**: 기존 `refreshToken` 컬럼에 해시 덮어쓰기 (ALTER TABLE 불필요)
- **pepper 추가**: `MELISSA_REFRESH_TOKEN_PEPPER` 환경변수 필수 (JWT secret과 분리)
- **조회 로직**: refresh API에서 해시 계산 후 `findByRefreshToken(hash)` 호출

### 3. Access 토큰 만료 시간 단축
- **변경**: 1일 → **2시간** (탈취 시 피해 최소화)
- Refresh 토큰: 15일 유지

### 4. 보안 로깅 제거
- Google 로그인 `idToken` 평문 로깅 제거 (토큰 유출 방지)

### 5. 에러 응답 개선
- **신규 에러코드**: `TOKEN_TYPE_MISMATCH(AUTH4007)` 추가
- JWT 검증 순서 조정: 만료/위조 → typ 확인 (500 방지)

## 🔍 Code Review

### 필수 확인 사항
1. **환경변수 설정** (배포 전 필수)
   - `MELISSA_REFRESH_TOKEN_PEPPER` 추가 확인 (32바이트 이상 권장)
   - JWT secret과 pepper가 **서로 다른 값**인지 확인
   
2. **운영 영향도**
   - 기존 로그인 유저 → **1회 재로그인 필요** (구 토큰 무력화)
   - 신규 로그인 → 정상 동작
   - Access 2시간 만료로 refresh API 호출 빈도 증가 (프론트 자동 처리 확인)

3. **DB 마이그레이션**
   - `refreshToken` 컬럼 재사용 (자동 처리, ALTER TABLE 불필요)
   
4. **롤백 시나리오**
   - 코드 롤백 시 신규 토큰도 무력화 → 재로그인 1회 추가 발생

### 주요 코드 리뷰 포인트
- `JwtProvider`: typ claim 추가 로직 + deprecated API → parserBuilder 변경
- `JwtAuthenticationFilter`: Access만 인증 컨텍스트 생성, 나머지는 401
- `UserService.refreshAccessToken()`: JWT 검증 순서(만료/위조 → typ → DB) 확인
- `RefreshTokenHasher`: SHA-256 + pepper 구현 확인

## 📸 ScreenShot
(배포 후 확인)
- [x] MELISSA_REFRESH_TOKEN_PEPPER 주입
- [x] 로그인 → Access+Refresh 발급 확인
- [x] Refresh로 보호 API 호출 → 401 확인
- [x] Refresh API → 새 토큰 발급 확인
- [x] 로그아웃 후 Refresh 재사용 → 401 확인