### PR TITLE
feat: Feed API 페이징 로직 개선 + 날짜 묶음 기반 무한 페이징으로 전환

### DIFF
--- a/src/main/java/com/melissa/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/melissa/diary/repository/DiaryRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 
 import java.sql.Date;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -96,8 +95,8 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     /**
      * 피드 전용 조회 (최신순, 커서 기반 페이지네이션)
-     * - createdAt DESC, id DESC 정렬
-     * - 커서 조건: (createdAt < cursorCreatedAt) OR (createdAt = cursorCreatedAt AND id < cursorDiaryId)
+     * - id DESC 정렬 (AUTO_INCREMENT로 최신순 보장)
+     * - 커서 조건: id < cursorDiaryId
      * - FETCH JOIN으로 Thread, AiProfile 한번에 로딩 (N+1 방지)
      *
      * 주의: Pageable은 limit 용도로만 사용 (page=0 고정)
@@ -108,16 +107,11 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
         INNER JOIN FETCH t.aiProfile ap
         WHERE d.user.id = :userId
           AND d.isActive = true
-          AND (
-            :cursorCreatedAt IS NULL
-            OR d.createdAt < :cursorCreatedAt
-            OR (d.createdAt = :cursorCreatedAt AND d.id < :cursorDiaryId)
-          )
-        ORDER BY d.createdAt DESC, d.id DESC
+          AND (:cursorDiaryId IS NULL OR d.id < :cursorDiaryId)
+        ORDER BY d.id DESC
         """)
     List<Diary> findFeedPage(
             @Param("userId") Long userId,
-            @Param("cursorCreatedAt") LocalDateTime cursorCreatedAt,
             @Param("cursorDiaryId") Long cursorDiaryId,
             Pageable pageable);
     

--- a/src/main/java/com/melissa/diary/service/CalendarService.java
+++ b/src/main/java/com/melissa/diary/service/CalendarService.java
@@ -195,12 +195,14 @@ public class CalendarService {
             }
             
             // 배치 데이터를 날짜별로 그룹화
+            boolean earlyExit = false;
             for (Diary diary : batch) {
                 String key = diary.getYear() + "-" + diary.getMonth() + "-" + diary.getDay();
                 
                 // 이미 목표 날짜 수(+1)에 도달했으면 중단
                 if (byDayKey.size() >= resolvedLimit + 1 && !byDayKey.containsKey(key)) {
                     hasMore = true;
+                    earlyExit = true;
                     break;
                 }
                 
@@ -213,6 +215,11 @@ public class CalendarService {
                 }
                 
                 currentCursor = diary.getId(); // 다음 조회를 위한 커서 업데이트
+            }
+            
+            // 일찍 종료했다면 hasMore는 이미 true로 설정됨
+            if (earlyExit) {
+                break;
             }
             
             // 배치 크기보다 적게 조회되었다면 더 이상 데이터가 없음

--- a/src/main/java/com/melissa/diary/service/CalendarService.java
+++ b/src/main/java/com/melissa/diary/service/CalendarService.java
@@ -15,8 +15,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -157,78 +155,104 @@ public class CalendarService {
 
     /**
      * 최신순 피드 조회 (커서 기반 무한 페이징)
-     * - 월간 전체조회(DailySummaryResponseDTO) 구조를 재사용하기 위해 "일자별 그룹"으로 반환
-     * - 정렬 안정성: createdAt DESC, diaryId DESC
+     * - 날짜 묶음 N개를 보장 (일기 개수가 아닌 고유 날짜 개수 기준)
+     * - 정렬: id DESC (AUTO_INCREMENT로 최신순 보장)
      */
     @Transactional(readOnly = true)
