### PR TITLE
feat(push-002): 알림 발송 상태모델 개편(성공 마킹 + 실패 재시도)

### DIFF
--- a/src/main/java/com/melissa/diary/domain/UserSetting.java
+++ b/src/main/java/com/melissa/diary/domain/UserSetting.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 import java.sql.Time;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -28,6 +29,13 @@ public class UserSetting {
 
     @Column(name = "last_sent_date")
     private LocalDate lastSentDate;
+
+    @Column(name = "last_attempt_at")
+    private LocalDateTime lastAttemptAt;
+
+    @Builder.Default
+    @Column(name = "retry_count", nullable = false, columnDefinition = "INT DEFAULT 0")
+    private Integer retryCount = 0;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/melissa/diary/repository/UserSettingRepository.java
+++ b/src/main/java/com/melissa/diary/repository/UserSettingRepository.java
@@ -7,32 +7,43 @@ import org.springframework.data.repository.query.Param;
 
 import java.sql.Time;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface UserSettingRepository extends JpaRepository<UserSetting, Long> {
-    // 특정 사용자(User) ID를 통해 해당 UserSetting을 찾는다
     Optional<UserSetting> findByUserId(Long userId);
+
     boolean existsByUserId(Long userId);
 
     void deleteByUserId(Long userId);
 
     /**
-     * 알림 발송 대상 조회 (시간 일치, 알림 활성화, 미발송, 유효 토큰)
-     * FETCH JOIN으로 N+1 문제 방지
+     * Notification targets:
+     * 1) current slot users (notificationTime)
+     * 2) retry candidates (failed today, retry count not exceeded, retry wait elapsed)
      */
     @Query("""
         SELECT DISTINCT us FROM UserSetting us
         INNER JOIN FETCH us.user u
         INNER JOIN FETCH u.expoPushTokenList ept
-        WHERE us.notificationTime = :notificationTime
-        AND us.notificationEnabled = true
+        WHERE us.notificationEnabled = true
         AND (us.lastSentDate IS NULL OR us.lastSentDate < :today)
         AND ept.invalid = false
+        AND (
+            us.notificationTime = :notificationTime
+            OR (
+                us.lastAttemptAt IS NOT NULL
+                AND FUNCTION('DATE', us.lastAttemptAt) = :today
+                AND us.retryCount < :maxRetryCount
+                AND us.lastAttemptAt <= :retryEligibleBefore
+            )
+        )
         """)
     List<UserSetting> findNotificationTargets(
             @Param("notificationTime") Time notificationTime,
-            @Param("today") LocalDate today
+            @Param("today") LocalDate today,
+            @Param("retryEligibleBefore") LocalDateTime retryEligibleBefore,
+            @Param("maxRetryCount") int maxRetryCount
     );
-
 }

--- a/src/main/java/com/melissa/diary/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/melissa/diary/scheduler/NotificationScheduler.java
@@ -10,14 +10,15 @@ import org.springframework.stereotype.Component;
 
 import java.sql.Time;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
- * 푸시 알림 스케줄러
- * 매 10분마다 실행하여 해당 시간 알림 설정 사용자에게 발송
+ * Push notification scheduler.
+ * Runs every 10 minutes in KST.
  */
 @Component
 @RequiredArgsConstructor
@@ -25,46 +26,53 @@ import java.util.List;
 public class NotificationScheduler {
 
     private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
+    private static final int RETRY_INTERVAL_MINUTES = 10;
+    private static final int MAX_RETRY_COUNT = 6;
 
     private final UserSettingRepository userSettingRepository;
     private final NotificationService notificationService;
 
-    /**
-     * 10분 단위 알림 발송 (00, 10, 20, 30, 40, 50분)
-     */
     @Scheduled(cron = "0 */10 * * * *", zone = "Asia/Seoul")
     public void sendDailyNotifications() {
         long startTime = System.currentTimeMillis();
         ZonedDateTime nowInKst = ZonedDateTime.now(KST_ZONE_ID);
         LocalDate todayInKst = nowInKst.toLocalDate();
+        LocalDateTime retryEligibleBefore = nowInKst.toLocalDateTime().minusMinutes(RETRY_INTERVAL_MINUTES);
         LocalTime targetTime = floorToTenMinuteSlot(nowInKst.toLocalTime());
         Time notificationTime = Time.valueOf(targetTime);
 
-        log.info("[NotificationScheduler] 알림 스케줄러 시작. zone={}, now={}, targetTime={}",
-                KST_ZONE_ID, nowInKst.toLocalDateTime(), targetTime);
+        log.info(
+                "[NotificationScheduler] started. zone={}, now={}, targetTime={}, retryInterval={}m, maxRetryCount={}",
+                KST_ZONE_ID,
+                nowInKst.toLocalDateTime(),
+                targetTime,
+                RETRY_INTERVAL_MINUTES,
+                MAX_RETRY_COUNT
+        );
 
         try {
             List<UserSetting> targets = userSettingRepository.findNotificationTargets(
                     notificationTime,
-                    todayInKst
+                    todayInKst,
+                    retryEligibleBefore,
+                    MAX_RETRY_COUNT
             );
 
             if (targets.isEmpty()) {
-                log.info("[NotificationScheduler] 발송 대상 없음. 시간: {}", targetTime);
+                log.info("[NotificationScheduler] no targets. targetTime={}", targetTime);
                 return;
             }
 
-            log.info("[NotificationScheduler] 발송 대상 조회 완료. 대상: {}명", targets.size());
+            log.info("[NotificationScheduler] targets fetched. count={}", targets.size());
 
             notificationService.sendBatchNotifications(targets);
 
             long elapsedTime = System.currentTimeMillis() - startTime;
-            log.info("[NotificationScheduler] 알림 스케줄러 완료 (배치 순차 발송 시작). 대상: {}명, 조회 시간: {}ms",
-                    targets.size(), elapsedTime);
+            log.info("[NotificationScheduler] completed. targetCount={}, elapsed={}ms", targets.size(), elapsedTime);
 
         } catch (Exception e) {
             long elapsedTime = System.currentTimeMillis() - startTime;
-            log.error("[NotificationScheduler] 알림 스케줄러 실행 중 오류 발생. 소요 시간: {}ms", elapsedTime, e);
+            log.error("[NotificationScheduler] failed. elapsed={}ms", elapsedTime, e);
         }
     }
 

--- a/src/main/java/com/melissa/diary/service/NotificationService.java
+++ b/src/main/java/com/melissa/diary/service/NotificationService.java
@@ -15,6 +15,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 /**
@@ -25,6 +27,7 @@ import java.util.List;
 public class NotificationService {
 
     private static final int BATCH_SIZE = 100;
+    private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
 
     private final UserSettingRepository userSettingRepository;
     private final ExpoPushTokenRepository expoPushTokenRepository;
@@ -38,9 +41,6 @@ public class NotificationService {
         this.expoWebClient = expoWebClient;
     }
 
-    /**
-     * 스케줄러 스레드 블로킹을 피하기 위한 비동기 진입점
-     */
     @Async("notificationExecutor")
     public void sendBatchNotifications(List<UserSetting> userSettings) {
         int totalCount = userSettings.size();
@@ -73,9 +73,6 @@ public class NotificationService {
                 totalCount, totalSuccess, totalFail, totalElapsedTime, Thread.currentThread().getName());
     }
 
-    /**
-     * 배치 단위를 새로운 트랜잭션으로 처리
-     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public int[] processBatchWithTransaction(List<UserSetting> batch, int batchNumber, int totalBatches) {
         long batchStartTime = System.currentTimeMillis();
@@ -86,11 +83,14 @@ public class NotificationService {
 
         for (UserSetting userSetting : batch) {
             try {
-                sendNotificationToUser(userSetting);
-                successCount++;
+                boolean delivered = sendNotificationToUser(userSetting);
+                if (delivered) {
+                    successCount++;
+                } else {
+                    failCount++;
+                }
             } catch (Exception e) {
-                log.error("[Notification] failed to send notification to userId={}",
-                        userSetting.getUser().getId(), e);
+                log.error("[Notification] failed to send notification to userId={}", userSetting.getUser().getId(), e);
                 failCount++;
             }
         }
@@ -103,16 +103,16 @@ public class NotificationService {
     }
 
     /**
-     * 단일 사용자 알림 발송
+     * @return true when at least one push was delivered successfully.
      */
-    public void sendNotificationToUser(UserSetting userSetting) {
+    public boolean sendNotificationToUser(UserSetting userSetting) {
         Long userId = userSetting.getUser().getId();
+        LocalDate today = LocalDate.now(KST_ZONE_ID);
+        LocalDateTime now = LocalDateTime.now(KST_ZONE_ID);
 
-        // 날짜 기준 중복 발송 방지: 먼저 lastSentDate를 갱신한 뒤 발송
-        boolean updated = updateLastSentDateIfNotTodayInternal(userSetting);
-        if (!updated) {
+        if (isAlreadySentToday(userSetting, today)) {
             log.debug("[Notification] already sent today. userId={}", userId);
-            return;
+            return true;
         }
 
         List<ExpoPushToken> validTokens = userSetting.getUser().getExpoPushTokenList().stream()
@@ -121,7 +121,8 @@ public class NotificationService {
 
         if (validTokens.isEmpty()) {
             log.warn("[Notification] no valid token. userId={}", userId);
-            return;
+            markNotificationAttemptFailedInternal(userSetting, today, now, "NO_VALID_TOKEN");
+            return false;
         }
 
         log.info("[Notification] sending notification. userId={}, tokenCount={}", userId, validTokens.size());
@@ -147,13 +148,19 @@ public class NotificationService {
             }
         }
 
-        log.info("[Notification] user notification completed. userId={}, success={}, fail={}",
+        if (tokenSuccessCount > 0) {
+            markNotificationSuccessInternal(userSetting, today, now);
+            log.info("[Notification] user notification completed. userId={}, success={}, fail={}",
+                    userId, tokenSuccessCount, tokenFailCount);
+            return true;
+        }
+
+        markNotificationAttemptFailedInternal(userSetting, today, now, "ALL_TOKEN_SEND_FAILED");
+        log.warn("[Notification] user notification failed. userId={}, success={}, fail={}",
                 userId, tokenSuccessCount, tokenFailCount);
+        return false;
     }
 
-    /**
-     * Expo Push API 호출
-     */
     private void sendPushNotification(String token, String title, String body) {
         ExpoPushNotificationDTO.PushRequest request = ExpoPushNotificationDTO.PushRequest.builder()
                 .to(token)
@@ -196,9 +203,51 @@ public class NotificationService {
         }
     }
 
-    /**
-     * 같은 배치 트랜잭션 내에서 Invalid 토큰 처리
-     */
+    private boolean isAlreadySentToday(UserSetting setting, LocalDate today) {
+        return today.equals(setting.getLastSentDate());
+    }
+
+    private void markNotificationSuccessInternal(UserSetting setting, LocalDate today, LocalDateTime now) {
+        try {
+            setting.setLastSentDate(today);
+            setting.setLastAttemptAt(now);
+            setting.setRetryCount(0);
+            userSettingRepository.save(setting);
+            log.info("[Notification] delivery state marked success. userSettingId={}, date={}", setting.getId(), today);
+        } catch (Exception e) {
+            log.error("[Notification] failed to mark success state. userSettingId={}", setting.getId(), e);
+        }
+    }
+
+    private void markNotificationAttemptFailedInternal(
+            UserSetting setting,
+            LocalDate today,
+            LocalDateTime now,
+            String reason
+    ) {
+        try {
+            int nextRetryCount = calculateNextRetryCount(setting, today);
+            setting.setRetryCount(nextRetryCount);
+            setting.setLastAttemptAt(now);
+            userSettingRepository.save(setting);
+            log.info("[Notification] delivery state marked failure. userSettingId={}, retryCount={}, reason={}",
+                    setting.getId(), nextRetryCount, reason);
+        } catch (Exception e) {
+            log.error("[Notification] failed to mark failure state. userSettingId={}", setting.getId(), e);
+        }
+    }
+
+    private int calculateNextRetryCount(UserSetting setting, LocalDate today) {
+        Integer currentRetryCount = setting.getRetryCount() == null ? 0 : setting.getRetryCount();
+        LocalDateTime lastAttemptAt = setting.getLastAttemptAt();
+
+        if (lastAttemptAt == null || !today.equals(lastAttemptAt.toLocalDate())) {
+            return 1;
+        }
+
+        return currentRetryCount + 1;
+    }
+
     private void markTokenAsInvalidInternal(ExpoPushToken token) {
         try {
             token.markInvalid();
@@ -209,30 +258,8 @@ public class NotificationService {
         }
     }
 
-    /**
-     * 오늘 아직 발송하지 않은 경우에만 lastSentDate 갱신
-     */
-    private boolean updateLastSentDateIfNotTodayInternal(UserSetting setting) {
-        try {
-            LocalDate today = LocalDate.now();
-
-            if (today.equals(setting.getLastSentDate())) {
-                return false;
-            }
-
-            setting.setLastSentDate(today);
-            userSettingRepository.save(setting);
-            log.debug("[Notification] lastSentDate updated. userSettingId={}, date={}", setting.getId(), today);
-            return true;
-
-        } catch (Exception e) {
-            log.error("[Notification] failed to update lastSentDate. userSettingId={}", setting.getId(), e);
-            return false;
-        }
-    }
-
     private String buildNotificationTitle(UserSetting userSetting) {
-        return "📝 오늘의 일기를 작성해보세요!";
+        return "📖 오늘의 일기를 작성해보세요!";
     }
 
     private String buildNotificationBody(UserSetting userSetting) {

--- a/src/main/resources/db/migration/manual/STAB-005-apply.sql
+++ b/src/main/resources/db/migration/manual/STAB-005-apply.sql
@@ -1,0 +1,76 @@
+-- STAB-005 apply script
+-- Target DB: MySQL 8.x
+-- Purpose:
+-- 1) add notification delivery-state columns on user_setting
+-- 2) backfill and enforce retry_count default/non-null
+-- 3) add retry targeting index
+
+-- =========================
+-- A. Add last_attempt_at column (idempotent)
+-- =========================
+SET @has_last_attempt_col := (
+    SELECT COUNT(*)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'user_setting'
+      AND column_name = 'last_attempt_at'
+);
+
+SET @sql := IF(
+    @has_last_attempt_col = 0,
+    'ALTER TABLE user_setting ADD COLUMN last_attempt_at DATETIME NULL AFTER last_sent_date',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- B. Add retry_count column (idempotent)
+-- =========================
+SET @has_retry_count_col := (
+    SELECT COUNT(*)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'user_setting'
+      AND column_name = 'retry_count'
+);
+
+SET @sql := IF(
+    @has_retry_count_col = 0,
+    'ALTER TABLE user_setting ADD COLUMN retry_count INT NULL DEFAULT 0 AFTER last_attempt_at',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- C. Backfill + enforce retry_count
+-- =========================
+UPDATE user_setting
+SET retry_count = 0
+WHERE retry_count IS NULL OR retry_count < 0;
+
+ALTER TABLE user_setting
+    MODIFY COLUMN retry_count INT NOT NULL DEFAULT 0;
+
+-- =========================
+-- D. Add retry targeting index (idempotent)
+-- =========================
+SET @has_retry_idx := (
+    SELECT COUNT(*)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'user_setting'
+      AND index_name = 'idx_user_setting_retry_target'
+);
+
+SET @sql := IF(
+    @has_retry_idx = 0,
+    'CREATE INDEX idx_user_setting_retry_target ON user_setting (notification_enabled, last_sent_date, last_attempt_at, retry_count, notification_time, user_id)',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/main/resources/db/migration/manual/STAB-005-precheck.sql
+++ b/src/main/resources/db/migration/manual/STAB-005-precheck.sql
@@ -1,0 +1,63 @@
+-- STAB-005 pre-check (run before apply script)
+-- Target DB: MySQL 8.x
+-- Purpose: inspect notification delivery-state migration readiness
+
+-- 1) Baseline rows
+SELECT COUNT(*) AS user_setting_total_count
+FROM user_setting;
+
+-- 2) Column existence
+SELECT COUNT(*) AS has_last_attempt_at_column
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'user_setting'
+  AND column_name = 'last_attempt_at';
+
+SELECT COUNT(*) AS has_retry_count_column
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'user_setting'
+  AND column_name = 'retry_count';
+
+-- 3) If retry_count exists, inspect null/invalid distribution
+SET @has_retry_count_col := (
+    SELECT COUNT(*)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'user_setting'
+      AND column_name = 'retry_count'
+);
+
+SET @sql := IF(
+    @has_retry_count_col = 1,
+    'SELECT COUNT(*) AS retry_count_null_count FROM user_setting WHERE retry_count IS NULL',
+    'SELECT NULL AS retry_count_null_count'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql := IF(
+    @has_retry_count_col = 1,
+    'SELECT COUNT(*) AS retry_count_negative_count FROM user_setting WHERE retry_count < 0',
+    'SELECT NULL AS retry_count_negative_count'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql := IF(
+    @has_retry_count_col = 1,
+    'SELECT retry_count, COUNT(*) AS cnt FROM user_setting GROUP BY retry_count ORDER BY retry_count LIMIT 20',
+    'SELECT ''retry_count column not found'' AS note'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- 4) Existing indexes
+SELECT table_name, index_name, column_name, seq_in_index
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+  AND table_name = 'user_setting'
+ORDER BY index_name, seq_in_index;

--- a/src/main/resources/db/migration/manual/STAB-005-rollback.sql
+++ b/src/main/resources/db/migration/manual/STAB-005-rollback.sql
@@ -1,0 +1,63 @@
+-- STAB-005 rollback script
+-- Target DB: MySQL 8.x
+-- Note: rollback drops delivery-state index and columns introduced by STAB-005.
+
+-- =========================
+-- A. Drop retry index (if present)
+-- =========================
+SET @has_retry_idx := (
+    SELECT COUNT(*)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'user_setting'
+      AND index_name = 'idx_user_setting_retry_target'
+);
+
+SET @sql := IF(
+    @has_retry_idx > 0,
+    'DROP INDEX idx_user_setting_retry_target ON user_setting',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- B. Drop retry_count column (if present)
+-- =========================
+SET @has_retry_count_col := (
+    SELECT COUNT(*)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'user_setting'
+      AND column_name = 'retry_count'
+);
+
+SET @sql := IF(
+    @has_retry_count_col > 0,
+    'ALTER TABLE user_setting DROP COLUMN retry_count',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- C. Drop last_attempt_at column (if present)
+-- =========================
+SET @has_last_attempt_col := (
+    SELECT COUNT(*)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'user_setting'
+      AND column_name = 'last_attempt_at'
+);
+
+SET @sql := IF(
+    @has_last_attempt_col > 0,
+    'ALTER TABLE user_setting DROP COLUMN last_attempt_at',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/test/java/com/melissa/diary/scheduler/NotificationSchedulerTest.java
+++ b/src/test/java/com/melissa/diary/scheduler/NotificationSchedulerTest.java
@@ -7,12 +7,14 @@ import org.mockito.ArgumentCaptor;
 
 import java.sql.Time;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -33,16 +35,18 @@ class NotificationSchedulerTest {
         NotificationService notificationService = mock(NotificationService.class);
         NotificationScheduler scheduler = new NotificationScheduler(repository, notificationService);
 
-        when(repository.findNotificationTargets(any(Time.class), any(LocalDate.class)))
+        when(repository.findNotificationTargets(any(Time.class), any(LocalDate.class), any(LocalDateTime.class), anyInt()))
                 .thenReturn(List.of());
 
         scheduler.sendDailyNotifications();
 
         ArgumentCaptor<LocalDate> dateCaptor = ArgumentCaptor.forClass(LocalDate.class);
-        verify(repository).findNotificationTargets(any(Time.class), dateCaptor.capture());
+        ArgumentCaptor<Integer> retryCountCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(repository).findNotificationTargets(any(Time.class), dateCaptor.capture(), any(LocalDateTime.class), retryCountCaptor.capture());
         verify(notificationService, never()).sendBatchNotifications(any());
 
         LocalDate expectedKstDate = LocalDate.now(ZoneId.of("Asia/Seoul"));
         assertThat(dateCaptor.getValue()).isEqualTo(expectedKstDate);
+        assertThat(retryCountCaptor.getValue()).isEqualTo(6);
     }
 }

--- a/src/test/java/com/melissa/diary/service/NotificationServiceStateModelTest.java
+++ b/src/test/java/com/melissa/diary/service/NotificationServiceStateModelTest.java
@@ -1,0 +1,112 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.UserSetting;
+import com.melissa.diary.repository.ExpoPushTokenRepository;
+import com.melissa.diary.repository.UserSettingRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.sql.Time;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class NotificationServiceStateModelTest {
+
+    @Test
+    void marksFailedAttemptWhenNoValidToken() {
+        UserSettingRepository userSettingRepository = mock(UserSettingRepository.class);
+        ExpoPushTokenRepository expoPushTokenRepository = mock(ExpoPushTokenRepository.class);
+        WebClient webClient = mock(WebClient.class);
+        NotificationService service = new NotificationService(userSettingRepository, expoPushTokenRepository, webClient);
+
+        User user = User.builder()
+                .id(1L)
+                .expoPushTokenList(new ArrayList<>())
+                .build();
+        UserSetting setting = UserSetting.builder()
+                .id(10L)
+                .user(user)
+                .notificationEnabled(true)
+                .notificationTime(Time.valueOf("23:00:00"))
+                .retryCount(0)
+                .build();
+
+        boolean delivered = service.sendNotificationToUser(setting);
+
+        assertThat(delivered).isFalse();
+        assertThat(setting.getRetryCount()).isEqualTo(1);
+        assertThat(setting.getLastAttemptAt()).isNotNull();
+        verify(userSettingRepository).save(setting);
+        verify(expoPushTokenRepository, never()).save(any());
+    }
+
+    @Test
+    void resetsRetryCountOnNewDayFailure() {
+        UserSettingRepository userSettingRepository = mock(UserSettingRepository.class);
+        ExpoPushTokenRepository expoPushTokenRepository = mock(ExpoPushTokenRepository.class);
+        WebClient webClient = mock(WebClient.class);
+        NotificationService service = new NotificationService(userSettingRepository, expoPushTokenRepository, webClient);
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDateTime yesterdayAttempt = today.minusDays(1).atTime(23, 0);
+
+        User user = User.builder()
+                .id(1L)
+                .expoPushTokenList(new ArrayList<>())
+                .build();
+        UserSetting setting = UserSetting.builder()
+                .id(11L)
+                .user(user)
+                .notificationEnabled(true)
+                .notificationTime(Time.valueOf("23:00:00"))
+                .retryCount(5)
+                .lastAttemptAt(yesterdayAttempt)
+                .build();
+
+        boolean delivered = service.sendNotificationToUser(setting);
+
+        assertThat(delivered).isFalse();
+        assertThat(setting.getRetryCount()).isEqualTo(1);
+        assertThat(setting.getLastAttemptAt()).isAfter(yesterdayAttempt);
+        verify(userSettingRepository).save(setting);
+    }
+
+    @Test
+    void skipsWhenAlreadySentToday() {
+        UserSettingRepository userSettingRepository = mock(UserSettingRepository.class);
+        ExpoPushTokenRepository expoPushTokenRepository = mock(ExpoPushTokenRepository.class);
+        WebClient webClient = mock(WebClient.class);
+        NotificationService service = new NotificationService(userSettingRepository, expoPushTokenRepository, webClient);
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        User user = User.builder()
+                .id(1L)
+                .expoPushTokenList(new ArrayList<>())
+                .build();
+        UserSetting setting = UserSetting.builder()
+                .id(12L)
+                .user(user)
+                .notificationEnabled(true)
+                .notificationTime(Time.valueOf("23:00:00"))
+                .lastSentDate(today)
+                .retryCount(3)
+                .build();
+
+        boolean delivered = service.sendNotificationToUser(setting);
+
+        assertThat(delivered).isTrue();
+        assertThat(setting.getRetryCount()).isEqualTo(3);
+        verify(userSettingRepository, never()).save(any(UserSetting.class));
+        verify(expoPushTokenRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
알림 발송 상태모델을 개편하여 성공 시에만 성공 상태를 마킹하고, 실패 건은 재시도 대상으로 다시 조회되도록 개선했습니다.  
기존 `lastSentDate` 선갱신 구조로 인해 실패해도 당일 재시도가 차단되던 문제를 해결했습니다.

## 📋 변경 사항
- `UserSetting` 상태 필드 추가
  - `lastAttemptAt` (`last_attempt_at`)
  - `retryCount` (`retry_count`, default 0, not null)
- `NotificationService` 상태 전이 로직 개편
  - 성공(최소 1 토큰 성공) 시: `lastSentDate=today`, `retryCount=0`, `lastAttemptAt=now`
  - 실패 시: `lastAttemptAt=now`, `retryCount` 증가(일자 변경 시 1로 리셋)
  - 당일 이미 성공한 사용자(`lastSentDate=today`)는 skip
- `UserSettingRepository.findNotificationTargets` 조회 조건 확장
  - 현재 슬롯 대상 + 재시도 대상(오늘 실패, retry 상한 미만, 재시도 대기시간 경과)
- `NotificationScheduler` 재시도 파라미터 전달
  - `retryEligibleBefore = now - 10m`
  - `maxRetryCount = 6`
- DB 수동 마이그레이션 SQL 추가
  - `STAB-005-precheck.sql`
  - `STAB-005-apply.sql`
  - `STAB-005-rollback.sql`
- 테스트 추가/수정
  - `NotificationServiceStateModelTest` 신규
  - `NotificationSchedulerTest` 파라미터 변경 반영

## 🔍 Code Review
- 핵심 리뷰 포인트
  - 실패/성공 상태 전이 규칙이 의도대로 반영되었는지
  - 재시도 대상 조회 조건(`today`, `retryCount`, `lastAttemptAt`) 정합성
  - 스케줄러 파라미터(`10분`, `6회`) 운영 정책 적합성
- 확인한 내용
  - `NotificationSchedulerTest`, `NotificationServiceStateModelTest` 통과
  - DB 인덱스 `idx_user_setting_retry_target` 6컬럼 순서 검증 완료
- 참고
  - 기존에 부분 생성된 인덱스 보정을 위해 `STAB-005-index-check-and-create.sql` 실행 가능

## 📸 ScreenShot
해당 없음 (백엔드 로직/DB 마이그레이션 변경)