### PR TITLE
fix(push-004): Expo Push 요청 payload data=null 전송으로 인한 400 Bad Request 수정

### DIFF
--- a/src/main/java/com/melissa/diary/service/NotificationService.java
+++ b/src/main/java/com/melissa/diary/service/NotificationService.java
@@ -11,6 +11,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -197,6 +198,10 @@ public class NotificationService {
 
         } catch (InvalidTokenException e) {
             throw e;
+        } catch (WebClientResponseException e) {
+            log.error("[Notification] Expo API response error. token={}, status={}, body={}",
+                    token, e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new RuntimeException("Expo API response error", e);
         } catch (Exception e) {
             log.error("[Notification] notification send exception. token={}", token, e);
             throw new RuntimeException("Notification send failed", e);

--- a/src/main/java/com/melissa/diary/web/dto/ExpoPushNotificationDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/ExpoPushNotificationDTO.java
@@ -1,5 +1,6 @@
 package com.melissa.diary.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -22,6 +23,7 @@ public class ExpoPushNotificationDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class PushRequest {
         
         @JsonProperty("to")

--- a/src/test/java/com/melissa/diary/web/dto/ExpoPushRequestSerializationTest.java
+++ b/src/test/java/com/melissa/diary/web/dto/ExpoPushRequestSerializationTest.java
@@ -1,0 +1,47 @@
+package com.melissa.diary.web.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExpoPushRequestSerializationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void omitsDataWhenNull() throws Exception {
+        ExpoPushNotificationDTO.PushRequest request = ExpoPushNotificationDTO.PushRequest.builder()
+                .to("ExponentPushToken[test]")
+                .title("title")
+                .body("body")
+                .data(null)
+                .sound("default")
+                .priority("high")
+                .build();
+
+        String json = objectMapper.writeValueAsString(request);
+
+        assertThat(json).doesNotContain("\"data\"");
+    }
+
+    @Test
+    void includesDataWhenObjectPresent() throws Exception {
+        ExpoPushNotificationDTO.PushRequest request = ExpoPushNotificationDTO.PushRequest.builder()
+                .to("ExponentPushToken[test]")
+                .title("title")
+                .body("body")
+                .data(new Payload("daily_reminder", 1L))
+                .sound("default")
+                .priority("high")
+                .build();
+
+        String json = objectMapper.writeValueAsString(request);
+
+        assertThat(json).contains("\"data\"");
+        assertThat(json).contains("\"type\":\"daily_reminder\"");
+        assertThat(json).contains("\"userId\":1");
+    }
+
+    private record Payload(String type, Long userId) {}
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
Expo Push 요청 payload에 `data: null`이 포함되어 400 Bad Request가 발생하던 문제를 수정했습니다.  
`data`가 null일 때는 JSON에서 필드를 제외하도록 변경하고, Expo 응답 오류 시 body를 로그로 남기도록 보강했습니다.

## 📋 변경 사항
- `ExpoPushNotificationDTO.PushRequest`에 `@JsonInclude(JsonInclude.Include.NON_NULL)` 적용
  - `data == null`인 경우 payload에서 `data` 키 미전송
- `NotificationService`에서 `WebClientResponseException` 분기 추가
  - status + response body 로깅으로 400 상세 원인 확인 가능
- 단위 테스트 추가:
  - `ExpoPushRequestSerializationTest`
    - `data=null`일 때 JSON에 `data` 필드가 없는지 검증
    - `data` 객체 존재 시 `data` 필드가 포함되는지 검증
- 기존 DTO 응답 파싱 테스트와 함께 실행하여 회귀 확인

## 🔍 Code Review
- 변경 범위는 Expo Push 요청 직렬화 및 오류 로깅에 한정됨
- 재시도 정책/스케줄러/DB 상태모델 로직은 이번 PR에서 변경하지 않음
- 확인 요청 포인트:
  - 운영 로그에서 400 발생 시 response body가 충분히 식별 가능한지
  - `data` 미전송 시 실제 Expo 수신 성공률이 개선되는지

## 📸 ScreenShot
해당 없음 (백엔드 직렬화/로깅/테스트 변경)