### PR TITLE
fix(push-001): Expo Push 응답 파싱 객체/배열 호환 처리 + DTO 테스트 추가

### DIFF
--- a/src/main/java/com/melissa/diary/web/dto/ExpoPushNotificationDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/ExpoPushNotificationDTO.java
@@ -1,5 +1,7 @@
 package com.melissa.diary.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -49,9 +51,11 @@ public class ExpoPushNotificationDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class PushResponse {
         
         @JsonProperty("data")
+        @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
         private List<PushTicket> data;
     }
     
@@ -61,6 +65,7 @@ public class ExpoPushNotificationDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class PushTicket {
         
         @JsonProperty("status")
@@ -82,6 +87,7 @@ public class ExpoPushNotificationDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class PushErrorDetail {
         
         @JsonProperty("error")

--- a/src/test/java/com/melissa/diary/web/dto/ExpoPushNotificationDTOTest.java
+++ b/src/test/java/com/melissa/diary/web/dto/ExpoPushNotificationDTOTest.java
@@ -1,0 +1,55 @@
+package com.melissa.diary.web.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExpoPushNotificationDTOTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void deserializesWhenDataIsArray() throws Exception {
+        String json = """
+                {
+                  "data": [
+                    {
+                      "status": "ok",
+                      "id": "ticket-array-1"
+                    }
+                  ]
+                }
+                """;
+
+        ExpoPushNotificationDTO.PushResponse response =
+                objectMapper.readValue(json, ExpoPushNotificationDTO.PushResponse.class);
+
+        assertThat(response.getData()).isNotNull().hasSize(1);
+        assertThat(response.getData().get(0).getStatus()).isEqualTo("ok");
+        assertThat(response.getData().get(0).getId()).isEqualTo("ticket-array-1");
+    }
+
+    @Test
+    void deserializesWhenDataIsSingleObject() throws Exception {
+        String json = """
+                {
+                  "data": {
+                    "status": "error",
+                    "message": "The recipient device is not registered with FCM.",
+                    "details": {
+                      "error": "DeviceNotRegistered"
+                    }
+                  }
+                }
+                """;
+
+        ExpoPushNotificationDTO.PushResponse response =
+                objectMapper.readValue(json, ExpoPushNotificationDTO.PushResponse.class);
+
+        assertThat(response.getData()).isNotNull().hasSize(1);
+        assertThat(response.getData().get(0).getStatus()).isEqualTo("error");
+        assertThat(response.getData().get(0).getDetails()).isNotNull();
+        assertThat(response.getData().get(0).getDetails().getError()).isEqualTo("DeviceNotRegistered");
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- `PUSH-001` 이슈 대응으로 Expo Push 응답 파싱 호환성을 개선했습니다.
- 기존 `data` 배열 고정 파싱에서 발생하던 단건 응답(`data` 객체) 역직렬화 실패를 해결했습니다.
- 관련 DTO 단위 테스트를 추가해 객체/배열 케이스를 모두 검증했습니다.

Core Push Stability Sprint: Notification Delivery & KST Consistency  
Related Issue: #263

## 📋 변경 사항
- `ExpoPushNotificationDTO.PushResponse.data`에 단일 객체도 배열로 수용되도록 설정 추가
- 응답 DTO에 unknown field 무시 설정 추가
- 테스트 추가:
  - `data`가 배열인 응답 파싱 성공
  - `data`가 객체인 응답 파싱 성공

변경 파일:
- `src/main/java/com/melissa/diary/web/dto/ExpoPushNotificationDTO.java`
- `src/test/java/com/melissa/diary/web/dto/ExpoPushNotificationDTOTest.java`


## 🔍 Code Review
- 이번 PR은 DTO 파싱 계층만 수정했으며 비즈니스 로직(`lastSentDate`, retry, timezone)은 변경하지 않았습니다.
- `DeviceNotRegistered` 등 에러 분기 로직이 파싱 단계에서 막히지 않고 후속 로직까지 도달 가능한지 확인 부탁드립니다.
- 기존 응답(배열)과 신규 케이스(객체) 모두 역호환 유지되는지 중점 확인 부탁드립니다.

테스트:
- 실행: `.\gradlew.bat test --tests "com.melissa.diary.web.dto.ExpoPushNotificationDTOTest"`
- 결과: PASS

## 📸 ScreenShot
