### PR TITLE
fix(push-003): 알림 스케줄/조회 시간대 Asia/Seoul 고정

### DIFF
--- a/src/main/java/com/melissa/diary/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/melissa/diary/scheduler/NotificationScheduler.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Component;
 import java.sql.Time;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
@@ -21,50 +23,53 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class NotificationScheduler {
-    
+
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
+
     private final UserSettingRepository userSettingRepository;
     private final NotificationService notificationService;
-    
+
     /**
      * 10분 단위 알림 발송 (00, 10, 20, 30, 40, 50분)
      */
     @Scheduled(cron = "0 */10 * * * *", zone = "Asia/Seoul")
     public void sendDailyNotifications() {
         long startTime = System.currentTimeMillis();
-        LocalTime now = LocalTime.now();
-        
-        // 현재 시각을 10분 단위로 내림 (예: 23:03 → 23:00, 23:17 → 23:10)
-        int currentMinute = (now.getMinute() / 10) * 10;
-        LocalTime targetTime = LocalTime.of(now.getHour(), currentMinute, 0);
+        ZonedDateTime nowInKst = ZonedDateTime.now(KST_ZONE_ID);
+        LocalDate todayInKst = nowInKst.toLocalDate();
+        LocalTime targetTime = floorToTenMinuteSlot(nowInKst.toLocalTime());
         Time notificationTime = Time.valueOf(targetTime);
-        
-        log.info("[NotificationScheduler] 알림 스케줄러 시작. 대상 시간: {}", targetTime);
-        
+
+        log.info("[NotificationScheduler] 알림 스케줄러 시작. zone={}, now={}, targetTime={}",
+                KST_ZONE_ID, nowInKst.toLocalDateTime(), targetTime);
+
         try {
-            // 발송 대상 조회
             List<UserSetting> targets = userSettingRepository.findNotificationTargets(
-                    notificationTime, 
-                    LocalDate.now()
+                    notificationTime,
+                    todayInKst
             );
-            
+
             if (targets.isEmpty()) {
                 log.info("[NotificationScheduler] 발송 대상 없음. 시간: {}", targetTime);
                 return;
             }
-            
+
             log.info("[NotificationScheduler] 발송 대상 조회 완료. 대상: {}명", targets.size());
-            
-            // 배치 순차 발송 (비동기 시작, 100명씩 분할하여 안정적으로 순차 처리)
+
             notificationService.sendBatchNotifications(targets);
-            
+
             long elapsedTime = System.currentTimeMillis() - startTime;
-            log.info("[NotificationScheduler] 알림 스케줄러 완료 (배치 순차 발송 시작). 대상: {}명, 조회 시간: {}ms", 
+            log.info("[NotificationScheduler] 알림 스케줄러 완료 (배치 순차 발송 시작). 대상: {}명, 조회 시간: {}ms",
                     targets.size(), elapsedTime);
-            
+
         } catch (Exception e) {
             long elapsedTime = System.currentTimeMillis() - startTime;
             log.error("[NotificationScheduler] 알림 스케줄러 실행 중 오류 발생. 소요 시간: {}ms", elapsedTime, e);
         }
     }
-}
 
+    static LocalTime floorToTenMinuteSlot(LocalTime time) {
+        int minuteSlot = (time.getMinute() / 10) * 10;
+        return LocalTime.of(time.getHour(), minuteSlot, 0);
+    }
+}

--- a/src/test/java/com/melissa/diary/scheduler/NotificationSchedulerTest.java
+++ b/src/test/java/com/melissa/diary/scheduler/NotificationSchedulerTest.java
@@ -1,0 +1,48 @@
+package com.melissa.diary.scheduler;
+
+import com.melissa.diary.repository.UserSettingRepository;
+import com.melissa.diary.service.NotificationService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.sql.Time;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NotificationSchedulerTest {
+
+    @Test
+    void floorToTenMinuteSlotRoundsDownWithZeroSeconds() {
+        LocalTime result = NotificationScheduler.floorToTenMinuteSlot(LocalTime.of(23, 17, 42));
+
+        assertThat(result).isEqualTo(LocalTime.of(23, 10, 0));
+    }
+
+    @Test
+    void sendDailyNotificationsUsesKstDateForTargetQuery() {
+        UserSettingRepository repository = mock(UserSettingRepository.class);
+        NotificationService notificationService = mock(NotificationService.class);
+        NotificationScheduler scheduler = new NotificationScheduler(repository, notificationService);
+
+        when(repository.findNotificationTargets(any(Time.class), any(LocalDate.class)))
+                .thenReturn(List.of());
+
+        scheduler.sendDailyNotifications();
+
+        ArgumentCaptor<LocalDate> dateCaptor = ArgumentCaptor.forClass(LocalDate.class);
+        verify(repository).findNotificationTargets(any(Time.class), dateCaptor.capture());
+        verify(notificationService, never()).sendBatchNotifications(any());
+
+        LocalDate expectedKstDate = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        assertThat(dateCaptor.getValue()).isEqualTo(expectedKstDate);
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
알림 스케줄러의 시간/날짜 계산 기준을 `Asia/Seoul`로 명시 고정하여, 서버 기본 타임존과 무관하게 KST 기준으로 대상 조회가 되도록 수정했습니다.

## 📋 변경 사항
- `NotificationScheduler`에서 `ZonedDateTime.now(ZoneId.of("Asia/Seoul"))` 사용
- 대상 조회 파라미터를 `LocalDate.now()` 대신 `todayInKst`로 전달
- 10분 슬롯 계산 로직 분리: `floorToTenMinuteSlot`
- 단위 테스트 추가:
  - 10분 슬롯 내림 처리 검증
  - 조회 날짜가 KST 기준인지 검증

## 🔍 Code Review
- 변경 범위는 스케줄러 시간 계산 및 테스트에 한정됨
- 비즈니스 재시도/상태전이 로직(`lastSentDate`)은 이번 PR 범위에서 미변경
- KST 기준 날짜/시간 전달 일관성 및 10분 슬롯 경계값 처리 확인 요청

## 📸 ScreenShot
해당 없음 (백엔드 로직/테스트 변경)