### PR TITLE
feat(stab-002): 핵심 도메인 DB constraints 적용 및 migration/rollback 스크립트 추가

### DIFF
--- a/src/main/java/com/melissa/diary/domain/UserSetting.java
+++ b/src/main/java/com/melissa/diary/domain/UserSetting.java
@@ -30,6 +30,6 @@ public class UserSetting {
     private LocalDate lastSentDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 }

--- a/src/main/java/com/melissa/diary/service/UserService.java
+++ b/src/main/java/com/melissa/diary/service/UserService.java
@@ -5,6 +5,7 @@ import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
 import com.melissa.diary.converter.UserConverter;
 import com.melissa.diary.domain.User;
 import com.melissa.diary.repository.ThreadRepository;
+import com.melissa.diary.repository.UserMemoryRepository;
 import com.melissa.diary.repository.UserRepository;
 import com.melissa.diary.repository.UserSettingRepository;
 import com.melissa.diary.security.JwtProvider;
@@ -29,6 +30,7 @@ public class UserService {
     private final RefreshTokenHasher refreshTokenHasher;
     private final ThreadRepository threadRepository;
     private final UserSettingRepository userSettingRepository;
+    private final UserMemoryRepository userMemoryRepository;
 
 
     @Transactional
@@ -188,6 +190,7 @@ public class UserService {
 
         // 유저 설정 삭제
         userSettingRepository.deleteByUserId(userId);
+        userMemoryRepository.deleteByUserId(userId);
 
         // 삭제될 유저 정보를 DTO로 변환
         UserResponseDTO.DeleteResultDTO deleteDTO = UserConverter.toDeleteDTO(user);

--- a/src/main/resources/db/migration/manual/STAB-002-README.md
+++ b/src/main/resources/db/migration/manual/STAB-002-README.md
@@ -1,0 +1,62 @@
+# STAB-002 Manual Migration Guide
+
+## 목적
+핵심 도메인에 DB 제약(`NOT NULL`, `UNIQUE`, `FK`, `CHECK`)을 우선 적용하고,
+조회 성능 및 운영 안전성을 위한 인덱스를 추가한다.
+
+## 대상 스크립트
+- `STAB-002-precheck.sql`
+- `STAB-002-apply.sql`
+- `STAB-002-rollback.sql`
+
+## 실행 순서
+1. `STAB-002-precheck.sql` 실행
+2. pre-check 결과가 모두 정상인지 확인
+3. `STAB-002-apply.sql` 실행
+4. 애플리케이션 주요 시나리오 스모크 테스트
+5. 장애 발생 시 `STAB-002-rollback.sql` 실행
+
+## Pre-check 통과 기준
+- `user_setting_null_user_id = 0`
+- `user_memory_null_user_id = 0`
+- `user_setting`/`user_memory` duplicate 결과 없음
+- orphan count = 0
+- `thread_invalid_month_or_day = 0`
+- `diary_invalid_month_or_day = 0`
+- `user_setting.user_id` / `user_memory.user_id`의 FK action rule 확인 가능
+- `user_id` 컬럼 nullable 여부 확인 가능
+
+## 적용 후 검증 쿼리 예시
+```sql
+SELECT table_name, constraint_name, constraint_type
+FROM information_schema.table_constraints
+WHERE table_schema = DATABASE()
+  AND table_name IN ('user_setting', 'user_memory', 'thread', 'diary')
+ORDER BY table_name, constraint_type, constraint_name;
+
+SELECT table_name, index_name, non_unique
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+  AND table_name IN ('user_setting', 'diary', 'daily_chat_log')
+ORDER BY table_name, index_name;
+
+SELECT
+  rc.constraint_name,
+  rc.table_name,
+  rc.update_rule,
+  rc.delete_rule
+FROM information_schema.referential_constraints rc
+WHERE rc.constraint_schema = DATABASE()
+  AND rc.table_name IN ('user_setting', 'user_memory');
+
+SELECT table_name, column_name, is_nullable
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name IN ('user_setting', 'user_memory')
+  AND column_name = 'user_id';
+```
+
+## 주의사항
+- MySQL DDL은 대부분 auto-commit이므로, apply 도중 오류가 나면 일부 변경이 남을 수 있다.
+- 운영 적용 전에 스테이징에서 동일 데이터 조건으로 리허설을 권장한다.
+- 롤백 스크립트의 nullable 복원은 기본 비활성화되어 있으며, 필요 시 주석 해제 후 사용한다.

--- a/src/main/resources/db/migration/manual/STAB-002-apply.sql
+++ b/src/main/resources/db/migration/manual/STAB-002-apply.sql
@@ -1,0 +1,332 @@
+-- STAB-002 apply script
+-- Purpose:
+-- 1) strengthen NOT NULL / UNIQUE / FK constraints on core domain
+-- 2) add CHECK constraints for month/day
+-- 3) add supporting indexes for dominant query patterns
+-- Target DB: MySQL 8.x
+
+-- =========================
+-- A. Fail-fast assertions
+-- =========================
+DROP PROCEDURE IF EXISTS sp_stab002_assert;
+DELIMITER //
+CREATE PROCEDURE sp_stab002_assert()
+BEGIN
+    DECLARE v_count BIGINT DEFAULT 0;
+
+    SELECT COUNT(*) INTO v_count
+    FROM user_setting
+    WHERE user_id IS NULL;
+    IF v_count > 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'STAB-002 blocked: user_setting.user_id contains NULL';
+    END IF;
+
+    SELECT COUNT(*) INTO v_count
+    FROM user_memory
+    WHERE user_id IS NULL;
+    IF v_count > 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'STAB-002 blocked: user_memory.user_id contains NULL';
+    END IF;
+
+    SELECT COUNT(*) INTO v_count
+    FROM (
+        SELECT user_id
+        FROM user_setting
+        GROUP BY user_id
+        HAVING COUNT(*) > 1
+    ) d;
+    IF v_count > 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'STAB-002 blocked: duplicate user_setting.user_id found';
+    END IF;
+
+    SELECT COUNT(*) INTO v_count
+    FROM (
+        SELECT user_id
+        FROM user_memory
+        GROUP BY user_id
+        HAVING COUNT(*) > 1
+    ) d;
+    IF v_count > 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'STAB-002 blocked: duplicate user_memory.user_id found';
+    END IF;
+
+    SELECT COUNT(*) INTO v_count
+    FROM user_setting s
+    LEFT JOIN `user` u ON u.id = s.user_id
+    WHERE u.id IS NULL;
+    IF v_count > 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'STAB-002 blocked: orphan rows found in user_setting.user_id';
+    END IF;
+
+    SELECT COUNT(*) INTO v_count
+    FROM user_memory m
+    LEFT JOIN `user` u ON u.id = m.user_id
+    WHERE u.id IS NULL;
+    IF v_count > 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'STAB-002 blocked: orphan rows found in user_memory.user_id';
+    END IF;
+
+    SELECT COUNT(*) INTO v_count
+    FROM thread
+    WHERE month < 1 OR month > 12 OR day < 1 OR day > 31;
+    IF v_count > 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'STAB-002 blocked: invalid month/day rows found in thread';
+    END IF;
+
+    SELECT COUNT(*) INTO v_count
+    FROM diary
+    WHERE month < 1 OR month > 12 OR day < 1 OR day > 31;
+    IF v_count > 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'STAB-002 blocked: invalid month/day rows found in diary';
+    END IF;
+END //
+DELIMITER ;
+
+CALL sp_stab002_assert();
+DROP PROCEDURE IF EXISTS sp_stab002_assert;
+
+-- =========================
+-- B. NOT NULL enforcement
+-- =========================
+ALTER TABLE user_setting
+    MODIFY COLUMN user_id BIGINT NOT NULL;
+
+ALTER TABLE user_memory
+    MODIFY COLUMN user_id BIGINT NOT NULL;
+
+-- =========================
+-- C. UNIQUE constraints (idempotent create)
+-- =========================
+SET @has_unique_user_setting :=
+    (SELECT COUNT(*)
+     FROM information_schema.statistics
+     WHERE table_schema = DATABASE()
+       AND table_name = 'user_setting'
+       AND column_name = 'user_id'
+       AND non_unique = 0);
+SET @sql := IF(@has_unique_user_setting = 0,
+               'CREATE UNIQUE INDEX ux_user_setting_user_id ON user_setting (user_id)',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_unique_user_memory :=
+    (SELECT COUNT(*)
+     FROM information_schema.statistics
+     WHERE table_schema = DATABASE()
+       AND table_name = 'user_memory'
+       AND column_name = 'user_id'
+       AND non_unique = 0);
+SET @sql := IF(@has_unique_user_memory = 0,
+               'CREATE UNIQUE INDEX ux_user_memory_user_id ON user_memory (user_id)',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- D. FK constraints normalization
+-- Goal: enforce ON DELETE CASCADE for user_setting/user_memory -> user
+-- =========================
+SET @fk_name :=
+    (SELECT kcu.CONSTRAINT_NAME
+     FROM information_schema.key_column_usage kcu
+     WHERE kcu.table_schema = DATABASE()
+       AND kcu.table_name = 'user_setting'
+       AND kcu.column_name = 'user_id'
+       AND kcu.referenced_table_name = 'user'
+     LIMIT 1);
+
+SET @fk_delete_rule :=
+    (SELECT rc.DELETE_RULE
+     FROM information_schema.referential_constraints rc
+     WHERE rc.constraint_schema = DATABASE()
+       AND rc.table_name = 'user_setting'
+       AND rc.constraint_name = @fk_name
+     LIMIT 1);
+
+SET @need_recreate_fk := IF(@fk_name IS NULL, 1, IF(@fk_delete_rule = 'CASCADE', 0, 1));
+
+SET @sql := IF(@need_recreate_fk = 1 AND @fk_name IS NOT NULL,
+               CONCAT('ALTER TABLE user_setting DROP FOREIGN KEY `', @fk_name, '`'),
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql := IF(@need_recreate_fk = 1,
+               'ALTER TABLE user_setting ADD CONSTRAINT fk_user_setting_user FOREIGN KEY (user_id) REFERENCES `user`(id) ON DELETE CASCADE ON UPDATE RESTRICT',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @fk_name :=
+    (SELECT kcu.CONSTRAINT_NAME
+     FROM information_schema.key_column_usage kcu
+     WHERE kcu.table_schema = DATABASE()
+       AND kcu.table_name = 'user_memory'
+       AND kcu.column_name = 'user_id'
+       AND kcu.referenced_table_name = 'user'
+     LIMIT 1);
+
+SET @fk_delete_rule :=
+    (SELECT rc.DELETE_RULE
+     FROM information_schema.referential_constraints rc
+     WHERE rc.constraint_schema = DATABASE()
+       AND rc.table_name = 'user_memory'
+       AND rc.constraint_name = @fk_name
+     LIMIT 1);
+
+SET @need_recreate_fk := IF(@fk_name IS NULL, 1, IF(@fk_delete_rule = 'CASCADE', 0, 1));
+
+SET @sql := IF(@need_recreate_fk = 1 AND @fk_name IS NOT NULL,
+               CONCAT('ALTER TABLE user_memory DROP FOREIGN KEY `', @fk_name, '`'),
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql := IF(@need_recreate_fk = 1,
+               'ALTER TABLE user_memory ADD CONSTRAINT fk_user_memory_user FOREIGN KEY (user_id) REFERENCES `user`(id) ON DELETE CASCADE ON UPDATE RESTRICT',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- E. CHECK constraints for date fragments
+-- =========================
+SET @has_chk_thread_month :=
+    (SELECT COUNT(*)
+     FROM information_schema.table_constraints
+     WHERE table_schema = DATABASE()
+       AND table_name = 'thread'
+       AND constraint_name = 'chk_thread_month'
+       AND constraint_type = 'CHECK');
+SET @sql := IF(@has_chk_thread_month = 0,
+               'ALTER TABLE thread ADD CONSTRAINT chk_thread_month CHECK (month BETWEEN 1 AND 12)',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_chk_thread_day :=
+    (SELECT COUNT(*)
+     FROM information_schema.table_constraints
+     WHERE table_schema = DATABASE()
+       AND table_name = 'thread'
+       AND constraint_name = 'chk_thread_day'
+       AND constraint_type = 'CHECK');
+SET @sql := IF(@has_chk_thread_day = 0,
+               'ALTER TABLE thread ADD CONSTRAINT chk_thread_day CHECK (day BETWEEN 1 AND 31)',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_chk_diary_month :=
+    (SELECT COUNT(*)
+     FROM information_schema.table_constraints
+     WHERE table_schema = DATABASE()
+       AND table_name = 'diary'
+       AND constraint_name = 'chk_diary_month'
+       AND constraint_type = 'CHECK');
+SET @sql := IF(@has_chk_diary_month = 0,
+               'ALTER TABLE diary ADD CONSTRAINT chk_diary_month CHECK (month BETWEEN 1 AND 12)',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_chk_diary_day :=
+    (SELECT COUNT(*)
+     FROM information_schema.table_constraints
+     WHERE table_schema = DATABASE()
+       AND table_name = 'diary'
+       AND constraint_name = 'chk_diary_day'
+       AND constraint_type = 'CHECK');
+SET @sql := IF(@has_chk_diary_day = 0,
+               'ALTER TABLE diary ADD CONSTRAINT chk_diary_day CHECK (day BETWEEN 1 AND 31)',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- F. Supporting indexes for query patterns
+-- =========================
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'user_setting'
+                   AND index_name = 'idx_user_setting_notification_target');
+SET @sql := IF(@has_idx = 0,
+               'CREATE INDEX idx_user_setting_notification_target ON user_setting (notification_time, notification_enabled, last_sent_date, user_id)',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'diary'
+                   AND index_name = 'idx_diary_user_day_active_created');
+SET @sql := IF(@has_idx = 0,
+               'CREATE INDEX idx_diary_user_day_active_created ON diary (user_id, year, month, day, is_active, created_at, id)',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'diary'
+                   AND index_name = 'idx_diary_user_month_active_day_created');
+SET @sql := IF(@has_idx = 0,
+               'CREATE INDEX idx_diary_user_month_active_day_created ON diary (user_id, year, month, is_active, day, created_at, id)',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'diary'
+                   AND index_name = 'idx_diary_feed_user_active_id');
+SET @sql := IF(@has_idx = 0,
+               'CREATE INDEX idx_diary_feed_user_active_id ON diary (user_id, is_active, id)',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'diary'
+                   AND index_name = 'idx_diary_thread_active_created');
+SET @sql := IF(@has_idx = 0,
+               'CREATE INDEX idx_diary_thread_active_created ON diary (thread_id, is_active, created_at, id)',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'daily_chat_log'
+                   AND index_name = 'idx_daily_chat_log_thread_created');
+SET @sql := IF(@has_idx = 0,
+               'CREATE INDEX idx_daily_chat_log_thread_created ON daily_chat_log (thread_id, created_at, id)',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/main/resources/db/migration/manual/STAB-002-precheck.sql
+++ b/src/main/resources/db/migration/manual/STAB-002-precheck.sql
@@ -1,0 +1,69 @@
+    -- STAB-002 pre-check (run before apply script)
+-- Target DB: MySQL 8.x
+
+-- 1) Null checks
+SELECT COUNT(*) AS user_setting_null_user_id
+FROM user_setting
+WHERE user_id IS NULL;
+
+SELECT COUNT(*) AS user_memory_null_user_id
+FROM user_memory
+WHERE user_id IS NULL;
+
+-- 2) Duplicate checks for 1:1 tables
+SELECT user_id, COUNT(*) AS duplicate_count
+FROM user_setting
+GROUP BY user_id
+HAVING COUNT(*) > 1;
+
+SELECT user_id, COUNT(*) AS duplicate_count
+FROM user_memory
+GROUP BY user_id
+HAVING COUNT(*) > 1;
+
+-- 3) Orphan checks against user table
+SELECT COUNT(*) AS user_setting_orphan_count
+FROM user_setting s
+LEFT JOIN `user` u ON u.id = s.user_id
+WHERE s.user_id IS NOT NULL
+  AND u.id IS NULL;
+
+SELECT COUNT(*) AS user_memory_orphan_count
+FROM user_memory m
+LEFT JOIN `user` u ON u.id = m.user_id
+WHERE m.user_id IS NOT NULL
+  AND u.id IS NULL;
+
+-- 4) Date range checks (for CHECK constraints)
+SELECT COUNT(*) AS thread_invalid_month_or_day
+FROM thread
+WHERE month < 1 OR month > 12 OR day < 1 OR day > 31;
+
+SELECT COUNT(*) AS diary_invalid_month_or_day
+FROM diary
+WHERE month < 1 OR month > 12 OR day < 1 OR day > 31;
+
+-- 5) Existing FK/unique/index visibility (for review)
+SELECT table_name, constraint_name, constraint_type
+FROM information_schema.table_constraints
+WHERE table_schema = DATABASE()
+  AND table_name IN ('user_setting', 'user_memory', 'thread', 'diary', 'daily_chat_log')
+ORDER BY table_name, constraint_type, constraint_name;
+
+-- 6) FK action rules for target 1:1 tables
+SELECT
+  rc.constraint_name,
+  rc.table_name,
+  rc.referenced_table_name,
+  rc.update_rule,
+  rc.delete_rule
+FROM information_schema.referential_constraints rc
+WHERE rc.constraint_schema = DATABASE()
+  AND rc.table_name IN ('user_setting', 'user_memory');
+
+-- 7) Nullability check on target FK columns
+SELECT table_name, column_name, is_nullable
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name IN ('user_setting', 'user_memory')
+  AND column_name = 'user_id';

--- a/src/main/resources/db/migration/manual/STAB-002-rollback.sql
+++ b/src/main/resources/db/migration/manual/STAB-002-rollback.sql
@@ -1,0 +1,180 @@
+-- STAB-002 rollback script
+-- Target DB: MySQL 8.x
+-- Note: This reverts named constraints/indexes introduced by STAB-002 apply script.
+
+-- =========================
+-- A. Drop added indexes (if present)
+-- =========================
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'daily_chat_log'
+                   AND index_name = 'idx_daily_chat_log_thread_created');
+SET @sql := IF(@has_idx > 0,
+               'DROP INDEX idx_daily_chat_log_thread_created ON daily_chat_log',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'diary'
+                   AND index_name = 'idx_diary_thread_active_created');
+SET @sql := IF(@has_idx > 0,
+               'DROP INDEX idx_diary_thread_active_created ON diary',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'diary'
+                   AND index_name = 'idx_diary_feed_user_active_id');
+SET @sql := IF(@has_idx > 0,
+               'DROP INDEX idx_diary_feed_user_active_id ON diary',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'diary'
+                   AND index_name = 'idx_diary_user_month_active_day_created');
+SET @sql := IF(@has_idx > 0,
+               'DROP INDEX idx_diary_user_month_active_day_created ON diary',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'diary'
+                   AND index_name = 'idx_diary_user_day_active_created');
+SET @sql := IF(@has_idx > 0,
+               'DROP INDEX idx_diary_user_day_active_created ON diary',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'user_setting'
+                   AND index_name = 'idx_user_setting_notification_target');
+SET @sql := IF(@has_idx > 0,
+               'DROP INDEX idx_user_setting_notification_target ON user_setting',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'user_setting'
+                   AND index_name = 'ux_user_setting_user_id');
+SET @sql := IF(@has_idx > 0,
+               'DROP INDEX ux_user_setting_user_id ON user_setting',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx := (SELECT COUNT(*) FROM information_schema.statistics
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'user_memory'
+                   AND index_name = 'ux_user_memory_user_id');
+SET @sql := IF(@has_idx > 0,
+               'DROP INDEX ux_user_memory_user_id ON user_memory',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- B. Drop added CHECK constraints (if present)
+-- =========================
+SET @has_chk := (SELECT COUNT(*) FROM information_schema.table_constraints
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'thread'
+                   AND constraint_name = 'chk_thread_month'
+                   AND constraint_type = 'CHECK');
+SET @sql := IF(@has_chk > 0,
+               'ALTER TABLE thread DROP CHECK chk_thread_month',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_chk := (SELECT COUNT(*) FROM information_schema.table_constraints
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'thread'
+                   AND constraint_name = 'chk_thread_day'
+                   AND constraint_type = 'CHECK');
+SET @sql := IF(@has_chk > 0,
+               'ALTER TABLE thread DROP CHECK chk_thread_day',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_chk := (SELECT COUNT(*) FROM information_schema.table_constraints
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'diary'
+                   AND constraint_name = 'chk_diary_month'
+                   AND constraint_type = 'CHECK');
+SET @sql := IF(@has_chk > 0,
+               'ALTER TABLE diary DROP CHECK chk_diary_month',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_chk := (SELECT COUNT(*) FROM information_schema.table_constraints
+                 WHERE table_schema = DATABASE()
+                   AND table_name = 'diary'
+                   AND constraint_name = 'chk_diary_day'
+                   AND constraint_type = 'CHECK');
+SET @sql := IF(@has_chk > 0,
+               'ALTER TABLE diary DROP CHECK chk_diary_day',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- C. Drop named FK constraints introduced by STAB-002 (if present)
+-- =========================
+SET @has_fk := (SELECT COUNT(*) FROM information_schema.table_constraints
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'user_setting'
+                  AND constraint_name = 'fk_user_setting_user'
+                  AND constraint_type = 'FOREIGN KEY');
+SET @sql := IF(@has_fk > 0,
+               'ALTER TABLE user_setting DROP FOREIGN KEY fk_user_setting_user',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_fk := (SELECT COUNT(*) FROM information_schema.table_constraints
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'user_memory'
+                  AND constraint_name = 'fk_user_memory_user'
+                  AND constraint_type = 'FOREIGN KEY');
+SET @sql := IF(@has_fk > 0,
+               'ALTER TABLE user_memory DROP FOREIGN KEY fk_user_memory_user',
+               'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- D. Optional nullable rollback (disabled by default)
+-- =========================
+-- Uncomment only when you intentionally want to relax constraints.
+-- ALTER TABLE user_setting MODIFY COLUMN user_id BIGINT NULL;
+-- ALTER TABLE user_memory MODIFY COLUMN user_id BIGINT NULL;
+


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
STAB-002 이슈 대응으로 핵심 도메인 DB 제약 강화를 위한 precheck/apply/rollback 스크립트를 추가하고,
애플리케이션 코드와 DB 제약 정합성을 맞췄습니다.
실 DB 검증 결과 기준으로 `user_setting`, `user_memory`의 `user_id`는 NOT NULL, FK는 ON DELETE CASCADE로 정규화되었습니다.

## 📋 변경 사항
- 수동 마이그레이션 스크립트 추가
  - `src/main/resources/db/migration/manual/STAB-002-precheck.sql`
  - `src/main/resources/db/migration/manual/STAB-002-apply.sql`
  - `src/main/resources/db/migration/manual/STAB-002-rollback.sql`
  - `src/main/resources/db/migration/manual/STAB-002-README.md`
- 코드 정합성 보강
  - `src/main/java/com/melissa/diary/domain/UserSetting.java`
    - `@JoinColumn(name = "user_id", nullable = false)` 명시
  - `src/main/java/com/melissa/diary/service/UserService.java`
    - 회원탈퇴 시 `userMemoryRepository.deleteByUserId(userId)` 추가
- 운영 DB 확인 결과(사용자 수행)
  - `user_setting.user_id`, `user_memory.user_id` 모두 `IS_NULLABLE = NO`
  - FK `DELETE_RULE = CASCADE`, `UPDATE_RULE = RESTRICT`

## 🔍 Code Review
- apply 스크립트가 기존 FK(`NO ACTION`) 환경에서도 안전하게 `CASCADE`로 정규화하는지
- rollback 스크립트가 추가된 제약/인덱스를 역순으로 정확히 제거하는지
- `UserSetting`의 nullable=false 변경이 기존 비즈니스 플로우와 충돌 없는지
- `deleteUser`에서 `user_memory` 삭제 추가가 사이드이펙트 없이 동작하는지
- README 실행 순서(precheck -> apply -> post-check -> rollback)가 운영 절차로 충분한지

## 📸 ScreenShot
- N/A (DB migration script + backend code 변경 PR)