-    public CalendarResponseDTO.FeedResponseDTO getFeed(Long userId, Integer limit, String cursorCreatedAt, Long cursorDiaryId) {
+    public CalendarResponseDTO.FeedResponseDTO getFeed(Long userId, Integer limit, Long cursorDiaryId) {
         // 유저 검증
         getUser(userId);
 
+        // limit은 날짜 묶음 개수 (기본 20개, 최대 50개)
         int resolvedLimit = (limit == null ? 20 : limit);
         if (resolvedLimit < 1 || resolvedLimit > 50) {
             throw new ErrorHandler(ErrorStatus.CALENDAR_INVALID_LIMIT);
         }
 
-        // 커서 짝 검증 (2필드 커서)
-        boolean hasCreatedAt = cursorCreatedAt != null && !cursorCreatedAt.isBlank();
-        boolean hasDiaryId = cursorDiaryId != null;
-        if (hasCreatedAt != hasDiaryId) {
-            throw new ErrorHandler(ErrorStatus.CALENDAR_INVALID_CURSOR);
-        }
-
-        LocalDateTime parsedCursorCreatedAt = null;
-        if (hasCreatedAt) {
-            try {
-                parsedCursorCreatedAt = LocalDateTime.parse(cursorCreatedAt);
-            } catch (DateTimeParseException e) {
-                throw new ErrorHandler(ErrorStatus.CALENDAR_INVALID_CURSOR);
+        // 날짜 묶음을 저장할 자료구조 (순서 유지)
+        Map<String, List<CalendarResponseDTO.DiaryDetailDTO>> byDayKey = new LinkedHashMap<>();
+        Map<String, int[]> dayParts = new LinkedHashMap<>(); // year, month, day 저장
+        
+        Long currentCursor = cursorDiaryId;
+        boolean hasMore = true;
+        
+        // 날짜 묶음이 resolvedLimit+1개가 될 때까지 반복 조회 (+1은 hasNext 판단용)
+        while (byDayKey.size() <= resolvedLimit && hasMore) {
+            // 한 번에 가져올 일기 개수 (배치 사이즈)
+            // 날짜당 평균 1.5개 일기를 가정하여, 부족한 날짜 수 * 2
+            int remainingDays = (resolvedLimit + 1) - byDayKey.size();
+            int batchSize = Math.max(remainingDays * 2, 20);
+            
+            List<Diary> batch = diaryRepository.findFeedPage(
+                    userId,
+                    currentCursor,
+                    PageRequest.of(0, batchSize)
+            );
+            
+            if (batch.isEmpty()) {
+                hasMore = false;
+                break;
+            }
+            
+            // 배치 데이터를 날짜별로 그룹화
+            for (Diary diary : batch) {
+                String key = diary.getYear() + "-" + diary.getMonth() + "-" + diary.getDay();
+                
+                // 이미 목표 날짜 수(+1)에 도달했으면 중단
+                if (byDayKey.size() >= resolvedLimit + 1 && !byDayKey.containsKey(key)) {
+                    hasMore = true;
+                    break;
+                }
+                
+                List<CalendarResponseDTO.DiaryDetailDTO> diaryList = byDayKey.computeIfAbsent(key, k -> new ArrayList<>());
+                
+                // 각 날짜별 최대 3개까지만 추가
+                if (diaryList.size() < 3) {
+                    diaryList.add(DiaryConverter.toDiaryDetailDTO(diary));
+                    dayParts.putIfAbsent(key, new int[]{diary.getYear(), diary.getMonth(), diary.getDay()});
+                }
+                
+                currentCursor = diary.getId(); // 다음 조회를 위한 커서 업데이트
+            }
+            
+            // 배치 크기보다 적게 조회되었다면 더 이상 데이터가 없음
+            if (batch.size() < batchSize) {
+                hasMore = false;
             }
         }
 
-        // limit+1로 가져와서 hasNext 판단
-        List<Diary> diaries = diaryRepository.findFeedPage(
-                userId,
-                parsedCursorCreatedAt,
-                cursorDiaryId,
-                PageRequest.of(0, resolvedLimit + 1)
-        );
-
-        boolean hasNext = diaries.size() > resolvedLimit;
+        // hasNext 판단 및 실제 반환할 날짜 목록 결정
+        boolean hasNext = byDayKey.size() > resolvedLimit;
+        List<String> dayKeys = new ArrayList<>(byDayKey.keySet());
+        
         if (hasNext) {
-            diaries = diaries.subList(0, resolvedLimit);
+            // 초과된 날짜 제거
+            dayKeys = dayKeys.subList(0, resolvedLimit);
         }
-
-        // 일자별 그룹핑 (최신순 피드 흐름을 유지하기 위해 LinkedHashMap 사용)
-        Map<String, List<CalendarResponseDTO.DiaryDetailDTO>> byDayKey = new LinkedHashMap<>();
-        Map<String, int[]> dayParts = new LinkedHashMap<>(); // year, month, day 저장
-
-        for (Diary diary : diaries) {
-            String key = diary.getYear() + "-" + diary.getMonth() + "-" + diary.getDay();
-            byDayKey.computeIfAbsent(key, k -> new ArrayList<>()).add(DiaryConverter.toDiaryDetailDTO(diary));
-            dayParts.putIfAbsent(key, new int[]{diary.getYear(), diary.getMonth(), diary.getDay()});
-        }
-
-        List<CalendarResponseDTO.DailySummaryResponseDTO> days = byDayKey.entrySet().stream()
-                .map(entry -> {
-                    String key = entry.getKey();
+        
+        // 응답 DTO 생성
+        List<CalendarResponseDTO.DailySummaryResponseDTO> days = dayKeys.stream()
+                .map(key -> {
                     int[] parts = dayParts.get(key);
                     return CalendarResponseDTO.DailySummaryResponseDTO.builder()
                             .year(parts[0])
                             .month(parts[1])
                             .day(parts[2])
-                            .diaries(entry.getValue())
+                            .diaries(byDayKey.get(key))
                             .build();
                 })
                 .collect(Collectors.toList());
 
+        // 다음 커서 계산: 마지막 날짜의 마지막 일기 ID
         CalendarResponseDTO.FeedNextCursorDTO nextCursor = null;
-        if (hasNext && !diaries.isEmpty()) {
-            Diary last = diaries.get(diaries.size() - 1);
-            nextCursor = CalendarResponseDTO.FeedNextCursorDTO.builder()
-                    .cursorCreatedAt(last.getCreatedAt())
-                    .cursorDiaryId(last.getId())
-                    .build();
+        if (hasNext && !days.isEmpty()) {
+            List<CalendarResponseDTO.DiaryDetailDTO> lastDayDiaries = days.get(days.size() - 1).getDiaries();
+            if (!lastDayDiaries.isEmpty()) {
+                Long lastDiaryId = lastDayDiaries.get(lastDayDiaries.size() - 1).getDiaryId();
+                nextCursor = CalendarResponseDTO.FeedNextCursorDTO.builder()
+                        .cursorDiaryId(lastDiaryId)
+                        .build();
+            }
         }
 
         return CalendarResponseDTO.FeedResponseDTO.builder()

--- a/src/main/java/com/melissa/diary/web/controller/CalendarController.java
+++ b/src/main/java/com/melissa/diary/web/controller/CalendarController.java
@@ -91,30 +91,24 @@ public class CalendarController {
 
     @Operation(summary = "피드 전용 최신순 조회 (커서 기반 무한 페이징)",
                description = """
-                   [v1.3.0+] 피드 전용 최신순 정렬(createdAt DESC, diaryId DESC)을 보장하며, 커서 기반 무한 페이징을 제공합니다.
-                   - 첫 요청(첫 페이지)은 cursorCreatedAt/cursorDiaryId 없이 호출합니다.
-                   - 다음 페이지부터는 직전 응답의 pageInfo.nextCursor 값을 그대로 재전송합니다.
+                   [v1.3.0+] 피드 전용 최신순 정렬(id DESC)을 보장하며, 커서 기반 무한 페이징을 제공합니다.
+                   - limit은 날짜 묶음 개수입니다 (일기 개수가 아님). 기본 20개, 최대 50개.
+                   - 첫 요청(첫 페이지)은 cursorDiaryId 없이 호출합니다.
+                   - 다음 페이지부터는 직전 응답의 pageInfo.nextCursor.cursorDiaryId 값을 그대로 재전송합니다.
                    - 마지막 페이지에서는 pageInfo.hasNext=false 이며 pageInfo.nextCursor=null 입니다.
-                   - 커서는 2필드(cursorCreatedAt + cursorDiaryId)이며 둘 중 하나만 전달하면 400 입니다.
+                   - 각 날짜 묶음에는 최대 3개의 일기가 포함됩니다.
                    """)
     @ApiResponses({
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "CALENDAR4004: 유효하지 않은 커서 / CALENDAR4005: 유효하지 않은 limit"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "CALENDAR4005: 유효하지 않은 limit"),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음")
     })
     @GetMapping("/feed")
     public ApiResponse<CalendarResponseDTO.FeedResponseDTO> getFeed(
-            @Parameter(description = "조회 개수 (기본 20, 최대 50)", example = "20")
+            @Parameter(description = "조회할 날짜 묶음 개수 (기본 20, 최대 50)", example = "20")
             @RequestParam(name = "limit", required = false) Integer limit,
             @Parameter(description = """
-                    커서 createdAt (ISO-8601)
-                    - 첫 요청은 미전송(null) 가능
-                    - 다음 페이지부터는 직전 응답의 pageInfo.nextCursor.cursorCreatedAt 값을 그대로 재전송
-                    - 마지막 페이지는 pageInfo.nextCursor=null 이므로 커서를 다시 미전송
-                    """, example = "2025-12-30T21:15:10.123456")
-            @RequestParam(name = "cursorCreatedAt", required = false) String cursorCreatedAt,
-            @Parameter(description = """
-                    커서 diaryId
+                    커서 diaryId (단일 필드 커서)
                     - 첫 요청은 미전송(null) 가능
                     - 다음 페이지부터는 직전 응답의 pageInfo.nextCursor.cursorDiaryId 값을 그대로 재전송
                     - 마지막 페이지는 pageInfo.nextCursor=null 이므로 커서를 다시 미전송
@@ -123,7 +117,7 @@ public class CalendarController {
             Principal principal) {
 
         Long userId = Long.parseLong(principal.getName());
-        CalendarResponseDTO.FeedResponseDTO response = calendarService.getFeed(userId, limit, cursorCreatedAt, cursorDiaryId);
+        CalendarResponseDTO.FeedResponseDTO response = calendarService.getFeed(userId, limit, cursorDiaryId);
 
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/melissa/diary/web/dto/CalendarResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/CalendarResponseDTO.java
@@ -158,7 +158,7 @@ public class CalendarResponseDTO {
     }
 
     /**
-     * 다음 커서
+     * 다음 커서 (단일 필드)
      */
     @Getter
     @Builder
@@ -167,10 +167,7 @@ public class CalendarResponseDTO {
     @Schema(description = "피드 다음 커서")
     public static class FeedNextCursorDTO {
 
-        @Schema(description = "커서 createdAt (ISO-8601, 서버가 내려준 값을 그대로 재전송)", example = "2025-12-30T21:15:10.123456", requiredMode = Schema.RequiredMode.REQUIRED)
-        private LocalDateTime cursorCreatedAt;
-
-        @Schema(description = "커서 diaryId", example = "401", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "커서 diaryId (서버가 내려준 값을 그대로 재전송)", example = "401", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long cursorDiaryId;
     }
 


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
Feed API 페이징 로직을 개선하여 일기 개수 기준에서 날짜 묶음 개수 기준으로 변경하고, 커서를 단순화했습니다.

#### 주요 개선사항
> - 날짜 묶음 20개를 보장하는 페이징 구현
> - 2필드 커서(cursorCreatedAt + cursorDiaryId)를 단일 커서(cursorDiaryId)로 단순화
> - id DESC 정렬로 쿼리 최적화
> - 프론트엔드 요구사항 반영: UI에서 날짜별로 그룹화하여 표시하므로 날짜 묶음 단위 페이징이 필요

## 📋 변경 사항
### 1. CalendarResponseDTO.java - DTO 구조 단순화
- FeedNextCursorDTO에서 cursorCreatedAt 필드 제거
- cursorDiaryId 단일 필드만 유지

### 2. DiaryRepository.java - 쿼리 개선
- 정렬: ORDER BY d.createdAt DESC, d.id DESC → ORDER BY d.id DESC
- 커서 조건 단순화: d.id < :cursorDiaryId
- 파라미터 감소: 3개 → 2개

근거: Diary.id는 AUTO_INCREMENT이므로 최신순 정렬 보장

### 3. CalendarService.java - 핵심 로직 변경
변경 전: 일기 20개 조회 후 날짜별 그룹화 (날짜 개수 불확실)

변경 후: 날짜 묶음 20개를 보장하도록 반복 조회
- 배치 단위로 일기 조회 (부족한 날짜 수 × 2 크기)
- 날짜별로 그룹화하며 각 날짜당 최대 3개까지만 저장
- 목표 날짜 수에 도달하면 종료
- earlyExit 플래그로 조기 종료 시 hasMore 값 보존

### 4. CalendarController.java - API 명세 업데이트
- cursorCreatedAt 파라미터 제거
- limit 설명 수정: "조회할 날짜 묶음 개수"
- Swagger 문서 업데이트 (날짜 묶음 기준 명시)
- 에러 응답 정리: CALENDAR4004 제거

## 🔍 Code Review

로직 검증
- 날짜 묶음이 정확히 limit개만큼 반환되는지 확인
- 각 날짜별 최대 3개 일기만 포함되는지 확인
- hasNext, nextCursor가 올바르게 계산되는지 확인
- LinkedHashMap 사용 적절성 (메서드 로컬 변수이므로 스레드 안전)

하위 호환성
- 프론트엔드와 API 변경사항 동기화 필요 (cursorCreatedAt 파라미터 제거됨)
- 배포 전 프론트엔드 팀과 커뮤니케이션 필수

## 📸 ScreenShot
