### PR TITLE
feat(stab-003): 채팅/푸시토큰 HTTP 멱등 처리 도입 및 TTL 정리 추가

### DIFF
--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -69,6 +69,10 @@ public enum ErrorStatus implements BaseErrorCode {
     EXPO_TOKEN_ALREADY_EXISTS(HttpStatus.CONFLICT, "EXPO4002", "이미 등록된 Expo Push Token입니다."),
     EXPO_TOKEN_INVALID_FORMAT(HttpStatus.BAD_REQUEST, "EXPO4003", "유효하지 않은 Expo Push Token 형식입니다."),
 
+    // Idempotency
+    IDEMPOTENCY_REQUEST_IN_PROGRESS(HttpStatus.CONFLICT, "IDEMP4001", "같은 요청이 이미 처리 중입니다."),
+    IDEMPOTENCY_REQUEST_MISMATCH(HttpStatus.CONFLICT, "IDEMP4002", "같은 멱등 키로 다른 요청 본문을 보낼 수 없습니다."),
+
     // Diary (v1.3.0)
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY4001", "해당 일기를 찾을 수 없습니다."),
     DIARY_FORBIDDEN(HttpStatus.FORBIDDEN, "DIARY4002", "해당 일기에 접근할 권한이 없습니다."),

--- a/src/main/java/com/melissa/diary/domain/IdempotencyRecord.java
+++ b/src/main/java/com/melissa/diary/domain/IdempotencyRecord.java
@@ -1,0 +1,96 @@
+package com.melissa.diary.domain;
+
+import com.melissa.diary.domain.enums.IdempotencyStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(
+        name = "idempotency_record",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_idempotency_user_endpoint_key",
+                        columnNames = {"user_id", "endpoint", "idempotency_key"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_idempotency_expires_at", columnList = "expires_at")
+        }
+)
+@EntityListeners(AuditingEntityListener.class)
+public class IdempotencyRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 120)
+    private String endpoint;
+
+    @Column(name = "idempotency_key", nullable = false, length = 128)
+    private String idempotencyKey;
+
+    @Column(name = "request_hash", nullable = false, length = 64)
+    private String requestHash;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private IdempotencyStatus status;
+
+    @Column(name = "response_body", columnDefinition = "TEXT")
+    private String responseBody;
+
+    @Column(name = "error_message", length = 500)
+    private String errorMessage;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Version
+    @Column(nullable = false)
+    @Builder.Default
+    private Long version = 0L;
+
+    public void markPending() {
+        this.status = IdempotencyStatus.PENDING;
+        this.responseBody = null;
+        this.errorMessage = null;
+    }
+
+    public void markSucceeded(String responseBody) {
+        this.status = IdempotencyStatus.SUCCEEDED;
+        this.responseBody = responseBody;
+        this.errorMessage = null;
+    }
+
+    public void markFailedRetryable(String errorMessage) {
+        this.status = IdempotencyStatus.FAILED_RETRYABLE;
+        this.errorMessage = errorMessage;
+    }
+
+    public void markFailedFinal(String errorMessage) {
+        this.status = IdempotencyStatus.FAILED_FINAL;
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/com/melissa/diary/domain/enums/IdempotencyStatus.java
+++ b/src/main/java/com/melissa/diary/domain/enums/IdempotencyStatus.java
@@ -1,0 +1,8 @@
+package com.melissa.diary.domain.enums;
+
+public enum IdempotencyStatus {
+    PENDING,
+    SUCCEEDED,
+    FAILED_RETRYABLE,
+    FAILED_FINAL
+}

--- a/src/main/java/com/melissa/diary/repository/IdempotencyRecordRepository.java
+++ b/src/main/java/com/melissa/diary/repository/IdempotencyRecordRepository.java
@@ -1,0 +1,64 @@
+package com.melissa.diary.repository;
+
+import com.melissa.diary.domain.IdempotencyRecord;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface IdempotencyRecordRepository extends JpaRepository<IdempotencyRecord, Long> {
+
+    @Modifying
+    @Query(value = """
+        INSERT IGNORE INTO idempotency_record (
+            user_id,
+            endpoint,
+            idempotency_key,
+            request_hash,
+            status,
+            expires_at,
+            created_at,
+            updated_at,
+            version
+        )
+        VALUES (
+            :userId,
+            :endpoint,
+            :idempotencyKey,
+            :requestHash,
+            'PENDING',
+            :expiresAt,
+            NOW(),
+            NOW(),
+            0
+        )
+        """, nativeQuery = true)
+    int insertPendingIfAbsent(
+            @Param("userId") Long userId,
+            @Param("endpoint") String endpoint,
+            @Param("idempotencyKey") String idempotencyKey,
+            @Param("requestHash") String requestHash,
+            @Param("expiresAt") LocalDateTime expiresAt
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT ir
+        FROM IdempotencyRecord ir
+        WHERE ir.userId = :userId
+          AND ir.endpoint = :endpoint
+          AND ir.idempotencyKey = :idempotencyKey
+        """)
+    Optional<IdempotencyRecord> findForUpdate(
+            @Param("userId") Long userId,
+            @Param("endpoint") String endpoint,
+            @Param("idempotencyKey") String idempotencyKey
+    );
+
+    long deleteByExpiresAtBefore(LocalDateTime cutoff);
+}

--- a/src/main/java/com/melissa/diary/scheduler/IdempotencyCleanupScheduler.java
+++ b/src/main/java/com/melissa/diary/scheduler/IdempotencyCleanupScheduler.java
@@ -1,0 +1,23 @@
+package com.melissa.diary.scheduler;
+
+import com.melissa.diary.service.IdempotencyService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class IdempotencyCleanupScheduler {
+
+    private final IdempotencyService idempotencyService;
+
+    @Scheduled(cron = "${idempotency.cleanup-cron:0 0 * * * *}", zone = "Asia/Seoul")
+    public void cleanupExpiredRecords() {
+        long deleted = idempotencyService.cleanupExpiredRecords();
+        if (deleted > 0) {
+            log.info("[IdempotencyCleanup] removed expired records. count={}", deleted);
+        }
+    }
+}

--- a/src/main/java/com/melissa/diary/service/IdempotencyService.java
+++ b/src/main/java/com/melissa/diary/service/IdempotencyService.java
@@ -1,0 +1,176 @@
+package com.melissa.diary.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.IdempotencyRecord;
+import com.melissa.diary.domain.enums.IdempotencyStatus;
+import com.melissa.diary.repository.IdempotencyRecordRepository;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+
+@Service
+public class IdempotencyService {
+
+    private final IdempotencyRecordRepository idempotencyRecordRepository;
+    private final long ttlHours;
+    private final ObjectMapper objectMapper;
+
+    public IdempotencyService(
+            IdempotencyRecordRepository idempotencyRecordRepository,
+            ObjectMapper objectMapper,
+            @Value("${idempotency.ttl-hours:24}") long ttlHours
+    ) {
+        this.idempotencyRecordRepository = idempotencyRecordRepository;
+        this.objectMapper = objectMapper.copy()
+                .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+        this.ttlHours = ttlHours > 0 ? ttlHours : 24;
+    }
+
+    @Transactional
+    public ClaimResult claim(Long userId, String endpoint, String idempotencyKey, Object request) {
+        String normalizedKey = normalizeKey(idempotencyKey);
+        String requestHash = hashRequest(request);
+        LocalDateTime expiresAt = nextExpiration();
+
+        int inserted = idempotencyRecordRepository.insertPendingIfAbsent(
+                userId,
+                endpoint,
+                normalizedKey,
+                requestHash,
+                expiresAt
+        );
+
+        IdempotencyRecord existing = idempotencyRecordRepository.findForUpdate(userId, endpoint, normalizedKey)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus._INTERNAL_SERVER_ERROR));
+
+        if (inserted > 0) {
+            return new ClaimResult(ClaimAction.PROCEED, existing);
+        }
+
+        if (isExpired(existing)) {
+            existing.setRequestHash(requestHash);
+            existing.setExpiresAt(expiresAt);
+            existing.markPending();
+            return new ClaimResult(ClaimAction.PROCEED, existing);
+        }
+
+        validateRequestHash(existing, requestHash);
+
+        if (existing.getStatus() == IdempotencyStatus.SUCCEEDED) {
+            return new ClaimResult(ClaimAction.RETURN_CACHED, existing);
+        }
+
+        if (existing.getStatus() == IdempotencyStatus.FAILED_RETRYABLE) {
+            existing.setExpiresAt(expiresAt);
+            existing.markPending();
+            return new ClaimResult(ClaimAction.PROCEED, existing);
+        }
+
+        throw new ErrorHandler(ErrorStatus.IDEMPOTENCY_REQUEST_IN_PROGRESS);
+    }
+
+    @Transactional
+    public void markSucceeded(Long recordId, String responseBody) {
+        IdempotencyRecord record = idempotencyRecordRepository.findById(recordId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus._INTERNAL_SERVER_ERROR));
+        record.markSucceeded(responseBody);
+    }
+
+    @Transactional
+    public void markFailedRetryable(Long recordId, Throwable throwable) {
+        IdempotencyRecord record = idempotencyRecordRepository.findById(recordId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus._INTERNAL_SERVER_ERROR));
+        record.markFailedRetryable(buildErrorMessage(throwable));
+    }
+
+    @Transactional
+    public long cleanupExpiredRecords() {
+        return idempotencyRecordRepository.deleteByExpiresAtBefore(LocalDateTime.now());
+    }
+
+    public String serialize(Object body) {
+        try {
+            return objectMapper.writeValueAsString(body);
+        } catch (JsonProcessingException e) {
+            throw new ErrorHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public <T> T deserialize(String body, Class<T> type) {
+        try {
+            return objectMapper.readValue(body, type);
+        } catch (JsonProcessingException e) {
+            throw new ErrorHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public String hashRequestForTest(Object request) {
+        return hashRequest(request);
+    }
+
+    private String normalizeKey(String idempotencyKey) {
+        String normalizedKey = idempotencyKey == null ? "" : idempotencyKey.trim();
+        if (normalizedKey.isEmpty()) {
+            throw new ErrorHandler(ErrorStatus._BAD_REQUEST);
+        }
+        return normalizedKey;
+    }
+
+    private String hashRequest(Object request) {
+        try {
+            byte[] payload = objectMapper.writeValueAsBytes(request);
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(payload);
+            return HexFormat.of().formatHex(digest);
+        } catch (JsonProcessingException | NoSuchAlgorithmException e) {
+            throw new ErrorHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void validateRequestHash(IdempotencyRecord existing, String requestHash) {
+        if (!existing.getRequestHash().equals(requestHash)) {
+            throw new ErrorHandler(ErrorStatus.IDEMPOTENCY_REQUEST_MISMATCH);
+        }
+    }
+
+    private boolean isExpired(IdempotencyRecord record) {
+        return record.getExpiresAt() != null && !record.getExpiresAt().isAfter(LocalDateTime.now());
+    }
+
+    private LocalDateTime nextExpiration() {
+        return LocalDateTime.now().plusHours(ttlHours);
+    }
+
+    private String buildErrorMessage(Throwable throwable) {
+        if (throwable == null || throwable.getMessage() == null || throwable.getMessage().isBlank()) {
+            return "request failed";
+        }
+        String message = throwable.getMessage();
+        return message.length() > 500 ? message.substring(0, 500) : message;
+    }
+
+    @Getter
+    public static class ClaimResult {
+        private final ClaimAction action;
+        private final IdempotencyRecord record;
+
+        public ClaimResult(ClaimAction action, IdempotencyRecord record) {
+            this.action = action;
+            this.record = record;
+        }
+    }
+
+    public enum ClaimAction {
+        PROCEED,
+        RETURN_CACHED
+    }
+}

--- a/src/main/java/com/melissa/diary/web/controller/ExpoPushTokenController.java
+++ b/src/main/java/com/melissa/diary/web/controller/ExpoPushTokenController.java
@@ -2,6 +2,7 @@ package com.melissa.diary.web.controller;
 
 import com.melissa.diary.apiPayload.ApiResponse;
 import com.melissa.diary.service.ExpoPushTokenService;
+import com.melissa.diary.service.IdempotencyService;
 import com.melissa.diary.web.dto.ExpoPushTokenRequestDTO;
 import com.melissa.diary.web.dto.ExpoPushTokenResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,80 +11,123 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
 import java.util.List;
 
 @RestController
-@Tag(name = "ExpoPushTokenAPI", description = "Expo Push 알림 토큰 관리 API")
+@Tag(name = "ExpoPushTokenAPI", description = "Expo Push token management API")
 @RequestMapping("/api/v1/expo-push-tokens")
 @RequiredArgsConstructor
 @Slf4j
 public class ExpoPushTokenController {
-    
+
+    private static final String IDEMPOTENCY_HEADER = "Idempotency-Key";
+    private static final String REGISTER_TOKEN_ENDPOINT = "POST:/api/v1/expo-push-tokens";
+    private static final String DELETE_TOKEN_ENDPOINT = "DELETE:/api/v1/expo-push-tokens";
+
     private final ExpoPushTokenService expoPushTokenService;
-    
-    /**
-     * Expo Push Token 등록 (로그인 사용자)
-     */
+    private final IdempotencyService idempotencyService;
+
     @Operation(
-            summary = "Expo Push Token 등록",
-            description = "로그인한 사용자의 Expo Push Token을 등록합니다. 이미 존재하는 토큰이면 사용자 정보를 업데이트합니다."
+            summary = "Register Expo Push Token",
+            description = "Registers or updates the Expo Push Token for the authenticated user."
     )
     @PostMapping
     public ApiResponse<ExpoPushTokenResponseDTO.TokenResponse> registerToken(
             Principal principal,
+            @RequestHeader(value = IDEMPOTENCY_HEADER, required = false) String idempotencyKey,
             @Valid @RequestBody ExpoPushTokenRequestDTO.RegisterTokenRequest request) {
-        
+
         Long userId = Long.parseLong(principal.getName());
-        log.info("[ExpoPushTokenController] 토큰 등록 요청. userId={}, platform={}", 
+        log.info("[ExpoPushTokenController] register token request. userId={}, platform={}",
                 userId, request.getPlatform());
-        
-        ExpoPushTokenResponseDTO.TokenResponse response = 
-                expoPushTokenService.registerToken(userId, request);
-        
-        return ApiResponse.onSuccess(response);
+
+        if (isBlank(idempotencyKey)) {
+            ExpoPushTokenResponseDTO.TokenResponse response = expoPushTokenService.registerToken(userId, request);
+            return ApiResponse.onSuccess(response);
+        }
+
+        var claim = idempotencyService.claim(userId, REGISTER_TOKEN_ENDPOINT, idempotencyKey, request);
+        if (claim.getAction() == IdempotencyService.ClaimAction.RETURN_CACHED) {
+            ExpoPushTokenResponseDTO.TokenResponse cached = idempotencyService.deserialize(
+                    claim.getRecord().getResponseBody(),
+                    ExpoPushTokenResponseDTO.TokenResponse.class
+            );
+            return ApiResponse.onSuccess(cached);
+        }
+
+        try {
+            ExpoPushTokenResponseDTO.TokenResponse response = expoPushTokenService.registerToken(userId, request);
+            idempotencyService.markSucceeded(claim.getRecord().getId(), idempotencyService.serialize(response));
+            return ApiResponse.onSuccess(response);
+        } catch (RuntimeException e) {
+            idempotencyService.markFailedRetryable(claim.getRecord().getId(), e);
+            throw e;
+        }
     }
-    
-    /**
-     * 사용자별 토큰 목록 조회
-     */
+
     @Operation(
-            summary = "내 Expo Push Token 목록 조회",
-            description = "현재 로그인한 사용자의 등록된 모든 Expo Push Token을 조회합니다."
+            summary = "Get Expo Push Tokens",
+            description = "Returns all Expo Push Tokens registered for the authenticated user."
     )
     @GetMapping
-    public ApiResponse<List<ExpoPushTokenResponseDTO.TokenResponse>> getUserTokens(
-            Principal principal) {
-        
+    public ApiResponse<List<ExpoPushTokenResponseDTO.TokenResponse>> getUserTokens(Principal principal) {
         Long userId = Long.parseLong(principal.getName());
-        log.info("[ExpoPushTokenController] 토큰 목록 조회 요청. userId={}", userId);
-        
-        List<ExpoPushTokenResponseDTO.TokenResponse> tokens = 
-                expoPushTokenService.getUserTokens(userId);
-        
+        log.info("[ExpoPushTokenController] get tokens request. userId={}", userId);
+
+        List<ExpoPushTokenResponseDTO.TokenResponse> tokens = expoPushTokenService.getUserTokens(userId);
         return ApiResponse.onSuccess(tokens);
     }
-    
-    /**
-     * 특정 토큰 삭제
-     */
+
     @Operation(
-            summary = "Expo Push Token 삭제",
-            description = "특정 Expo Push Token을 삭제합니다. 더 이상 해당 기기로 알림이 발송되지 않습니다."
+            summary = "Delete Expo Push Token",
+            description = "Deletes a specific Expo Push Token."
     )
     @DeleteMapping("/{expoPushToken}")
     public ApiResponse<ExpoPushTokenResponseDTO.DeleteResponse> deleteToken(
-            @Parameter(description = "삭제할 Expo Push Token", required = true, example = "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]")
-            @PathVariable String expoPushToken) {
-        
-        log.info("[ExpoPushTokenController] 토큰 삭제 요청. token={}", expoPushToken);
-        
-        ExpoPushTokenResponseDTO.DeleteResponse response = 
-                expoPushTokenService.deleteToken(expoPushToken);
-        
-        return ApiResponse.onSuccess(response);
+            @Parameter(description = "Expo Push Token to delete", required = true,
+                    example = "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]")
+            @PathVariable String expoPushToken,
+            @RequestHeader(value = IDEMPOTENCY_HEADER, required = false) String idempotencyKey,
+            Principal principal) {
+
+        Long userId = Long.parseLong(principal.getName());
+        log.info("[ExpoPushTokenController] delete token request. userId={}, token={}", userId, expoPushToken);
+
+        if (isBlank(idempotencyKey)) {
+            ExpoPushTokenResponseDTO.DeleteResponse response = expoPushTokenService.deleteToken(expoPushToken);
+            return ApiResponse.onSuccess(response);
+        }
+
+        var claim = idempotencyService.claim(userId, DELETE_TOKEN_ENDPOINT, idempotencyKey, expoPushToken);
+        if (claim.getAction() == IdempotencyService.ClaimAction.RETURN_CACHED) {
+            ExpoPushTokenResponseDTO.DeleteResponse cached = idempotencyService.deserialize(
+                    claim.getRecord().getResponseBody(),
+                    ExpoPushTokenResponseDTO.DeleteResponse.class
+            );
+            return ApiResponse.onSuccess(cached);
+        }
+
+        try {
+            ExpoPushTokenResponseDTO.DeleteResponse response = expoPushTokenService.deleteToken(expoPushToken);
+            idempotencyService.markSucceeded(claim.getRecord().getId(), idempotencyService.serialize(response));
+            return ApiResponse.onSuccess(response);
+        } catch (RuntimeException e) {
+            idempotencyService.markFailedRetryable(claim.getRecord().getId(), e);
+            throw e;
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
     }
 }
-

--- a/src/main/java/com/melissa/diary/web/controller/ThreadController.java
+++ b/src/main/java/com/melissa/diary/web/controller/ThreadController.java
@@ -2,6 +2,7 @@ package com.melissa.diary.web.controller;
 
 import com.melissa.diary.apiPayload.ApiResponse;
 import com.melissa.diary.service.ChatLogService;
+import com.melissa.diary.service.IdempotencyService;
 import com.melissa.diary.service.ThreadService;
 import com.melissa.diary.web.dto.ChatLogRequestDTO;
 import com.melissa.diary.web.dto.ChatLogResponseDTO;
@@ -20,29 +21,37 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 
 import java.security.Principal;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @RestController
-@Tag(name = "Thread&ChatsAPI", description = "Thread&Chats 관련 API")
+@Tag(name = "Thread&ChatsAPI", description = "Thread&Chats 관리 API")
 @RequestMapping("/api")
 @RequiredArgsConstructor
 @Slf4j
 public class ThreadController {
 
+    private static final String IDEMPOTENCY_HEADER = "Idempotency-Key";
+    private static final String V1_CHAT_MESSAGE_ENDPOINT = "POST:/api/v1/chats/message";
+    private static final String V2_CHAT_MESSAGE_ENDPOINT = "POST:/api/v2/chats/message";
+    private static final String V2_CHAT_MESSAGE_TEST_ENDPOINT = "POST:/api/v2/chats/message-test";
+
     private final ThreadService threadService;
     private final ChatLogService chatLogService;
+    private final IdempotencyService idempotencyService;
 
     @Operation(summary = "채팅 스레드 생성",
-               description = "해당 날짜의 채팅 스레드를 생성합니다. 기존에 존재 시, 같은 threadId 리턴")
+            description = "해당 날짜의 채팅 스레드를 생성합니다. 기존 스레드가 있으면 같은 threadId를 반환합니다.")
     @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "THREAD4001: 해당 날짜의 스레드가 이미 존재"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음 / PROFILE4002: AI 프로필을 찾을 수 없음")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "THREAD4001: 해당 날짜의 스레드가 이미 존재"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음 / PROFILE4002: AI 프로필을 찾을 수 없음")
     })
     @PostMapping("/v1/chats")
     public ApiResponse<ThreadResponseDTO.ThreadResponse> createThread(
             @Parameter(description = "AI 프로필 ID", required = true, example = "1")
             @RequestParam(name = "aiProfileId") Long aiProfileId,
-            @Parameter(description = "년도", required = true, example = "2025")
+            @Parameter(description = "연도", required = true, example = "2025")
             @RequestParam(name = "year") int year,
             @Parameter(description = "월", required = true, example = "1")
             @RequestParam(name = "month") int month,
@@ -51,24 +60,22 @@ public class ThreadController {
             Principal principal) {
 
         Long userId = Long.parseLong(principal.getName());
-
         ThreadResponseDTO.ThreadResponse response = threadService.createThread(userId, aiProfileId, year, month, day);
-
         return ApiResponse.onSuccess(response);
     }
 
     @Operation(summary = "채팅 스레드 삭제",
-               description = "해당 날짜의 스레드와 연결된 채팅 로그, 일기를 모두 삭제합니다.")
+            description = "해당 날짜의 스레드와 연결된 채팅 로그를 삭제합니다.")
     @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CALENDAR4002: 스레드에 접근할 권한이 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음 / CALENDAR4001: 스레드를 찾을 수 없음")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CALENDAR4002: 스레드에 접근할 권한이 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음 / CALENDAR4001: 스레드를 찾을 수 없음")
     })
     @DeleteMapping("/v1/chats")
     public ApiResponse<ThreadResponseDTO.ThreadResponse> deleteThread(
             @Parameter(description = "AI 프로필 ID", required = true, example = "1")
             @RequestParam(name = "aiProfileId") Long aiProfileId,
-            @Parameter(description = "년도", required = true, example = "2025")
+            @Parameter(description = "연도", required = true, example = "2025")
             @RequestParam(name = "year") int year,
             @Parameter(description = "월", required = true, example = "1")
             @RequestParam(name = "month") int month,
@@ -77,60 +84,74 @@ public class ThreadController {
             Principal principal) {
 
         Long userId = Long.parseLong(principal.getName());
-
         ThreadResponseDTO.ThreadResponse response = threadService.deleteTread(userId, aiProfileId, year, month, day);
-
         return ApiResponse.onSuccess(response);
     }
 
-    @Operation(summary = "AI 채팅 메시지 전송 (SSE 스트리밍)",
-               description = "AI에게 채팅 메시지를 전송하고, SSE로 실시간 응답을 받습니다.")
+    @Operation(summary = "AI 채팅 메시지 전송 (SSE)",
+            description = "AI에게 채팅 메시지를 전송하고 SSE로 응답을 받습니다.")
     @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CALENDAR4002: 스레드에 접근할 권한이 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음 / CALENDAR4001: 스레드를 찾을 수 없음 / PROFILE4002: AI 프로필을 찾을 수 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "QUOTA4001: 일일 사용량 초과")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CALENDAR4002: 스레드에 접근할 권한이 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음 / CALENDAR4001: 스레드를 찾을 수 없음 / PROFILE4002: AI 프로필을 찾을 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "429", description = "QUOTA4001: 일일 사용량 초과")
     })
     @PostMapping(value = "/v1/chats/message", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public Flux<ServerSentEvent<String>> messageToAi(
             @Valid @RequestBody ThreadRequestDTO.AiChatRequest request,
+            @RequestHeader(value = IDEMPOTENCY_HEADER, required = false) String idempotencyKey,
             Principal principal) {
         Long userId = Long.parseLong(principal.getName());
 
-        return threadService.messageToAi(userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent());
+        if (isBlank(idempotencyKey)) {
+            return threadService.messageToAi(
+                    userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent()
+            );
+        }
+
+        var claim = idempotencyService.claim(userId, V1_CHAT_MESSAGE_ENDPOINT, idempotencyKey, request);
+        if (claim.getAction() == IdempotencyService.ClaimAction.RETURN_CACHED) {
+            return buildCachedAiStream(claim.getRecord().getResponseBody());
+        }
+
+        return wrapIdempotentStream(
+                claim.getRecord().getId(),
+                threadService.messageToAi(
+                        userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent()
+                )
+        );
     }
 
     @Operation(summary = "채팅 메시지 조회",
-               description = "해당 날짜(Thread)의 채팅 메시지를 조회합니다.")
+            description = "해당 날짜 스레드의 채팅 메시지를 조회합니다.")
     @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CALENDAR4002: 스레드에 접근할 권한이 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음 / CALENDAR4001: 스레드를 찾을 수 없음")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CALENDAR4002: 스레드에 접근할 권한이 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음 / CALENDAR4001: 스레드를 찾을 수 없음")
     })
     @GetMapping("/v1/chats")
     public ApiResponse<ThreadResponseDTO.ChatListResponse> getMessages(
             @Parameter(description = "AI 프로필 ID", required = true, example = "1")
             @RequestParam(name = "aiProfileId") Long aiProfileId,
-            @Parameter(description = "년도", required = true, example = "2025")
+            @Parameter(description = "연도", required = true, example = "2025")
             @RequestParam(name = "year") int year,
             @Parameter(description = "월", required = true, example = "1")
             @RequestParam(name = "month") int month,
             @Parameter(description = "일", required = true, example = "15")
             @RequestParam(name = "day") int day,
-            Principal principal
-    ){
+            Principal principal) {
         Long userId = Long.parseLong(principal.getName());
         ThreadResponseDTO.ChatListResponse response = threadService.getThreadMessages(userId, aiProfileId, year, month, day);
         return ApiResponse.onSuccess(response);
     }
-    
-    @Operation(summary = "채팅 메시지 수정", 
-               description = "사용자가 작성한 채팅 메시지를 수정합니다. AI 메시지는 수정할 수 없습니다.")
+
+    @Operation(summary = "채팅 메시지 수정",
+            description = "사용자 메시지만 수정할 수 있습니다.")
     @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "CHAT4004: AI 메시지는 수정할 수 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CHAT4003: 채팅 메시지에 접근할 권한이 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "CHAT4002: 채팅 메시지를 찾을 수 없음")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "CHAT4004: AI 메시지는 수정할 수 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CHAT4003: 채팅 메시지에 접근할 권한이 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "CHAT4002: 채팅 메시지를 찾을 수 없음")
     })
     @PatchMapping("/v1/chats/{chatLogId}")
     public ApiResponse<ChatLogResponseDTO.ChatLogResponse> updateChatLog(
@@ -141,16 +162,15 @@ public class ThreadController {
 
         Long userId = Long.parseLong(principal.getName());
         ChatLogResponseDTO.ChatLogResponse response = chatLogService.updateChatLog(userId, chatLogId, request);
-
         return ApiResponse.onSuccess(response);
     }
-    
-    @Operation(summary = "채팅 메시지 삭제", 
-               description = "[v1.3.0] 사용자 또는 AI가 작성한 채팅 메시지를 삭제합니다.")
+
+    @Operation(summary = "채팅 메시지 삭제",
+            description = "사용자 또는 AI가 작성한 채팅 메시지를 삭제합니다.")
     @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CHAT4003: 채팅 메시지에 접근할 권한이 없음"),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "CHAT4002: 채팅 메시지를 찾을 수 없음")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "CHAT4003: 채팅 메시지에 접근할 권한이 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "CHAT4002: 채팅 메시지를 찾을 수 없음")
     })
     @DeleteMapping("/v1/chats/{chatLogId}")
     public ApiResponse<ChatLogResponseDTO.ChatLogDeleteResponse> deleteChatLog(
@@ -160,43 +180,110 @@ public class ThreadController {
 
         Long userId = Long.parseLong(principal.getName());
         ChatLogResponseDTO.ChatLogDeleteResponse response = chatLogService.deleteChatLog(userId, chatLogId);
-
         return ApiResponse.onSuccess(response);
     }
-    
-    // =============== v2: UserMemory 기반 API ===============
-    
-    /**
-     * v2: UserMemory 기반 SSE 스트리밍 채팅
-     */
+
     @PostMapping(value = "/v2/chats/message", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    @Operation(summary = "메모리 기반 스트리밍 채팅", 
-               description = "사용자 장기 기억을 활용한 AI와의 실시간 스트리밍 채팅입니다.")
+    @Operation(summary = "메모리 기반 SSE 채팅",
+            description = "사용자 메모리를 포함한 AI 채팅입니다.")
     public Flux<ServerSentEvent<String>> messageToAiV2(
             @Valid @RequestBody ThreadRequestDTO.AiChatRequestV2 request,
+            @RequestHeader(value = IDEMPOTENCY_HEADER, required = false) String idempotencyKey,
             Principal principal
     ) {
         Long userId = Long.parseLong(principal.getName());
-        return threadService.messageToAiV2(
-                userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent()
+
+        if (isBlank(idempotencyKey)) {
+            return threadService.messageToAiV2(
+                    userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent()
+            );
+        }
+
+        var claim = idempotencyService.claim(userId, V2_CHAT_MESSAGE_ENDPOINT, idempotencyKey, request);
+        if (claim.getAction() == IdempotencyService.ClaimAction.RETURN_CACHED) {
+            return buildCachedAiStream(claim.getRecord().getResponseBody());
+        }
+
+        return wrapIdempotentStream(
+                claim.getRecord().getId(),
+                threadService.messageToAiV2(
+                        userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent()
+                )
         );
     }
-    
-    /**
-     * v2: 웹 테스트용 Non-SSE 메모리 기반 채팅
-     * 정성적 평가를 위한 동기 API
-     */
+
     @PostMapping("/v2/chats/message-test")
-    @Operation(summary = "웹 테스트용 메모리 기반 채팅", 
-               description = "정성적 평가를 위한 웹 테스트용 API입니다. SSE 없이 일반 HTTP 응답으로 메모리 기반 AI 채팅을 제공합니다.")
+    @Operation(summary = "메모리 기반 테스트 채팅",
+            description = "SSE 없이 일반 HTTP 응답으로 메모리 기반 AI 채팅을 수행합니다.")
     public ApiResponse<ThreadResponseDTO.ChatResponse> messageToAiTest(
             @Valid @RequestBody ThreadRequestDTO.AiChatRequestV2 request,
+            @RequestHeader(value = IDEMPOTENCY_HEADER, required = false) String idempotencyKey,
             Principal principal
     ) {
         Long userId = Long.parseLong(principal.getName());
-        ThreadResponseDTO.ChatResponse response = threadService.messageToAiTest(
-                userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent()
-        );
-        return ApiResponse.onSuccess(response);
+
+        if (isBlank(idempotencyKey)) {
+            ThreadResponseDTO.ChatResponse response = threadService.messageToAiTest(
+                    userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent()
+            );
+            return ApiResponse.onSuccess(response);
+        }
+
+        var claim = idempotencyService.claim(userId, V2_CHAT_MESSAGE_TEST_ENDPOINT, idempotencyKey, request);
+        if (claim.getAction() == IdempotencyService.ClaimAction.RETURN_CACHED) {
+            ThreadResponseDTO.ChatResponse cached = idempotencyService.deserialize(
+                    claim.getRecord().getResponseBody(),
+                    ThreadResponseDTO.ChatResponse.class
+            );
+            return ApiResponse.onSuccess(cached);
+        }
+
+        try {
+            ThreadResponseDTO.ChatResponse response = threadService.messageToAiTest(
+                    userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent()
+            );
+            idempotencyService.markSucceeded(claim.getRecord().getId(), idempotencyService.serialize(response));
+            return ApiResponse.onSuccess(response);
+        } catch (RuntimeException e) {
+            idempotencyService.markFailedRetryable(claim.getRecord().getId(), e);
+            throw e;
+        }
+    }
+
+    private Flux<ServerSentEvent<String>> wrapIdempotentStream(Long recordId, Flux<ServerSentEvent<String>> source) {
+        StringBuilder answer = new StringBuilder();
+        AtomicBoolean failed = new AtomicBoolean(false);
+
+        return source
+                .doOnNext(event -> {
+                    if ("aiMessage".equals(event.event()) && event.data() != null) {
+                        answer.append(event.data());
+                    }
+                    if ("error".equals(event.event())) {
+                        failed.set(true);
+                    }
+                })
+                .doOnError(error -> {
+                    failed.set(true);
+                    idempotencyService.markFailedRetryable(recordId, error);
+                })
+                .doOnComplete(() -> {
+                    if (failed.get()) {
+                        idempotencyService.markFailedRetryable(recordId, new IllegalStateException("stream failed"));
+                        return;
+                    }
+                    idempotencyService.markSucceeded(recordId, answer.toString().trim());
+                });
+    }
+
+    private Flux<ServerSentEvent<String>> buildCachedAiStream(String cachedMessage) {
+        return Flux.just(
+                ServerSentEvent.<String>builder().event("aiMessage").data(cachedMessage).build(),
+                ServerSentEvent.<String>builder().event("finish").data("finish").build()
+        ).delayElements(Duration.ofMillis(10));
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,3 +68,7 @@ security:
     refresh-token-pepper: ${MELISSA_REFRESH_TOKEN_PEPPER}
   encrypt:
     secret-key: ${ENC_SECRET_KEY}
+
+idempotency:
+  ttl-hours: 24
+  cleanup-cron: "0 0 * * * *"

--- a/src/main/resources/db/migration/manual/STAB-006-apply.sql
+++ b/src/main/resources/db/migration/manual/STAB-006-apply.sql
@@ -1,0 +1,35 @@
+-- STAB-006 apply script
+-- Target DB: MySQL 8.x
+-- Purpose: add idempotency storage for chat message APIs
+
+SET @has_table := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'idempotency_record'
+);
+
+SET @sql := IF(
+    @has_table = 0,
+    'CREATE TABLE idempotency_record (
+        id BIGINT NOT NULL AUTO_INCREMENT,
+        user_id BIGINT NOT NULL,
+        endpoint VARCHAR(120) NOT NULL,
+        idempotency_key VARCHAR(128) NOT NULL,
+        request_hash VARCHAR(64) NOT NULL,
+        status VARCHAR(32) NOT NULL,
+        response_body TEXT NULL,
+        error_message VARCHAR(500) NULL,
+        expires_at DATETIME NOT NULL,
+        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        version BIGINT NOT NULL DEFAULT 0,
+        PRIMARY KEY (id),
+        CONSTRAINT uk_idempotency_user_endpoint_key UNIQUE (user_id, endpoint, idempotency_key),
+        INDEX idx_idempotency_expires_at (expires_at)
+    )',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/main/resources/db/migration/manual/STAB-006-precheck.sql
+++ b/src/main/resources/db/migration/manual/STAB-006-precheck.sql
@@ -1,0 +1,14 @@
+-- STAB-006 pre-check
+-- Target DB: MySQL 8.x
+-- Purpose: inspect idempotency_record migration readiness
+
+SELECT COUNT(*) AS has_idempotency_record_table
+FROM information_schema.tables
+WHERE table_schema = DATABASE()
+  AND table_name = 'idempotency_record';
+
+SELECT table_name, index_name, column_name, seq_in_index
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+  AND table_name = 'idempotency_record'
+ORDER BY index_name, seq_in_index;

--- a/src/main/resources/db/migration/manual/STAB-006-rollback.sql
+++ b/src/main/resources/db/migration/manual/STAB-006-rollback.sql
@@ -1,0 +1,18 @@
+-- STAB-006 rollback script
+-- Target DB: MySQL 8.x
+
+SET @has_table := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'idempotency_record'
+);
+
+SET @sql := IF(
+    @has_table > 0,
+    'DROP TABLE idempotency_record',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/test/java/com/melissa/diary/service/IdempotencyServiceTest.java
+++ b/src/test/java/com/melissa/diary/service/IdempotencyServiceTest.java
@@ -1,0 +1,181 @@
+package com.melissa.diary.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.IdempotencyRecord;
+import com.melissa.diary.domain.enums.IdempotencyStatus;
+import com.melissa.diary.repository.IdempotencyRecordRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IdempotencyServiceTest {
+
+    @Mock
+    private IdempotencyRecordRepository idempotencyRecordRepository;
+
+    private IdempotencyService idempotencyService;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        idempotencyService = new IdempotencyService(idempotencyRecordRepository, objectMapper, 24);
+    }
+
+    @Test
+    void claimCreatesPendingRecordForNewKey() {
+        IdempotencyRecord saved = IdempotencyRecord.builder()
+                .id(1L)
+                .userId(10L)
+                .endpoint("POST:/api/v1/chats/message")
+                .idempotencyKey("abc")
+                .requestHash("hash")
+                .status(IdempotencyStatus.PENDING)
+                .expiresAt(LocalDateTime.now().plusHours(24))
+                .build();
+        when(idempotencyRecordRepository.insertPendingIfAbsent(any(), any(), any(), any(), any())).thenReturn(1);
+        when(idempotencyRecordRepository.findForUpdate(10L, "POST:/api/v1/chats/message", "abc"))
+                .thenReturn(Optional.of(saved));
+
+        var result = idempotencyService.claim(10L, "POST:/api/v1/chats/message", "abc", new DummyRequest("hello"));
+
+        assertEquals(IdempotencyService.ClaimAction.PROCEED, result.getAction());
+        assertEquals(saved, result.getRecord());
+        verify(idempotencyRecordRepository).insertPendingIfAbsent(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void cleanupExpiredRecordsDeletesOldRows() {
+        when(idempotencyRecordRepository.deleteByExpiresAtBefore(any(LocalDateTime.class))).thenReturn(3L);
+
+        long deleted = idempotencyService.cleanupExpiredRecords();
+
+        assertEquals(3L, deleted);
+        verify(idempotencyRecordRepository).deleteByExpiresAtBefore(any(LocalDateTime.class));
+    }
+
+    @Test
+    void claimReturnsCachedRecordWhenSucceeded() {
+        when(idempotencyRecordRepository.insertPendingIfAbsent(any(), any(), any(), any(), any())).thenReturn(0);
+
+        String endpoint = "POST:/api/v1/chats/message";
+        String key = "abc";
+        DummyRequest request = new DummyRequest("hello");
+        String hash = idempotencyService.hashRequestForTest(request);
+        IdempotencyRecord existing = IdempotencyRecord.builder()
+                .id(1L)
+                .userId(10L)
+                .endpoint(endpoint)
+                .idempotencyKey(key)
+                .requestHash(hash)
+                .status(IdempotencyStatus.SUCCEEDED)
+                .responseBody("cached")
+                .expiresAt(LocalDateTime.now().plusHours(24))
+                .build();
+        when(idempotencyRecordRepository.findForUpdate(10L, endpoint, key)).thenReturn(Optional.of(existing));
+
+        var result = idempotencyService.claim(10L, endpoint, key, request);
+
+        assertEquals(IdempotencyService.ClaimAction.RETURN_CACHED, result.getAction());
+        assertEquals("cached", result.getRecord().getResponseBody());
+    }
+
+    @Test
+    void claimRejectsSameKeyWithDifferentPayload() {
+        when(idempotencyRecordRepository.insertPendingIfAbsent(any(), any(), any(), any(), any())).thenReturn(0);
+
+        IdempotencyRecord existing = IdempotencyRecord.builder()
+                .id(1L)
+                .userId(10L)
+                .endpoint("POST:/api/v1/chats/message")
+                .idempotencyKey("abc")
+                .requestHash(idempotencyService.hashRequestForTest(new DummyRequest("hello")))
+                .status(IdempotencyStatus.SUCCEEDED)
+                .expiresAt(LocalDateTime.now().plusHours(24))
+                .build();
+        when(idempotencyRecordRepository.findForUpdate(10L, "POST:/api/v1/chats/message", "abc"))
+                .thenReturn(Optional.of(existing));
+
+        assertThrows(ErrorHandler.class, () ->
+                idempotencyService.claim(10L, "POST:/api/v1/chats/message", "abc", new DummyRequest("other")));
+    }
+
+    @Test
+    void claimRetriesFailedRetryableRecord() {
+        when(idempotencyRecordRepository.insertPendingIfAbsent(any(), any(), any(), any(), any())).thenReturn(0);
+
+        String endpoint = "POST:/api/v1/chats/message";
+        String key = "abc";
+        DummyRequest request = new DummyRequest("hello");
+        IdempotencyRecord existing = IdempotencyRecord.builder()
+                .id(1L)
+                .userId(10L)
+                .endpoint(endpoint)
+                .idempotencyKey(key)
+                .requestHash(idempotencyService.hashRequestForTest(request))
+                .status(IdempotencyStatus.FAILED_RETRYABLE)
+                .expiresAt(LocalDateTime.now().plusHours(24))
+                .build();
+        when(idempotencyRecordRepository.findForUpdate(10L, endpoint, key)).thenReturn(Optional.of(existing));
+
+        var result = idempotencyService.claim(10L, endpoint, key, request);
+
+        assertEquals(IdempotencyService.ClaimAction.PROCEED, result.getAction());
+        assertEquals(IdempotencyStatus.PENDING, existing.getStatus());
+    }
+
+    @Test
+    void claimReusesExpiredRecordAsNewAttempt() {
+        when(idempotencyRecordRepository.insertPendingIfAbsent(any(), any(), any(), any(), any())).thenReturn(0);
+
+        String endpoint = "POST:/api/v1/chats/message";
+        String key = "abc";
+        DummyRequest request = new DummyRequest("hello");
+        IdempotencyRecord existing = IdempotencyRecord.builder()
+                .id(1L)
+                .userId(10L)
+                .endpoint(endpoint)
+                .idempotencyKey(key)
+                .requestHash("old-hash")
+                .status(IdempotencyStatus.SUCCEEDED)
+                .responseBody("old")
+                .expiresAt(LocalDateTime.now().minusMinutes(1))
+                .build();
+        when(idempotencyRecordRepository.findForUpdate(10L, endpoint, key)).thenReturn(Optional.of(existing));
+
+        var result = idempotencyService.claim(10L, endpoint, key, request);
+
+        assertEquals(IdempotencyService.ClaimAction.PROCEED, result.getAction());
+        assertEquals(IdempotencyStatus.PENDING, existing.getStatus());
+        assertEquals(idempotencyService.hashRequestForTest(request), existing.getRequestHash());
+    }
+
+    @Test
+    void serializeSupportsLocalDateTimePayload() {
+        String serialized = idempotencyService.serialize(new LocalDateTimeResponse(LocalDateTime.of(2026, 3, 17, 14, 10)));
+
+        assertEquals("{\"createdAt\":[2026,3,17,14,10]}", serialized);
+    }
+
+    private record DummyRequest(String content) {
+    }
+
+    private record LocalDateTimeResponse(LocalDateTime createdAt) {
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
이번 PR에서는 HTTP 요청 중복으로 인한 중복 처리 문제를 줄이기 위해 멱등 키 기반 요청 처리를 도입했습니다.

적용 범위는 채팅 전송 API와 Expo Push Token 등록/삭제 API입니다.
`Idempotency-Key` 헤더가 있을 때만 멱등 처리하고, 헤더가 없으면 기존 방식대로 동작하도록 구현해 백엔드 선배포가 가능하도록 구성했습니다.

추가로 idempotency 저장 테이블, 상태 모델, TTL 기반 만료 정책, 만료 레코드 정리 스케줄러를 함께 도입했습니다.
중복 키 처리 중 Hibernate 세션이 깨지던 문제는 `INSERT IGNORE + 조회` 방식으로 수정해 재요청 경로를 안정화했습니다.

## 📋 변경 사항
- `idempotency_record` 테이블 및 상태 모델(`PENDING`, `SUCCEEDED`, `FAILED_RETRYABLE`, `FAILED_FINAL`) 추가
- `(user_id, endpoint, idempotency_key)` 유니크 제약으로 요청 단위 중복 방지
- 채팅 API
  - `POST /api/v1/chats/message`
  - `POST /api/v2/chats/message`
  - `POST /api/v2/chats/message-test`
  에 선택적 HTTP 멱등 적용
- Expo Push Token API
  - `POST /api/v1/expo-push-tokens`
  - `DELETE /api/v1/expo-push-tokens/{expoPushToken}`
  에 선택적 HTTP 멱등 적용
- 동일 키 + 동일 본문 재요청 시 저장된 응답 재사용
- 동일 키 + 다른 본문 요청 시 `IDEMP4002` 충돌 에러 반환
- TTL 24시간, 시간 단위 cleanup scheduler 추가
- `Idempotency-Key` 응답 직렬화 시 `LocalDateTime` 처리 가능하도록 ObjectMapper 설정 보정
- duplicate insert 후 세션 예외가 발생하던 부분을 `INSERT IGNORE + SELECT ... FOR UPDATE` 방식으로 수정

이번 방식을 선택한 이유:
- 이번 이슈의 목표를 MQ/Outbox가 아닌 `HTTP 멱등`으로 한정했기 때문에 요청 경계에서 중복을 막는 구조가 가장 맞았습니다.
- 프론트와 배포 순서를 분리해야 해서 `Idempotency-Key`가 없으면 기존 동작을 유지하는 하위호환 방식이 가장 안전했습니다.
- 채팅 전송은 quota 차감, 메시지 저장, AI 응답 생성이 연결되어 있어 중복 요청 피해가 크기 때문에 우선 적용 가치가 높았습니다.
- Expo Push Token 등록/삭제는 재시도 시 같은 요청을 재사용 응답으로 수렴시키기 쉬운 구조라 이번 범위에 포함했습니다.

다른 방식을 선택하지 않은 이유:
- 다이어리 생성은 이번 PR에서 제외했습니다.
  프론트에서 즉시 중복 클릭이 어렵고 홈 리다이렉트가 걸려 있으며, 동일 내용으로도 사용자가 의도적으로 여러 번 생성할 수 있어 요청 재시도와 신규 생성 의도를 현재 UX만으로 명확히 구분하기 어렵다고 판단했습니다.
- 내용 기반 dedupe는 선택하지 않았습니다.
  멱등은 같은 요청 시도의 재전송을 막는 목적이지, 같은 내용 자체를 금지하는 정책이 아니기 때문입니다.
- MQ/Outbox/Retry는 이번 PR에 넣지 않았습니다.
  실패 복구와 비동기 재시도는 후속 이슈에서 별도로 다루는 편이 책임 분리가 명확하다고 판단했습니다.
- 모든 POST API에 일괄 적용하지 않았습니다.
  도메인별로 중복 요청의 비용과 의도 구분 가능성을 기준으로 선택 적용하는 것이 더 안전하다고 봤습니다.

## 🔍 Code Review
중점적으로 봐주시면 좋은 부분은 아래입니다.

- `Idempotency-Key`가 없을 때 기존 동작이 완전히 유지되는지
- 같은 키 + 같은 본문 재요청 시 실제 비즈니스 로직이 다시 실행되지 않고 캐시 응답이 반환되는지
- 같은 키 + 다른 본문 요청 시 `IDEMP4002`로 차단되는지
- 채팅 `message-test` 응답 저장 시 직렬화/역직렬화가 안정적으로 동작하는지
- 중복 요청 경로에서 `INSERT IGNORE + FOR UPDATE` 흐름이 트랜잭션/정합성 측면에서 적절한지
- TTL 만료 후 동일 키 요청이 새 요청처럼 처리되는지

수동 검증 내용:
- 키 없이 성공
- 키 포함 성공
- 같은 키 재요청 시 캐시 응답 반환
- 같은 키 + 다른 내용 요청 시 에러 반환
- 다른 키 + 같은 내용 요청 시 정상 처리

테스트:
- `./gradlew compileJava` 성공
- `./gradlew test --tests com.melissa.diary.service.IdempotencyServiceTest` 성공

참고:
- 전체 `./gradlew test`는 이번 변경과 무관한 기존 테스트/환경 변수 이슈로 실패했습니다.
- `message-test`의 외부 AI 실패를 성공 캐시할지 여부는 이번 PR 범위 밖이며, 실패 재시도 정책 이슈에서 분리해 다루는 것이 맞다고 봤습니다.

## 📸 ScreenShot
- 없음