### PR TITLE
feat(stab-004): Diary image_status explicit state + state transition guards 적용

### DIFF
--- a/src/main/java/com/melissa/diary/converter/DiaryConverter.java
+++ b/src/main/java/com/melissa/diary/converter/DiaryConverter.java
@@ -24,6 +24,7 @@ public class DiaryConverter {
                 .hashtag1(diary.getHashtag1())
                 .hashtag2(diary.getHashtag2())
                 .imageUrl(diary.getImageUrl())
+                .imageStatus(diary.getImageStatus() != null ? diary.getImageStatus().name() : null)
                 .version(diary.getVersion())
                 .createdAt(diary.getCreatedAt())
                 .build();
@@ -40,6 +41,7 @@ public class DiaryConverter {
                 .hashtag1(diary.getHashtag1())
                 .hashtag2(diary.getHashtag2())
                 .imageUrl(diary.getImageUrl())
+                .imageStatus(diary.getImageStatus() != null ? diary.getImageStatus().name() : null)
                 .build();
     }
 }

--- a/src/main/java/com/melissa/diary/domain/Diary.java
+++ b/src/main/java/com/melissa/diary/domain/Diary.java
@@ -2,6 +2,7 @@ package com.melissa.diary.domain;
 
 import com.melissa.diary.converter.EncryptionAttributeConverter;
 import com.melissa.diary.domain.common.BaseEntity;
+import com.melissa.diary.domain.enums.DiaryImageStatus;
 import com.melissa.diary.domain.enums.DiaryType;
 import com.melissa.diary.domain.enums.Mood;
 import jakarta.persistence.*;
@@ -66,6 +67,11 @@ public class Diary extends BaseEntity {
     
     @Column(length = 255)
     private String imageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "image_status", nullable = false, length = 20)
+    @Builder.Default
+    private DiaryImageStatus imageStatus = DiaryImageStatus.NONE;
     
     @Column(nullable = false)
     @Builder.Default
@@ -74,5 +80,24 @@ public class Diary extends BaseEntity {
     @Column(nullable = false)
     @Builder.Default
     private boolean isActive = true;
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    public void requestImageGeneration() {
+        this.imageStatus = DiaryImageStatus.PENDING;
+        this.imageUrl = null;
+    }
+
+    public void markImageReady(String imageUrl) {
+        this.imageStatus = DiaryImageStatus.READY;
+        this.imageUrl = imageUrl;
+    }
+
+    public void markImageFailed(String fallbackImageUrl) {
+        this.imageStatus = DiaryImageStatus.FAILED;
+        this.imageUrl = fallbackImageUrl;
+    }
 }
 

--- a/src/main/java/com/melissa/diary/domain/ExpoPushToken.java
+++ b/src/main/java/com/melissa/diary/domain/ExpoPushToken.java
@@ -55,5 +55,13 @@ public class ExpoPushToken {
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    public void markValid() {
+        this.invalid = false;
+    }
+
+    public void markInvalid() {
+        this.invalid = true;
+    }
 }
 

--- a/src/main/java/com/melissa/diary/domain/enums/DiaryImageStatus.java
+++ b/src/main/java/com/melissa/diary/domain/enums/DiaryImageStatus.java
@@ -1,0 +1,9 @@
+package com.melissa.diary.domain.enums;
+
+public enum DiaryImageStatus {
+    NONE,
+    PENDING,
+    READY,
+    FAILED
+}
+

--- a/src/main/java/com/melissa/diary/service/DiaryImageService.java
+++ b/src/main/java/com/melissa/diary/service/DiaryImageService.java
@@ -2,6 +2,7 @@ package com.melissa.diary.service;
 
 import com.melissa.diary.ai.ImageGenerator;
 import com.melissa.diary.domain.Diary;
+import com.melissa.diary.domain.enums.DiaryImageStatus;
 import com.melissa.diary.repository.DiaryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,72 +10,78 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-/**
- * Diary 이미지 생성 서비스
- * - DALL-E로 이미지 생성
- * - S3에 업로드
- * - DB에 URL 저장
- */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class DiaryImageService {
-    
+
+    private static final String DEFAULT_IMG =
+            "https://melissa-s3.s3.ap-northeast-2.amazonaws.com/default.png";
+
     private final DiaryRepository diaryRepository;
     private final ImageGenerator imageGenerator;
     private final DiaryImagePromptRefinerService refiner;
-    
-    private static final String DEFAULT_IMG =
-            "https://melissa-s3.s3.ap-northeast-2.amazonaws.com/default.png";
-    
-    /**
-     * diaryId 기준으로 이미지를 생성하고 imageUrl을 저장한다.
-     * 비동기로 실행됨
-     */
+
     public void generateAndSaveImage(Long diaryId) {
         Diary diary = diaryRepository.findById(diaryId).orElse(null);
         if (diary == null) {
             log.error("[Async-DiaryImage] diaryId={} not found", diaryId);
             return;
         }
-        
-        // 1차 프롬프트 생성
+
+        if (!diary.isActive()) {
+            log.warn("[Async-DiaryImage] diaryId={} is inactive. skip image generation", diaryId);
+            return;
+        }
+
+        if (diary.getImageStatus() != DiaryImageStatus.PENDING) {
+            log.warn("[Async-DiaryImage] diaryId={} imageStatus={} is not PENDING. skip stale event",
+                    diaryId, diary.getImageStatus());
+            return;
+        }
+
         String rawPrompt = buildImagePrompt(diary);
-        // 2차 LLM으로 프롬프트 정제
         String finalPrompt = refiner.refine(rawPrompt);
-        
+
         try {
-            // DALL-E로 이미지 생성 → S3 diary 폴더에 업로드
             String url = imageGenerator.genDiaryImage(finalPrompt);
-            updateDiaryImage(diary, url);
-            log.info("[Async-DiaryImage] 이미지 생성 완료. diaryId={}, url={}", diaryId, url);
+            markImageReady(diaryId, url);
+            log.info("[Async-DiaryImage] image generation completed. diaryId={}, url={}", diaryId, url);
         } catch (Exception e) {
-            log.error("[Async-DiaryImage] diaryId={} 처리 실패", diaryId, e);
-            updateDiaryImage(diary, DEFAULT_IMG);  // 실패 시 기본 이미지
+            log.error("[Async-DiaryImage] diaryId={} processing failed", diaryId, e);
+            markImageFailed(diaryId, DEFAULT_IMG);
         }
     }
-    
-    /**
-     * imageUrl 컬럼만 갱신
-     */
+
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void updateDiaryImage(Diary diary, String url) {
-        diary.setImageUrl(url);
+    public void markImageReady(Long diaryId, String url) {
+        Diary diary = diaryRepository.findById(diaryId).orElse(null);
+        if (diary == null || diary.getImageStatus() != DiaryImageStatus.PENDING) {
+            return;
+        }
+
+        diary.markImageReady(url);
         diaryRepository.save(diary);
     }
-    
-    /**
-     * Diary 내용 기반으로 이미지 생성 프롬프트 작성
-     */
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markImageFailed(Long diaryId, String fallbackUrl) {
+        Diary diary = diaryRepository.findById(diaryId).orElse(null);
+        if (diary == null || diary.getImageStatus() != DiaryImageStatus.PENDING) {
+            return;
+        }
+
+        diary.markImageFailed(fallbackUrl);
+        diaryRepository.save(diary);
+    }
+
     private String buildImagePrompt(Diary diary) {
         StringBuilder prompt = new StringBuilder();
-        
-        // 제목 기반
+
         if (diary.getTitle() != null && !diary.getTitle().isBlank()) {
             prompt.append("제목: ").append(diary.getTitle()).append("\n");
         }
-        
-        // 내용 기반 (최대 200자)
+
         if (diary.getContent() != null && !diary.getContent().isBlank()) {
             String content = diary.getContent();
             if (content.length() > 200) {
@@ -82,13 +89,11 @@ public class DiaryImageService {
             }
             prompt.append("내용: ").append(content).append("\n");
         }
-        
-        // 기분 기반
+
         if (diary.getMood() != null) {
             prompt.append("기분: ").append(diary.getMood().name()).append("\n");
         }
-        
-        // 해시태그 기반
+
         if (diary.getHashtag1() != null) {
             prompt.append("키워드: ").append(diary.getHashtag1());
             if (diary.getHashtag2() != null) {
@@ -96,9 +101,9 @@ public class DiaryImageService {
             }
             prompt.append("\n");
         }
-        
-        prompt.append("\n위 내용을 바탕으로 일기의 분위기를 표현하는 따뜻하고 감성적인 이미지를 생성해주세요.");
-        
+
+        prompt.append("\n위 내용을 바탕으로 감성적인 일기 삽화를 생성해 주세요.");
+
         return prompt.toString();
     }
 }

--- a/src/main/java/com/melissa/diary/service/DiaryService.java
+++ b/src/main/java/com/melissa/diary/service/DiaryService.java
@@ -9,6 +9,7 @@ import com.melissa.diary.domain.DailyChatLog;
 import com.melissa.diary.domain.Diary;
 import com.melissa.diary.domain.Thread;
 import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.enums.DiaryImageStatus;
 import com.melissa.diary.domain.enums.DiaryType;
 import com.melissa.diary.domain.enums.Mood;
 import com.melissa.diary.domain.enums.Role;
@@ -139,6 +140,7 @@ public class DiaryService {
                 .hashtag1(hashtagData.getHashTag1())  // LLM 생성
                 .hashtag2(hashtagData.getHashTag2())  // LLM 생성
                 .imageUrl(null)  // 초기에는 null, 비동기로 생성
+                .imageStatus(Boolean.TRUE.equals(request.getGenerateImage()) ? DiaryImageStatus.PENDING : DiaryImageStatus.NONE)
                 .version(1)
                 .isActive(true)
                 .build();
@@ -230,6 +232,7 @@ public class DiaryService {
                 .hashtag1(diaryData.getHashTag1())
                 .hashtag2(diaryData.getHashTag2())
                 .imageUrl(null)  // 초기에는 null, 비동기로 생성
+                .imageStatus(Boolean.TRUE.equals(request.getGenerateImage()) ? DiaryImageStatus.PENDING : DiaryImageStatus.NONE)
                 .version(1)
                 .isActive(true)
                 .build();
@@ -324,7 +327,7 @@ public class DiaryService {
         // 이미지 재생성 요청 (선택적)
         if (Boolean.TRUE.equals(request.getGenerateImage())) {
             quotaService.checkAndConsume(user, UsageCost.SUMMARY);
-            diary.setImageUrl(null);  // 기존 이미지 초기화
+            diary.requestImageGeneration();
             diaryRepository.save(diary);
             publisher.publishEvent(new DiaryImageEvent(diary.getId()));
         }
@@ -361,7 +364,7 @@ public class DiaryService {
         }
         
         // 소프트 삭제
-        diary.setActive(false);
+        diary.deactivate();
         diaryRepository.save(diary);
         
         log.info("[Diary] 일기 삭제 완료. userId={}, diaryId={}", userId, diaryId);
@@ -390,6 +393,7 @@ public class DiaryService {
                 .hashtag1(diary.getHashtag1())
                 .hashtag2(diary.getHashtag2())
                 .imageUrl(diary.getImageUrl())
+                .imageStatus(diary.getImageStatus() != null ? diary.getImageStatus().name() : null)
                 .version(diary.getVersion())
                 .createdAt(diary.getCreatedAt())
                 .build();

--- a/src/main/java/com/melissa/diary/service/ExpoPushTokenService.java
+++ b/src/main/java/com/melissa/diary/service/ExpoPushTokenService.java
@@ -23,95 +23,82 @@ import java.util.stream.Collectors;
 @Slf4j
 @RequiredArgsConstructor
 public class ExpoPushTokenService {
-    
+
     private final ExpoPushTokenRepository expoPushTokenRepository;
     private final UserRepository userRepository;
-    
+
     /**
-     * Expo Push Token 등록 (로그인 O)
-     * - 이미 존재하는 토큰이면 사용자 정보만 업데이트
-     * - 새 토큰이면 신규 등록
+     * Expo Push Token 등록/업데이트
      */
     @Transactional
     public ExpoPushTokenResponseDTO.TokenResponse registerToken(
-            Long userId, 
+            Long userId,
             ExpoPushTokenRequestDTO.RegisterTokenRequest request) {
-        
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
-        
+
         String tokenValue = request.getExpoPushToken();
-        
-        // 이미 존재하는 토큰인지 확인
+
         Optional<ExpoPushToken> existingToken = expoPushTokenRepository.findByExpoPushToken(tokenValue);
-        
         if (existingToken.isPresent()) {
-            // 기존 토큰이 있으면 사용자 정보 업데이트
             ExpoPushToken token = existingToken.get();
             token.setUser(user);
             token.setPlatform(request.getPlatform());
             token.setDeviceId(request.getDeviceId());
-            token.setInvalid(false); // 다시 활성화
-            
+            token.markValid();
+
             ExpoPushToken savedToken = expoPushTokenRepository.save(token);
-            log.info("[ExpoPushToken] 기존 토큰 업데이트 완료. userId={}, tokenId={}", userId, savedToken.getId());
-            
+            log.info("[ExpoPushToken] updated existing token. userId={}, tokenId={}", userId, savedToken.getId());
             return ExpoPushTokenConverter.toResponse(savedToken);
-        } else {
-            // 새 토큰 등록
-            ExpoPushToken newToken = ExpoPushTokenConverter.toEntity(request, user);
-            
-            try {
-                ExpoPushToken savedToken = expoPushTokenRepository.save(newToken);
-                log.info("[ExpoPushToken] 새 토큰 등록 완료. userId={}, tokenId={}", userId, savedToken.getId());
-                
-                return ExpoPushTokenConverter.toResponse(savedToken);
-            } catch (DataIntegrityViolationException e) {
-                log.error("[ExpoPushToken] 토큰 등록 실패 (중복 가능성). userId={}, token={}", userId, tokenValue, e);
-                throw new ErrorHandler(ErrorStatus.EXPO_TOKEN_ALREADY_EXISTS);
-            }
+        }
+
+        ExpoPushToken newToken = ExpoPushTokenConverter.toEntity(request, user);
+        try {
+            ExpoPushToken savedToken = expoPushTokenRepository.save(newToken);
+            log.info("[ExpoPushToken] registered new token. userId={}, tokenId={}", userId, savedToken.getId());
+            return ExpoPushTokenConverter.toResponse(savedToken);
+        } catch (DataIntegrityViolationException e) {
+            log.error("[ExpoPushToken] token registration failed (likely duplicate). userId={}, token={}",
+                    userId, tokenValue, e);
+            throw new ErrorHandler(ErrorStatus.EXPO_TOKEN_ALREADY_EXISTS);
         }
     }
-    
+
     /**
      * 사용자별 토큰 목록 조회
      */
     @Transactional(readOnly = true)
     public List<ExpoPushTokenResponseDTO.TokenResponse> getUserTokens(Long userId) {
         List<ExpoPushToken> tokens = expoPushTokenRepository.findByUserId(userId);
-        
-        log.info("[ExpoPushToken] 토큰 목록 조회 완료. userId={}, count={}", userId, tokens.size());
-        
+        log.info("[ExpoPushToken] fetched user tokens. userId={}, count={}", userId, tokens.size());
+
         return tokens.stream()
                 .map(ExpoPushTokenConverter::toResponse)
                 .collect(Collectors.toList());
     }
-    
+
     /**
-     * 유효한 토큰만 조회 (배치 발송용)
+     * 유효한 토큰 전체 조회 (배치 발송용)
      */
     @Transactional(readOnly = true)
     public List<ExpoPushToken> getAllValidTokens() {
         List<ExpoPushToken> tokens = expoPushTokenRepository.findByInvalidFalse();
-        
-        log.info("[ExpoPushToken] 유효한 토큰 전체 조회 완료. count={}", tokens.size());
-        
+        log.info("[ExpoPushToken] fetched valid tokens. count={}", tokens.size());
         return tokens;
     }
-    
+
     /**
-     * 특정 토큰 삭제
+     * Expo Push Token 값으로 토큰 삭제
      */
     @Transactional
     public ExpoPushTokenResponseDTO.DeleteResponse deleteToken(String expoPushToken) {
         ExpoPushToken token = expoPushTokenRepository.findByExpoPushToken(expoPushToken)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.EXPO_TOKEN_NOT_FOUND));
-        
+
         expoPushTokenRepository.delete(token);
-        
-        log.info("[ExpoPushToken] 토큰 삭제 완료. tokenId={}, token={}", token.getId(), expoPushToken);
-        
+        log.info("[ExpoPushToken] deleted token. tokenId={}, token={}", token.getId(), expoPushToken);
+
         return ExpoPushTokenConverter.toDeleteResponse(expoPushToken);
     }
 }
-

--- a/src/main/java/com/melissa/diary/service/NotificationService.java
+++ b/src/main/java/com/melissa/diary/service/NotificationService.java
@@ -18,149 +18,139 @@ import java.time.LocalDate;
 import java.util.List;
 
 /**
- * 푸시 알림 발송 서비스
+ * Expo Push API 기반 푸시 알림 배치 발송 서비스
  */
 @Slf4j
 @Service
 public class NotificationService {
-    
-    private static final int BATCH_SIZE = 100;  // 배치당 처리 인원
-    
+
+    private static final int BATCH_SIZE = 100;
+
     private final UserSettingRepository userSettingRepository;
     private final ExpoPushTokenRepository expoPushTokenRepository;
     private final WebClient expoWebClient;
-    
+
     public NotificationService(UserSettingRepository userSettingRepository,
-                              ExpoPushTokenRepository expoPushTokenRepository,
-                              @Qualifier("expoWebClient") WebClient expoWebClient) {
+                               ExpoPushTokenRepository expoPushTokenRepository,
+                               @Qualifier("expoWebClient") WebClient expoWebClient) {
         this.userSettingRepository = userSettingRepository;
         this.expoPushTokenRepository = expoPushTokenRepository;
         this.expoWebClient = expoWebClient;
     }
-    
+
     /**
-     * 배치 순차 발송
-     * 비동기 시작으로 스케줄러 블로킹 방지, 100명씩 배치 트랜잭션으로 I/O 최적화
+     * 스케줄러 스레드 블로킹을 피하기 위한 비동기 진입점
      */
     @Async("notificationExecutor")
     public void sendBatchNotifications(List<UserSetting> userSettings) {
         int totalCount = userSettings.size();
         int batchCount = (int) Math.ceil((double) totalCount / BATCH_SIZE);
         long totalStartTime = System.currentTimeMillis();
-        
+
         int totalSuccess = 0;
         int totalFail = 0;
-        
-        log.info("[Notification] 배치 순차 발송 시작. 전체: {}명, 배치 수: {}, 스레드: {}", 
+
+        log.info("[Notification] batch notification started. totalUsers={}, batches={}, thread={}",
                 totalCount, batchCount, Thread.currentThread().getName());
-        
+
         for (int i = 0; i < totalCount; i += BATCH_SIZE) {
             int endIndex = Math.min(i + BATCH_SIZE, totalCount);
             List<UserSetting> batch = userSettings.subList(i, endIndex);
             int batchNumber = (i / BATCH_SIZE) + 1;
-            
-            // 배치 단위 트랜잭션 처리
+
             try {
                 int[] result = processBatchWithTransaction(batch, batchNumber, batchCount);
                 totalSuccess += result[0];
                 totalFail += result[1];
             } catch (Exception e) {
-                log.error("[Notification] 배치 {}/{} 처리 실패", batchNumber, batchCount, e);
+                log.error("[Notification] batch {}/{} failed", batchNumber, batchCount, e);
                 totalFail += batch.size();
             }
         }
-        
+
         long totalElapsedTime = System.currentTimeMillis() - totalStartTime;
-        log.info("[Notification] 전체 발송 완료. 전체: {}명, 성공: {}, 실패: {}, 총 소요: {}ms, 스레드: {}", 
+        log.info("[Notification] batch notification completed. totalUsers={}, success={}, fail={}, elapsed={}ms, thread={}",
                 totalCount, totalSuccess, totalFail, totalElapsedTime, Thread.currentThread().getName());
     }
-    
+
     /**
-     * 배치 단위 트랜잭션 처리 (100명씩)
-     * DB I/O 최적화를 위해 배치를 하나의 트랜잭션으로 처리
+     * 배치 단위를 새로운 트랜잭션으로 처리
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public int[] processBatchWithTransaction(List<UserSetting> batch, int batchNumber, int totalBatches) {
         long batchStartTime = System.currentTimeMillis();
         int successCount = 0;
         int failCount = 0;
-        
-        log.info("[Notification] 배치 {}/{} 발송 시작. 대상: {}명", 
-                batchNumber, totalBatches, batch.size());
-        
+
+        log.info("[Notification] batch {}/{} started. size={}", batchNumber, totalBatches, batch.size());
+
         for (UserSetting userSetting : batch) {
             try {
                 sendNotificationToUser(userSetting);
                 successCount++;
             } catch (Exception e) {
-                log.error("[Notification] 사용자 알림 발송 실패. userId={}", 
+                log.error("[Notification] failed to send notification to userId={}",
                         userSetting.getUser().getId(), e);
                 failCount++;
             }
         }
-        
+
         long batchElapsedTime = System.currentTimeMillis() - batchStartTime;
-        log.info("[Notification] 배치 {}/{} 발송 완료. 성공: {}, 실패: {}, 소요: {}ms", 
+        log.info("[Notification] batch {}/{} completed. success={}, fail={}, elapsed={}ms",
                 batchNumber, totalBatches, successCount, failCount, batchElapsedTime);
-        
+
         return new int[]{successCount, failCount};
     }
-    
+
     /**
-     * 개별 사용자 알림 발송
-     * 중복 발송 방지를 위해 발송 전 lastSentDate 먼저 갱신
-     * 배치 트랜잭션 내에서 실행됨
+     * 단일 사용자 알림 발송
      */
     public void sendNotificationToUser(UserSetting userSetting) {
         Long userId = userSetting.getUser().getId();
-        
-        // 중복 발송 방지: 발송 전에 먼저 lastSentDate 갱신 (같은 트랜잭션 내)
+
+        // 날짜 기준 중복 발송 방지: 먼저 lastSentDate를 갱신한 뒤 발송
         boolean updated = updateLastSentDateIfNotTodayInternal(userSetting);
         if (!updated) {
-            log.debug("[Notification] 이미 오늘 발송됨. userId={}", userId);
+            log.debug("[Notification] already sent today. userId={}", userId);
             return;
         }
-        
-        // 유효한 토큰 목록 조회
+
         List<ExpoPushToken> validTokens = userSetting.getUser().getExpoPushTokenList().stream()
                 .filter(token -> !token.getInvalid())
                 .toList();
-        
+
         if (validTokens.isEmpty()) {
-            log.warn("[Notification] 유효한 토큰 없음. userId={}", userId);
+            log.warn("[Notification] no valid token. userId={}", userId);
             return;
         }
-        
-        log.info("[Notification] 사용자 알림 발송 시작. userId={}, 토큰 수={}", userId, validTokens.size());
-        
+
+        log.info("[Notification] sending notification. userId={}, tokenCount={}", userId, validTokens.size());
+
         int tokenSuccessCount = 0;
         int tokenFailCount = 0;
-        
-        // 알림 메시지 구성
+
         String title = buildNotificationTitle(userSetting);
         String body = buildNotificationBody(userSetting);
-        
-        // 각 토큰에 발송
+
         for (ExpoPushToken token : validTokens) {
             try {
                 sendPushNotification(token.getExpoPushToken(), title, body);
                 tokenSuccessCount++;
-                log.info("[Notification] 토큰 발송 성공. userId={}, tokenId={}", userId, token.getId());
+                log.info("[Notification] token send success. userId={}, tokenId={}", userId, token.getId());
             } catch (InvalidTokenException e) {
-                // Invalid 토큰은 비활성화 (같은 트랜잭션 내)
                 markTokenAsInvalidInternal(token);
                 tokenFailCount++;
-                log.warn("[Notification] Invalid 토큰 비활성화. userId={}, tokenId={}", userId, token.getId());
+                log.warn("[Notification] invalid token disabled. userId={}, tokenId={}", userId, token.getId());
             } catch (Exception e) {
                 tokenFailCount++;
-                log.error("[Notification] 토큰 발송 실패. userId={}, tokenId={}", userId, token.getId(), e);
+                log.error("[Notification] token send failed. userId={}, tokenId={}", userId, token.getId(), e);
             }
         }
-        
-        log.info("[Notification] 사용자 알림 발송 완료. userId={}, 토큰 성공: {}, 실패: {}", 
+
+        log.info("[Notification] user notification completed. userId={}, success={}, fail={}",
                 userId, tokenSuccessCount, tokenFailCount);
     }
-    
+
     /**
      * Expo Push API 호출
      */
@@ -172,95 +162,86 @@ public class NotificationService {
                 .sound("default")
                 .priority("high")
                 .build();
-        
+
         try {
             ExpoPushNotificationDTO.PushResponse response = expoWebClient.post()
                     .bodyValue(request)
                     .retrieve()
                     .bodyToMono(ExpoPushNotificationDTO.PushResponse.class)
                     .onErrorResume(e -> {
-                        log.error("[Notification] Expo API 호출 실패. token={}", token, e);
-                        return Mono.error(new RuntimeException("Expo API 호출 실패", e));
+                        log.error("[Notification] Expo API call failed. token={}", token, e);
+                        return Mono.error(new RuntimeException("Expo API call failed", e));
                     })
                     .block();
-            
-            // 응답 검증
+
             if (response != null && response.getData() != null && !response.getData().isEmpty()) {
                 ExpoPushNotificationDTO.PushTicket ticket = response.getData().get(0);
-                
+
                 if ("error".equals(ticket.getStatus())) {
                     String errorType = ticket.getDetails() != null ? ticket.getDetails().getError() : "Unknown";
-                    
-                    // DeviceNotRegistered는 Invalid 토큰으로 처리
+
                     if ("DeviceNotRegistered".equals(errorType) || "InvalidCredentials".equals(errorType)) {
                         throw new InvalidTokenException(ticket.getMessage());
                     }
-                    
-                    throw new RuntimeException("Expo Push 실패: " + ticket.getMessage());
+
+                    throw new RuntimeException("Expo push failed: " + ticket.getMessage());
                 }
             }
-            
+
         } catch (InvalidTokenException e) {
-            throw e;  // 상위로 전파
+            throw e;
         } catch (Exception e) {
-            log.error("[Notification] 알림 발송 중 예외 발생. token={}", token, e);
-            throw new RuntimeException("알림 발송 실패", e);
+            log.error("[Notification] notification send exception. token={}", token, e);
+            throw new RuntimeException("Notification send failed", e);
         }
     }
-    
+
     /**
-     * Invalid 토큰 비활성화 (배치 트랜잭션 내에서 실행)
+     * 같은 배치 트랜잭션 내에서 Invalid 토큰 처리
      */
     private void markTokenAsInvalidInternal(ExpoPushToken token) {
         try {
-            token.setInvalid(true);
+            token.markInvalid();
             expoPushTokenRepository.save(token);
-            log.info("[Notification] 토큰 비활성화 완료. tokenId={}", token.getId());
+            log.info("[Notification] token disabled. tokenId={}", token.getId());
         } catch (Exception e) {
-            log.error("[Notification] 토큰 비활성화 실패. tokenId={}", token.getId(), e);
+            log.error("[Notification] failed to disable token. tokenId={}", token.getId(), e);
         }
     }
-    
+
     /**
-     * 발송 전 lastSentDate 갱신 (배치 트랜잭션 내에서 실행)
-     * @return 갱신 성공 여부 (true: 갱신됨, false: 이미 오늘 날짜)
+     * 오늘 아직 발송하지 않은 경우에만 lastSentDate 갱신
      */
     private boolean updateLastSentDateIfNotTodayInternal(UserSetting setting) {
         try {
             LocalDate today = LocalDate.now();
-            
-            // 이미 오늘 발송했으면 false 반환
+
             if (today.equals(setting.getLastSentDate())) {
                 return false;
             }
-            
-            // 오늘 날짜로 갱신
+
             setting.setLastSentDate(today);
             userSettingRepository.save(setting);
-            log.debug("[Notification] lastSentDate 갱신 완료. userSettingId={}, date={}", 
-                    setting.getId(), today);
+            log.debug("[Notification] lastSentDate updated. userSettingId={}, date={}", setting.getId(), today);
             return true;
-            
+
         } catch (Exception e) {
-            log.error("[Notification] lastSentDate 갱신 실패. userSettingId={}", setting.getId(), e);
+            log.error("[Notification] failed to update lastSentDate. userSettingId={}", setting.getId(), e);
             return false;
         }
     }
-    
-    // 알림 제목 생성
+
     private String buildNotificationTitle(UserSetting userSetting) {
         return "📝 오늘의 일기를 작성해보세요!";
     }
-    
-    // 알림 본문 생성
+
     private String buildNotificationBody(UserSetting userSetting) {
-        return "오늘 하루는 어땠나요? 멜리사와 대화하며 일기를 작성해보세요.";
+        return "오늘 하루는 어떠셨나요? 멜리사와 대화하며 일기를 작성해보세요.";
     }
-    
+
     public static class InvalidTokenException extends RuntimeException {
         public InvalidTokenException(String message) {
             super(message);
         }
     }
 }
-

--- a/src/main/java/com/melissa/diary/web/dto/CalendarResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/CalendarResponseDTO.java
@@ -54,6 +54,11 @@ public class CalendarResponseDTO {
         
         @Schema(description = "이미지 URL", example = "https://s3.amazonaws.com/...", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String imageUrl;
+
+        @Schema(description = "이미지 생성 상태", example = "READY",
+                allowableValues = {"NONE", "PENDING", "READY", "FAILED"},
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        private String imageStatus;
         
         @Schema(description = "버전", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private int version;
@@ -92,6 +97,11 @@ public class CalendarResponseDTO {
         
         @Schema(description = "이미지 URL", example = "https://s3.amazonaws.com/...", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String imageUrl;
+
+        @Schema(description = "이미지 생성 상태", example = "READY",
+                allowableValues = {"NONE", "PENDING", "READY", "FAILED"},
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        private String imageStatus;
     }
     
     /**

--- a/src/main/java/com/melissa/diary/web/dto/DiaryResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/DiaryResponseDTO.java
@@ -80,6 +80,11 @@ public class DiaryResponseDTO {
         
         @Schema(description = "이미지 URL (비동기 생성, 초기에는 null)", example = "https://s3.amazonaws.com/...", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String imageUrl;
+
+        @Schema(description = "이미지 생성 상태", example = "PENDING",
+                allowableValues = {"NONE", "PENDING", "READY", "FAILED"},
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        private String imageStatus;
         
         @Schema(description = "버전", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private int version;

--- a/src/main/resources/db/migration/manual/STAB-004-README.md
+++ b/src/main/resources/db/migration/manual/STAB-004-README.md
@@ -1,0 +1,55 @@
+# STAB-004 Manual Migration Guide
+
+## Purpose
+Introduce explicit diary image generation state at DB level and guard allowed values.
+
+## Scripts
+- `STAB-004-precheck.sql`
+- `STAB-004-apply.sql`
+- `STAB-004-rollback.sql`
+
+## Run Order
+1. Run `STAB-004-precheck.sql`
+2. Review precheck results
+3. Run `STAB-004-apply.sql`
+4. Run verification queries (below)
+5. If needed, run `STAB-004-rollback.sql`
+
+## Backfill Rule
+- `image_url IS NOT NULL` -> `image_status = 'READY'`
+- `image_url IS NULL` -> `image_status = 'NONE'`
+
+This is a conservative rule for legacy rows because old schema did not distinguish `PENDING` vs `NONE`.
+
+## Apply Verification Queries
+```sql
+SELECT COUNT(*) AS image_status_null_count
+FROM diary
+WHERE image_status IS NULL;
+
+SELECT COUNT(*) AS image_status_invalid_count
+FROM diary
+WHERE image_status NOT IN ('NONE', 'PENDING', 'READY', 'FAILED');
+
+SELECT image_status, COUNT(*) AS cnt
+FROM diary
+GROUP BY image_status
+ORDER BY image_status;
+
+SELECT table_name, constraint_name, constraint_type
+FROM information_schema.table_constraints
+WHERE table_schema = DATABASE()
+  AND table_name = 'diary'
+  AND constraint_name = 'chk_diary_image_status';
+
+SELECT column_name, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'diary'
+  AND column_name = 'image_status';
+```
+
+## Caution
+- MySQL DDL is auto-commit. If apply fails midway, partial changes may remain.
+- Rollback drops `image_status` column and all values in it.
+

--- a/src/main/resources/db/migration/manual/STAB-004-apply.sql
+++ b/src/main/resources/db/migration/manual/STAB-004-apply.sql
@@ -1,0 +1,100 @@
+-- STAB-004 apply script
+-- Target DB: MySQL 8.x
+-- Purpose:
+-- 1) add explicit image state column on diary
+-- 2) backfill legacy rows
+-- 3) enforce NOT NULL + DEFAULT + CHECK guard
+
+-- =========================
+-- A. Fail-fast assertion (only when column already exists)
+-- =========================
+DROP PROCEDURE IF EXISTS sp_stab004_assert;
+DELIMITER //
+CREATE PROCEDURE sp_stab004_assert()
+BEGIN
+    DECLARE v_has_col BIGINT DEFAULT 0;
+    DECLARE v_invalid BIGINT DEFAULT 0;
+
+    SELECT COUNT(*) INTO v_has_col
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'diary'
+      AND column_name = 'image_status';
+
+    IF v_has_col > 0 THEN
+        SELECT COUNT(*) INTO v_invalid
+        FROM diary
+        WHERE image_status IS NOT NULL
+          AND image_status NOT IN ('NONE', 'PENDING', 'READY', 'FAILED');
+
+        IF v_invalid > 0 THEN
+            SIGNAL SQLSTATE '45000'
+                SET MESSAGE_TEXT = 'STAB-004 blocked: diary.image_status contains invalid values';
+        END IF;
+    END IF;
+END //
+DELIMITER ;
+
+CALL sp_stab004_assert();
+DROP PROCEDURE IF EXISTS sp_stab004_assert;
+
+-- =========================
+-- B. Add column (idempotent)
+-- =========================
+SET @has_col := (
+    SELECT COUNT(*)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'diary'
+      AND column_name = 'image_status'
+);
+
+SET @sql := IF(
+    @has_col = 0,
+    'ALTER TABLE diary ADD COLUMN image_status VARCHAR(20) NULL AFTER image_url',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- C. Backfill legacy rows
+-- Rule:
+-- - image_url is present  -> READY
+-- - image_url is missing  -> NONE
+-- =========================
+UPDATE diary
+SET image_status = CASE
+    WHEN image_url IS NULL OR TRIM(image_url) = '' THEN 'NONE'
+    ELSE 'READY'
+END
+WHERE image_status IS NULL;
+
+-- =========================
+-- D. Enforce NOT NULL + DEFAULT
+-- =========================
+ALTER TABLE diary
+    MODIFY COLUMN image_status VARCHAR(20) NOT NULL DEFAULT 'NONE';
+
+-- =========================
+-- E. Add CHECK guard (idempotent)
+-- =========================
+SET @has_chk := (
+    SELECT COUNT(*)
+    FROM information_schema.table_constraints
+    WHERE table_schema = DATABASE()
+      AND table_name = 'diary'
+      AND constraint_name = 'chk_diary_image_status'
+      AND constraint_type = 'CHECK'
+);
+
+SET @sql := IF(
+    @has_chk = 0,
+    'ALTER TABLE diary ADD CONSTRAINT chk_diary_image_status CHECK (image_status IN (''NONE'', ''PENDING'', ''READY'', ''FAILED''))',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+

--- a/src/main/resources/db/migration/manual/STAB-004-precheck.sql
+++ b/src/main/resources/db/migration/manual/STAB-004-precheck.sql
@@ -1,0 +1,66 @@
+-- STAB-004 pre-check (run before apply script)
+-- Target DB: MySQL 8.x
+-- Purpose: inspect diary image status migration readiness
+
+-- 1) Baseline counts
+SELECT COUNT(*) AS diary_total_count
+FROM diary;
+
+SELECT COUNT(*) AS diary_image_url_null_count
+FROM diary
+WHERE image_url IS NULL;
+
+SELECT COUNT(*) AS diary_image_url_not_null_count
+FROM diary
+WHERE image_url IS NOT NULL;
+
+-- 2) image_status column existence
+SELECT COUNT(*) AS has_diary_image_status_column
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'diary'
+  AND column_name = 'image_status';
+
+-- 3) If column exists, inspect null/invalid/distribution
+SET @has_col := (
+    SELECT COUNT(*)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'diary'
+      AND column_name = 'image_status'
+);
+
+SET @sql := IF(
+    @has_col = 1,
+    'SELECT COUNT(*) AS diary_image_status_null_count FROM diary WHERE image_status IS NULL',
+    'SELECT NULL AS diary_image_status_null_count'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql := IF(
+    @has_col = 1,
+    'SELECT COUNT(*) AS diary_image_status_invalid_count FROM diary WHERE image_status IS NOT NULL AND image_status NOT IN (''NONE'', ''PENDING'', ''READY'', ''FAILED'')',
+    'SELECT NULL AS diary_image_status_invalid_count'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql := IF(
+    @has_col = 1,
+    'SELECT image_status, COUNT(*) AS cnt FROM diary GROUP BY image_status ORDER BY image_status',
+    'SELECT ''image_status column not found'' AS note'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- 4) Existing constraints visibility
+SELECT tc.table_name, tc.constraint_name, tc.constraint_type
+FROM information_schema.table_constraints tc
+WHERE tc.table_schema = DATABASE()
+  AND tc.table_name = 'diary'
+ORDER BY tc.constraint_type, tc.constraint_name;
+

--- a/src/main/resources/db/migration/manual/STAB-004-rollback.sql
+++ b/src/main/resources/db/migration/manual/STAB-004-rollback.sql
@@ -1,0 +1,45 @@
+-- STAB-004 rollback script
+-- Target DB: MySQL 8.x
+-- Note: rollback drops state guard and state column introduced by STAB-004.
+
+-- =========================
+-- A. Drop CHECK constraint (if present)
+-- =========================
+SET @has_chk := (
+    SELECT COUNT(*)
+    FROM information_schema.table_constraints
+    WHERE table_schema = DATABASE()
+      AND table_name = 'diary'
+      AND constraint_name = 'chk_diary_image_status'
+      AND constraint_type = 'CHECK'
+);
+
+SET @sql := IF(
+    @has_chk > 0,
+    'ALTER TABLE diary DROP CHECK chk_diary_image_status',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- B. Drop column (if present)
+-- =========================
+SET @has_col := (
+    SELECT COUNT(*)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'diary'
+      AND column_name = 'image_status'
+);
+
+SET @sql := IF(
+    @has_col > 0,
+    'ALTER TABLE diary DROP COLUMN image_status',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
Diary 이미지 생성 흐름을 null 기반 암묵 상태에서 명시 상태(`imageStatus`) 기반으로 전환했습니다.
코드 가드와 DB 가드(컬럼/체크/기본값)를 함께 반영해 상태 전이 일관성을 강화했습니다.

## 📋 변경 사항
- `DiaryImageStatus` enum 추가: `NONE`, `PENDING`, `READY`, `FAILED`
- `Diary` 엔티티에 `image_status` 필드 및 전이 메서드 추가
  - `requestImageGeneration()`
  - `markImageReady()`
  - `markImageFailed()`
  - `deactivate()`
- `DiaryService`/`DiaryImageService` 상태 전이 로직 반영
  - 생성/수정 시 `PENDING` 설정
  - 비동기 완료/실패 시 `READY/FAILED` 전이
  - stale 이벤트 가드(`PENDING` 아닌 경우 skip)
- API 응답 확장
  - `DiaryResponseDTO`, `CalendarResponseDTO`, `DiaryConverter`에 `imageStatus` 반영
- DB 수동 마이그레이션 추가
  - `STAB-004-precheck.sql`
  - `STAB-004-apply.sql`
  - `STAB-004-rollback.sql`
  - `STAB-004-README.md`
- 부가 정리
  - `ExpoPushToken`에 `markValid/markInvalid` 도메인 메서드 적용
  - `ExpoPushTokenService`, `NotificationService` UTF-8 인코딩 이슈 복구

## 🔍 Code Review
- 상태 전이 규칙이 서비스/비동기 경로에서 일관되게 지켜지는지
- `DiaryImageService`에서 `PENDING` 가드가 stale 이벤트를 정상 차단하는지
- `STAB-004-apply.sql` 백필 규칙이 운영 데이터 기대와 일치하는지
  - `image_url IS NOT NULL -> READY`
  - `image_url IS NULL -> NONE`
- 응답 스펙 확장(`imageStatus`)이 프론트 호환성을 깨지 않는지(추가 필드)

## 📸 ScreenShot
- API/DB 변경 PR이라 UI 스크린샷은 없음
- 로컬 스모크 결과:
<img width="1456" height="405" alt="image" src="https://github.com/user-attachments/assets/314551fc-8d2e-443f-a0df-5640054b8043" />
  - `generateImage=true` 생성 시 `PENDING -> READY` 전이 확인
  - `imageUrl` 채워짐 확인
- DB post-check 결과:
  - `image_status_null_count = 0`
  - `image_status_invalid_count = 0`
  - `chk_diary_image_status` 존재
  - `image_status`: `NOT NULL`, `DEFAULT 'NONE'`