### PR TITLE
refactor: #257 긴 트랜잭션 및 외부 API 구간 분리

### DIFF
--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -49,6 +49,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CHAT_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "CHAT4002", "해당 채팅 메시지를 찾을 수 없습니다."),
     CHAT_LOG_FORBIDDEN(HttpStatus.FORBIDDEN, "CHAT4003", "해당 채팅 메시지에 접근할 권한이 없습니다."),
     CHAT_LOG_AI_MESSAGE(HttpStatus.BAD_REQUEST, "CHAT4004", "AI 메시지는 수정할 수 없습니다."),
+    CHAT_SSE_DISABLED(HttpStatus.GONE, "CHAT4005", "SSE chat API is disabled."),
 
     // Quota
     QUOTA_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "QUOTA4001", "일일 사용량을 초과하였습니다."),

--- a/src/main/java/com/melissa/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/melissa/diary/repository/DiaryRepository.java
@@ -93,6 +93,14 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
         """)
     Optional<Diary> findByIdWithThreadAndProfile(@Param("id") Long id);
 
+    @Query("""
+        SELECT DISTINCT d FROM Diary d
+        INNER JOIN FETCH d.thread t
+        LEFT JOIN FETCH t.dailyChatLogs logs
+        WHERE d.id = :id
+        """)
+    Optional<Diary> findByIdWithThreadAndChatLogs(@Param("id") Long id);
+
     /**
      * 피드 전용 조회 (최신순, 커서 기반 페이지네이션)
      * - id DESC 정렬 (AUTO_INCREMENT로 최신순 보장)

--- a/src/main/java/com/melissa/diary/scheduler/MemoryUpdateScheduler.java
+++ b/src/main/java/com/melissa/diary/scheduler/MemoryUpdateScheduler.java
@@ -7,7 +7,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
@@ -26,7 +25,6 @@ public class MemoryUpdateScheduler {
      * 사용자가 일기를 작성한 경우에만 메모리 업데이트 수행
      */
     @Scheduled(cron = "0 0 3 * * *", zone = "Asia/Seoul")
-    @Transactional
     public void updateUserMemoriesFromYesterdayDiaries() {
         LocalDate yesterday = LocalDate.now().minusDays(1);
         log.info("[MemoryScheduler] 메모리 업데이트 스케줄러 시작. 대상 날짜: {}", yesterday);
@@ -50,7 +48,7 @@ public class MemoryUpdateScheduler {
                 try {
                     // Diary 내용이 있는 경우에만 메모리 업데이트
                     if (diary.getContent() != null && !diary.getContent().trim().isEmpty()) {
-                        userMemoryService.updateUserMemoryFromDiary(diary.getUser().getId(), diary);
+                        userMemoryService.updateUserMemoryFromDiarySeparated(diary.getUser().getId(), diary.getId());
                         successCount++;
                     } else {
                         log.debug("[MemoryScheduler] Diary 내용 없음. diaryId={}", diary.getId());

--- a/src/main/java/com/melissa/diary/service/DiaryService.java
+++ b/src/main/java/com/melissa/diary/service/DiaryService.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.io.IOException;
 import java.util.List;
@@ -47,6 +48,7 @@ public class DiaryService {
     private final ApplicationEventPublisher publisher;
     private final ChatClient summaryClient;
     private final ChatClient hashtagClient;
+    private final TransactionTemplate transactionTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
     
     public DiaryService(DiaryRepository diaryRepository, 
@@ -56,7 +58,8 @@ public class DiaryService {
                        QuotaService quotaService,
                        ApplicationEventPublisher publisher,
                        @Qualifier("summaryClient") ChatClient summaryClient,
-                       @Qualifier("hashtagClient") ChatClient hashtagClient) {
+                       @Qualifier("hashtagClient") ChatClient hashtagClient,
+                       TransactionTemplate transactionTemplate) {
         this.diaryRepository = diaryRepository;
         this.userRepository = userRepository;
         this.threadRepository = threadRepository;
@@ -65,6 +68,7 @@ public class DiaryService {
         this.publisher = publisher;
         this.summaryClient = summaryClient;
         this.hashtagClient = hashtagClient;
+        this.transactionTemplate = transactionTemplate;
     }
     
     /**
@@ -402,6 +406,301 @@ public class DiaryService {
     /**
      * 날짜 유효성 검증
      */
+    public DiaryResponseDTO.DiaryResponse createManualDiarySeparated(Long userId,
+                                                                     DiaryRequestDTO.ManualDiaryCreateRequest request) {
+        if (!isValidDate(request.getYear(), request.getMonth(), request.getDay())) {
+            throw new ErrorHandler(ErrorStatus.CALENDAR_INVALID_DATE);
+        }
+
+        prepareManualDiaryCreation(userId, request);
+        HashtagData hashtagData = generateHashtagsSafe(request.getTitle(), request.getContent(), userId);
+        return persistManualDiary(userId, request, hashtagData);
+    }
+
+    public DiaryResponseDTO.DiaryResponse createChatDiarySeparated(Long userId,
+                                                                   DiaryRequestDTO.ChatDiaryCreateRequest request) {
+        ChatDiaryPreparation preparation = prepareChatDiaryCreation(userId, request);
+        DiaryData diaryData = summarizeDiaryDataSafe(userId, preparation);
+        return persistChatDiary(userId, request, diaryData);
+    }
+
+    public DiaryResponseDTO.DiaryResponse updateDiarySeparated(Long userId, Long diaryId,
+                                                               DiaryRequestDTO.DiaryUpdateRequest request) {
+        DiaryResponseDTO.DiaryResponse response = applyDiaryUpdate(userId, diaryId, request);
+
+        if (Boolean.TRUE.equals(request.getGenerateImage())) {
+            response = requestDiaryImageGeneration(userId, diaryId);
+        }
+
+        return response;
+    }
+
+    private void prepareManualDiaryCreation(Long userId, DiaryRequestDTO.ManualDiaryCreateRequest request) {
+        transactionTemplate.executeWithoutResult(status -> {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+            quotaService.checkAndConsume(user, UsageCost.SUMMARY);
+            aiProfileRepository.findById(request.getAiProfileId())
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.PROFILE_NOT_FOUND));
+
+            validateDiaryCapacity(userId, request.getYear(), request.getMonth(), request.getDay());
+        });
+    }
+
+    private ChatDiaryPreparation prepareChatDiaryCreation(Long userId,
+                                                          DiaryRequestDTO.ChatDiaryCreateRequest request) {
+        ChatDiaryPreparation preparation = transactionTemplate.execute(status -> {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+            quotaService.checkAndConsume(user, UsageCost.SUMMARY);
+
+            Thread thread = threadRepository.findByUserIdAndAiProfileIdAndYearAndMonthAndDay(
+                            userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay())
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.CALENDAR_NOT_FOUND));
+
+            List<ChatLogSnapshot> chatLogs = thread.getDailyChatLogs().stream()
+                    .map(log -> new ChatLogSnapshot(log.getRole(), log.getContent()))
+                    .toList();
+
+            long userChatCount = chatLogs.stream()
+                    .filter(log -> Role.USER.equals(log.getRole()))
+                    .count();
+            if (userChatCount <= 2) {
+                throw new ErrorHandler(ErrorStatus.CHAT_NOT_FOUND);
+            }
+
+            validateDiaryCapacity(userId, request.getYear(), request.getMonth(), request.getDay());
+            return new ChatDiaryPreparation(thread.getId(), chatLogs);
+        });
+
+        if (preparation == null) {
+            throw new IllegalStateException("Failed to prepare chat diary creation");
+        }
+        return preparation;
+    }
+
+    private void validateDiaryCapacity(Long userId, int year, int month, int day) {
+        int diaryCount = diaryRepository.countByUserIdAndYearAndMonthAndDayAndIsActive(
+                userId, year, month, day, true);
+        if (diaryCount >= 3) {
+            throw new ErrorHandler(ErrorStatus.DIARY_MAX_COUNT_EXCEEDED);
+        }
+    }
+
+    private HashtagData generateHashtagsSafe(String title, String content, Long userId) {
+        try {
+            String hashtagPrompt = buildHashtagPrompt(title, content);
+            String llmHashtagResponse = hashtagClient.prompt().user(hashtagPrompt).call().content();
+            return parseHashtagResponse(llmHashtagResponse);
+        } catch (Exception e) {
+            log.error("[Diary] hashtag generation failed. fallback used. userId={}", userId, e);
+            return new HashtagData("diary", "record");
+        }
+    }
+
+    private DiaryData summarizeDiaryDataSafe(Long userId, ChatDiaryPreparation preparation) {
+        try {
+            String chatLogsPrompt = buildChatLogsPromptFromSnapshots(preparation.getChatLogs());
+            String summaryPrompt = buildSummaryPrompt(chatLogsPrompt);
+            String llmResponse = summaryClient.prompt().user(summaryPrompt).call().content();
+            return parseLLMResponse(llmResponse);
+        } catch (Exception e) {
+            log.error("[Diary] summary generation failed. fallback used. userId={}, threadId={}",
+                    userId, preparation.getThreadId(), e);
+
+            String fallbackContent = preparation.getChatLogs().stream()
+                    .filter(log -> Role.USER.equals(log.getRole()))
+                    .map(ChatLogSnapshot::getContent)
+                    .collect(Collectors.joining(" "));
+
+            return new DiaryData(
+                    "Untitled diary",
+                    fallbackContent.substring(0, Math.min(fallbackContent.length(), 500)),
+                    null,
+                    "daily",
+                    "record"
+            );
+        }
+    }
+
+    private DiaryResponseDTO.DiaryResponse persistManualDiary(Long userId,
+                                                              DiaryRequestDTO.ManualDiaryCreateRequest request,
+                                                              HashtagData hashtagData) {
+        DiaryResponseDTO.DiaryResponse response = transactionTemplate.execute(status -> {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+            AiProfile aiProfile = aiProfileRepository.findById(request.getAiProfileId())
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.PROFILE_NOT_FOUND));
+
+            validateDiaryCapacity(userId, request.getYear(), request.getMonth(), request.getDay());
+
+            Thread thread = threadRepository.findByUserIdAndAiProfileIdAndYearAndMonthAndDay(
+                            userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay())
+                    .orElseGet(() -> createNewThread(user, aiProfile,
+                            request.getYear(), request.getMonth(), request.getDay()));
+
+            Diary diary = Diary.builder()
+                    .user(user)
+                    .thread(thread)
+                    .year(request.getYear())
+                    .month(request.getMonth())
+                    .day(request.getDay())
+                    .title(request.getTitle())
+                    .content(request.getContent())
+                    .mood(parseMoodOrNull(request.getMood()))
+                    .type(DiaryType.MANUAL)
+                    .hashtag1(hashtagData.getHashTag1())
+                    .hashtag2(hashtagData.getHashTag2())
+                    .imageUrl(null)
+                    .imageStatus(Boolean.TRUE.equals(request.getGenerateImage()) ? DiaryImageStatus.PENDING : DiaryImageStatus.NONE)
+                    .version(1)
+                    .isActive(true)
+                    .build();
+
+            diary = diaryRepository.save(diary);
+
+            if (Boolean.TRUE.equals(request.getGenerateImage())) {
+                publisher.publishEvent(new DiaryImageEvent(diary.getId()));
+            }
+
+            return buildDiaryResponse(diary);
+        });
+
+        if (response == null) {
+            throw new IllegalStateException("Failed to persist manual diary");
+        }
+        return response;
+    }
+
+    private DiaryResponseDTO.DiaryResponse persistChatDiary(Long userId,
+                                                            DiaryRequestDTO.ChatDiaryCreateRequest request,
+                                                            DiaryData diaryData) {
+        DiaryResponseDTO.DiaryResponse response = transactionTemplate.execute(status -> {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+            Thread thread = threadRepository.findByUserIdAndAiProfileIdAndYearAndMonthAndDay(
+                            userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay())
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.CALENDAR_NOT_FOUND));
+
+            validateDiaryCapacity(userId, request.getYear(), request.getMonth(), request.getDay());
+
+            Diary diary = Diary.builder()
+                    .user(user)
+                    .thread(thread)
+                    .year(request.getYear())
+                    .month(request.getMonth())
+                    .day(request.getDay())
+                    .title(diaryData.getTitle())
+                    .content(diaryData.getStory())
+                    .mood(diaryData.getMood())
+                    .type(DiaryType.CHAT_BASED)
+                    .hashtag1(diaryData.getHashTag1())
+                    .hashtag2(diaryData.getHashTag2())
+                    .imageUrl(null)
+                    .imageStatus(Boolean.TRUE.equals(request.getGenerateImage()) ? DiaryImageStatus.PENDING : DiaryImageStatus.NONE)
+                    .version(1)
+                    .isActive(true)
+                    .build();
+
+            diary = diaryRepository.save(diary);
+
+            if (Boolean.TRUE.equals(request.getGenerateImage())) {
+                publisher.publishEvent(new DiaryImageEvent(diary.getId()));
+            }
+
+            return buildDiaryResponse(diary);
+        });
+
+        if (response == null) {
+            throw new IllegalStateException("Failed to persist chat diary");
+        }
+        return response;
+    }
+
+    private DiaryResponseDTO.DiaryResponse applyDiaryUpdate(Long userId, Long diaryId,
+                                                            DiaryRequestDTO.DiaryUpdateRequest request) {
+        DiaryResponseDTO.DiaryResponse response = transactionTemplate.execute(status -> {
+            userRepository.findById(userId)
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+            Diary diary = diaryRepository.findByIdWithThreadAndProfile(diaryId)
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.DIARY_NOT_FOUND));
+
+            validateDiaryOwnership(userId, diary);
+
+            if (request.getTitle() != null) {
+                diary.setTitle(request.getTitle());
+            }
+            if (request.getContent() != null) {
+                diary.setContent(request.getContent());
+            }
+            if (request.getMood() != null) {
+                diary.setMood(parseMoodOrNull(request.getMood()));
+            }
+            if (request.getHashtag1() != null) {
+                diary.setHashtag1(request.getHashtag1());
+            }
+            if (request.getHashtag2() != null) {
+                diary.setHashtag2(request.getHashtag2());
+            }
+
+            diary.setVersion(diary.getVersion() + 1);
+            diary = diaryRepository.save(diary);
+            return buildDiaryResponse(diary);
+        });
+
+        if (response == null) {
+            throw new IllegalStateException("Failed to update diary");
+        }
+        return response;
+    }
+
+    private DiaryResponseDTO.DiaryResponse requestDiaryImageGeneration(Long userId, Long diaryId) {
+        DiaryResponseDTO.DiaryResponse response = transactionTemplate.execute(status -> {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+            Diary diary = diaryRepository.findByIdWithThreadAndProfile(diaryId)
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.DIARY_NOT_FOUND));
+
+            validateDiaryOwnership(userId, diary);
+
+            quotaService.checkAndConsume(user, UsageCost.SUMMARY);
+            diary.requestImageGeneration();
+            diary = diaryRepository.save(diary);
+            publisher.publishEvent(new DiaryImageEvent(diary.getId()));
+            return buildDiaryResponse(diary);
+        });
+
+        if (response == null) {
+            throw new IllegalStateException("Failed to request diary image generation");
+        }
+        return response;
+    }
+
+    private Mood parseMoodOrNull(String moodValue) {
+        if (moodValue == null) {
+            return null;
+        }
+
+        try {
+            return Mood.valueOf(moodValue.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            log.warn("[Diary] ?좏슚?섏? ?딆? mood 媛? {}", moodValue);
+            return null;
+        }
+    }
+
+    private void validateDiaryOwnership(Long userId, Diary diary) {
+        if (!diary.getUser().getId().equals(userId)) {
+            throw new ErrorHandler(ErrorStatus.DIARY_FORBIDDEN);
+        }
+        if (!diary.isActive()) {
+            throw new ErrorHandler(ErrorStatus.DIARY_ALREADY_DELETED);
+        }
+    }
+
     private boolean isValidDate(int year, int month, int day) {
         if (month < 1 || month > 12) return false;
         if (day < 1 || day > 31) return false;
@@ -418,6 +717,18 @@ public class DiaryService {
         }
         
         return true;
+    }
+
+    private String buildChatLogsPromptFromSnapshots(List<ChatLogSnapshot> logs) {
+        return logs.stream()
+                .map(log -> {
+                    if (log.getRole() == Role.USER) {
+                        return "[User] " + log.getContent();
+                    } else {
+                        return "[Assistant] " + log.getContent();
+                    }
+                })
+                .collect(Collectors.joining("\n"));
     }
     
     /**
@@ -562,6 +873,20 @@ public class DiaryService {
     private static class HashtagData {
         private final String hashTag1;
         private final String hashTag2;
+    }
+
+    @lombok.Getter
+    @lombok.AllArgsConstructor
+    private static class ChatDiaryPreparation {
+        private final Long threadId;
+        private final List<ChatLogSnapshot> chatLogs;
+    }
+
+    @lombok.Getter
+    @lombok.AllArgsConstructor
+    private static class ChatLogSnapshot {
+        private final Role role;
+        private final String content;
     }
 }
 

--- a/src/main/java/com/melissa/diary/service/NotificationService.java
+++ b/src/main/java/com/melissa/diary/service/NotificationService.java
@@ -9,8 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -33,13 +32,16 @@ public class NotificationService {
     private final UserSettingRepository userSettingRepository;
     private final ExpoPushTokenRepository expoPushTokenRepository;
     private final WebClient expoWebClient;
+    private final TransactionTemplate transactionTemplate;
 
     public NotificationService(UserSettingRepository userSettingRepository,
                                ExpoPushTokenRepository expoPushTokenRepository,
-                               @Qualifier("expoWebClient") WebClient expoWebClient) {
+                               @Qualifier("expoWebClient") WebClient expoWebClient,
+                               TransactionTemplate transactionTemplate) {
         this.userSettingRepository = userSettingRepository;
         this.expoPushTokenRepository = expoPushTokenRepository;
         this.expoWebClient = expoWebClient;
+        this.transactionTemplate = transactionTemplate;
     }
 
     @Async("notificationExecutor")
@@ -74,7 +76,6 @@ public class NotificationService {
                 totalCount, totalSuccess, totalFail, totalElapsedTime, Thread.currentThread().getName());
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public int[] processBatchWithTransaction(List<UserSetting> batch, int batchNumber, int totalBatches) {
         long batchStartTime = System.currentTimeMillis();
         int successCount = 0;
@@ -214,10 +215,12 @@ public class NotificationService {
 
     private void markNotificationSuccessInternal(UserSetting setting, LocalDate today, LocalDateTime now) {
         try {
-            setting.setLastSentDate(today);
-            setting.setLastAttemptAt(now);
-            setting.setRetryCount(0);
-            userSettingRepository.save(setting);
+            transactionTemplate.executeWithoutResult(status -> {
+                setting.setLastSentDate(today);
+                setting.setLastAttemptAt(now);
+                setting.setRetryCount(0);
+                userSettingRepository.save(setting);
+            });
             log.info("[Notification] delivery state marked success. userSettingId={}, date={}", setting.getId(), today);
         } catch (Exception e) {
             log.error("[Notification] failed to mark success state. userSettingId={}", setting.getId(), e);
@@ -232,9 +235,11 @@ public class NotificationService {
     ) {
         try {
             int nextRetryCount = calculateNextRetryCount(setting, today);
-            setting.setRetryCount(nextRetryCount);
-            setting.setLastAttemptAt(now);
-            userSettingRepository.save(setting);
+            transactionTemplate.executeWithoutResult(status -> {
+                setting.setRetryCount(nextRetryCount);
+                setting.setLastAttemptAt(now);
+                userSettingRepository.save(setting);
+            });
             log.info("[Notification] delivery state marked failure. userSettingId={}, retryCount={}, reason={}",
                     setting.getId(), nextRetryCount, reason);
         } catch (Exception e) {
@@ -255,8 +260,10 @@ public class NotificationService {
 
     private void markTokenAsInvalidInternal(ExpoPushToken token) {
         try {
-            token.markInvalid();
-            expoPushTokenRepository.save(token);
+            transactionTemplate.executeWithoutResult(status -> {
+                token.markInvalid();
+                expoPushTokenRepository.save(token);
+            });
             log.info("[Notification] token disabled. tokenId={}", token.getId());
         } catch (Exception e) {
             log.error("[Notification] failed to disable token. tokenId={}", token.getId(), e);

--- a/src/main/java/com/melissa/diary/service/SocialLoginFacadeService.java
+++ b/src/main/java/com/melissa/diary/service/SocialLoginFacadeService.java
@@ -1,0 +1,69 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.repository.UserRepository;
+import com.melissa.diary.web.dto.UserRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class SocialLoginFacadeService {
+
+    private final SocialAuthService socialAuthService;
+    private final UserRepository userRepository;
+    private final TransactionTemplate transactionTemplate;
+
+    public User socialLoginGoogle(UserRequestDTO.GoogleOAuthDTO request) {
+        SocialAuthService.GooglePayload payload = socialAuthService.verifyGoogleToken(request.getIdToken());
+        if (payload == null) {
+            throw new ErrorHandler(ErrorStatus.SOCIAL_LOGIN_FAILED);
+        }
+        return upsertSocialUser("GOOGLE", payload.getSub(), payload.getEmail(), payload.getName());
+    }
+
+    public User socialLoginKakao(UserRequestDTO.KakaoOAuthDTO request) {
+        SocialAuthService.KakaoPayload payload = socialAuthService.verifyKakaoToken(request.getAccessToken());
+        if (payload == null) {
+            throw new ErrorHandler(ErrorStatus.SOCIAL_LOGIN_FAILED);
+        }
+        return upsertSocialUser("KAKAO", payload.getId(), payload.getEmail(), payload.getNickname());
+    }
+
+    public User socialLoginApple(UserRequestDTO.AppleOAuthDTO request) {
+        SocialAuthService.ApplePayload payload = socialAuthService.verifyAppleToken(request.getIdToken());
+        if (payload == null) {
+            throw new ErrorHandler(ErrorStatus.SOCIAL_LOGIN_FAILED);
+        }
+        return upsertSocialUser("APPLE", payload.getSub(), payload.getEmail(), payload.getName());
+    }
+
+    private User upsertSocialUser(String provider, String providerId, String email, String nickname) {
+        User user = transactionTemplate.execute(status -> {
+            User socialUser = userRepository.findByProviderAndProviderId(provider, providerId)
+                    .orElseGet(() -> userRepository.save(User.builder()
+                            .provider(provider)
+                            .providerId(providerId)
+                            .email(email)
+                            .nickname(nickname)
+                            .build()));
+
+            if (email != null) {
+                socialUser.setEmail(email);
+            }
+            if (nickname != null) {
+                socialUser.setNickname(nickname);
+            }
+
+            return socialUser;
+        });
+
+        if (user == null) {
+            throw new IllegalStateException("Failed to upsert social user");
+        }
+        return user;
+    }
+}

--- a/src/main/java/com/melissa/diary/service/ThreadService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadService.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import com.melissa.diary.domain.Thread;
 
 import reactor.core.publisher.Flux;
@@ -48,11 +49,13 @@ public class ThreadService {
     private final QuotaService quotaService;
     private final UserMemoryService userMemoryService;
     private final JailbreakDetector jailbreakDetector;
+    private final TransactionTemplate transactionTemplate;
 
     public ThreadService(ThreadRepository threadRepository, UserRepository userRepository, 
                         AiProfileRepository aiProfileRepository, DailyChatLogRepository dailyChatLogRepository, 
                         @Qualifier("aiChatClient") ChatClient chatClient, QuotaService quotaService, 
-                        JailbreakDetector jailbreakDetector, UserMemoryService userMemoryService) {
+                        JailbreakDetector jailbreakDetector, UserMemoryService userMemoryService,
+                        TransactionTemplate transactionTemplate) {
         this.threadRepository = threadRepository;
         this.userRepository = userRepository;
         this.aiProfileRepository = aiProfileRepository;
@@ -61,6 +64,7 @@ public class ThreadService {
         this.quotaService = quotaService;
         this.jailbreakDetector = jailbreakDetector;
         this.userMemoryService = userMemoryService;
+        this.transactionTemplate = transactionTemplate;
     }
 
     @Transactional
@@ -478,7 +482,6 @@ public class ThreadService {
      * v2: 웹 테스트용 Non-SSE 메모리 기반 채팅 (동기 방식)
      * 정성적 평가를 위한 API
      */
-    @Transactional
     public ThreadResponseDTO.ChatResponse messageToAiTest(Long userId, Long aiProfileId,
                                                          int year, int month, int day,
                                                          String content) {
@@ -598,6 +601,107 @@ public class ThreadService {
     /**
      * 날짜 유효성 검증
      */
+    public ThreadResponseDTO.ChatResponse messageToAiTestSeparated(Long userId, Long aiProfileId,
+                                                                   int year, int month, int day,
+                                                                   String content) {
+        PreparedChatContext context = prepareChatContext(userId, aiProfileId, year, month, day, content);
+
+        if (jailbreakDetector.isJailbreakAttempt(content)) {
+            String rejectMsg = "二꾩넚?⑸땲?? ?대떦 ?붿껌? 泥섎━?????놁뒿?덈떎.";
+            return persistAiChatResponse(context, rejectMsg);
+        }
+
+        String prompt = buildAiChatPromptV2(userId, content, context.getChatHistory(), context.getAiProfile());
+
+        try {
+            var chatResponse = chatClient.prompt()
+                    .system(sp -> sp.param("characterPrompt", context.getAiProfile().getPromptText()))
+                    .user(prompt)
+                    .call()
+                    .chatResponse();
+
+            log.info("[ThreadService] Test API ChatResponse: {}", chatResponse);
+
+            String aiResponse = null;
+            if (chatResponse != null && chatResponse.getResults() != null && !chatResponse.getResults().isEmpty()) {
+                aiResponse = chatResponse.getResults().get(0).getOutput().getText();
+            }
+
+            log.info("[ThreadService] Test API OpenAI ?먮낯 ?묐떟: {}", aiResponse);
+
+            String cleanAnswer = aiResponse != null ? aiResponse.replace("null", "").trim() : "";
+            log.info("[ThreadService] Test API ?뺤젣???묐떟: {}", cleanAnswer);
+            return persistAiChatResponse(context, cleanAnswer);
+        } catch (Exception e) {
+            log.error("[ThreadService] ???뚯뒪??梨꾪똿 以??ㅻ쪟 諛쒖깮. userId={}, aiProfileId={}", userId, aiProfileId, e);
+            String errorMsg = "梨꾪똿 泥섎━ 以??ㅻ쪟媛 諛쒖깮?덉뒿?덈떎.";
+            return persistAiChatResponse(context, errorMsg);
+        }
+    }
+
+    private PreparedChatContext prepareChatContext(Long userId, Long aiProfileId, int year, int month, int day, String content) {
+        PreparedChatContext context = transactionTemplate.execute(status -> {
+            quotaService.checkAndConsume(userId, UsageCost.CHAT);
+
+            Thread thread = threadRepository.findByUserIdAndAiProfileIdAndYearAndMonthAndDay(userId, aiProfileId, year, month, day)
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.CALENDAR_NOT_FOUND));
+
+            if (!thread.getUser().getId().equals(userId)) {
+                throw new ErrorHandler(ErrorStatus.THREAD_FORBIDDEN);
+            }
+
+            AiProfile aiProfile = aiProfileRepository.findById(aiProfileId)
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.PROFILE_NOT_FOUND));
+
+            DailyChatLog userLog = DailyChatLog.builder()
+                    .role(Role.USER)
+                    .content(content)
+                    .thread(thread)
+                    .aiProfile(aiProfile)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+            dailyChatLogRepository.save(userLog);
+
+            return new PreparedChatContext(thread.getId(), aiProfile, List.copyOf(thread.getDailyChatLogs()));
+        });
+
+        if (context == null) {
+            throw new IllegalStateException("Failed to prepare chat context");
+        }
+        return context;
+    }
+
+    private ThreadResponseDTO.ChatResponse persistAiChatResponse(PreparedChatContext context, String content) {
+        ThreadResponseDTO.ChatResponse response = transactionTemplate.execute(status -> {
+            Thread thread = threadRepository.getReferenceById(context.getThreadId());
+            AiProfile aiProfile = aiProfileRepository.getReferenceById(context.getAiProfile().getId());
+            LocalDateTime createdAt = LocalDateTime.now();
+
+            DailyChatLog aiChat = DailyChatLog.builder()
+                    .role(Role.AI)
+                    .content(content)
+                    .thread(thread)
+                    .aiProfile(aiProfile)
+                    .createdAt(createdAt)
+                    .build();
+            dailyChatLogRepository.save(aiChat);
+
+            return ThreadResponseDTO.ChatResponse.builder()
+                    .chatId(aiChat.getId())
+                    .role("AI")
+                    .content(content)
+                    .createAt(createdAt)
+                    .aiProfileName(context.getAiProfile().getProfileName())
+                    .aiProfileImageS3(context.getAiProfile().getImageS3())
+                    .build();
+        });
+
+        if (response == null) {
+            throw new IllegalStateException("Failed to persist AI chat response");
+        }
+        return response;
+    }
+
     private boolean isValidDate(int year, int month, int day) {
         if (month < 1 || month > 12) return false;
         if (day < 1 || day > 31) return false;
@@ -624,6 +728,19 @@ public class ThreadService {
 
         public ThreadData(com.melissa.diary.domain.Thread thread, AiProfile aiProfile, List<DailyChatLog> chatHistory) {
             this.thread = thread;
+            this.aiProfile = aiProfile;
+            this.chatHistory = chatHistory;
+        }
+    }
+
+    @Getter
+    private static class PreparedChatContext {
+        private final Long threadId;
+        private final AiProfile aiProfile;
+        private final List<DailyChatLog> chatHistory;
+
+        private PreparedChatContext(Long threadId, AiProfile aiProfile, List<DailyChatLog> chatHistory) {
+            this.threadId = threadId;
             this.aiProfile = aiProfile;
             this.chatHistory = chatHistory;
         }

--- a/src/main/java/com/melissa/diary/service/UserMemoryService.java
+++ b/src/main/java/com/melissa/diary/service/UserMemoryService.java
@@ -5,6 +5,7 @@ import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
 import com.melissa.diary.domain.Diary;
 import com.melissa.diary.domain.User;
 import com.melissa.diary.domain.UserMemory;
+import com.melissa.diary.repository.DiaryRepository;
 import com.melissa.diary.repository.UserMemoryRepository;
 import com.melissa.diary.repository.UserRepository;
 
@@ -13,6 +14,7 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.LocalDate;
 
@@ -24,18 +26,24 @@ public class UserMemoryService {
     
     private final UserMemoryRepository userMemoryRepository;
     private final UserRepository userRepository;
+    private final DiaryRepository diaryRepository;
     private final ChatClient memoryFusionClient;
     private final ChatClient topicChangeDetectionClient;
+    private final TransactionTemplate transactionTemplate;
     
     public UserMemoryService(
             UserMemoryRepository userMemoryRepository,
             UserRepository userRepository,
+            DiaryRepository diaryRepository,
             @Qualifier("memoryFusionClient") ChatClient memoryFusionClient,
-            @Qualifier("topicChangeDetectionClient") ChatClient topicChangeDetectionClient) {
+            @Qualifier("topicChangeDetectionClient") ChatClient topicChangeDetectionClient,
+            TransactionTemplate transactionTemplate) {
         this.userMemoryRepository = userMemoryRepository;
         this.userRepository = userRepository;
+        this.diaryRepository = diaryRepository;
         this.memoryFusionClient = memoryFusionClient;
         this.topicChangeDetectionClient = topicChangeDetectionClient;
+        this.transactionTemplate = transactionTemplate;
     }
     
     /**
@@ -73,6 +81,18 @@ public class UserMemoryService {
     /**
      * Diary를 기반으로 사용자 메모리 업데이트
      */
+    public void updateUserMemoryFromDiarySeparated(Long userId, Long diaryId) {
+        MemoryFusionContext context = loadMemoryFusionContext(userId, diaryId);
+        if (context == null) {
+            log.info("[UserMemory] empty diary content. skip separated memory update. userId={}, diaryId={}", userId, diaryId);
+            return;
+        }
+        String updatedMemory = fuseMemoryWithLLM(context.getCurrentMemory(), context.getDiaryInfo());
+        persistMemoryContent(context.getMemoryId(), updatedMemory);
+
+        log.info("[UserMemory] separated memory update completed. userId={}, diaryId={}", userId, diaryId);
+    }
+
     @Transactional
     public void updateUserMemoryFromDiary(Long userId, Diary diary) {
         // Diary에 내용이 없으면 스킵
@@ -101,6 +121,33 @@ public class UserMemoryService {
     /**
      * Diary 정보를 일기 정보로 변환
      */
+    private MemoryFusionContext loadMemoryFusionContext(Long userId, Long diaryId) {
+        MemoryFusionContext context = transactionTemplate.execute(status -> {
+            Diary diary = diaryRepository.findByIdWithThreadAndChatLogs(diaryId)
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.DIARY_NOT_FOUND));
+
+            if (diary.getContent() == null || diary.getContent().trim().isEmpty()) {
+                return null;
+            }
+
+            UserMemory userMemory = userMemoryRepository.findByUserId(userId)
+                    .orElseGet(() -> createEmptyMemory(userId));
+            String currentMemory = userMemory.getMemoryContent() != null ? userMemory.getMemoryContent() : "";
+            return new MemoryFusionContext(userMemory.getId(), currentMemory, buildDiaryInfo(diary));
+        });
+
+        return context;
+    }
+
+    private void persistMemoryContent(Long memoryId, String updatedMemory) {
+        transactionTemplate.executeWithoutResult(status -> {
+            UserMemory userMemory = userMemoryRepository.findById(memoryId)
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+            userMemory.updateMemoryContent(updatedMemory);
+            userMemoryRepository.save(userMemory);
+        });
+    }
+
     private String buildDiaryInfo(Diary diary) {
         LocalDate diaryDate = LocalDate.of(diary.getYear(), diary.getMonth(), diary.getDay());
         String formattedDate = diaryDate.format(DateTimeFormatter.ofPattern("yyyy년 M월 d일"));
@@ -454,5 +501,13 @@ public class UserMemoryService {
                 
                 위 기준에 따라 현재 메시지가 기존 대화 주제와 완전히 다른 새로운 분야로 전환되었는지 판단해주세요.
                 """, todayConversation, currentMessage);
+    }
+
+    @lombok.Getter
+    @lombok.AllArgsConstructor
+    private static class MemoryFusionContext {
+        private final Long memoryId;
+        private final String currentMemory;
+        private final String diaryInfo;
     }
 }

--- a/src/main/java/com/melissa/diary/web/controller/AuthController.java
+++ b/src/main/java/com/melissa/diary/web/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.melissa.diary.apiPayload.code.status.ErrorStatus;
 import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
 import com.melissa.diary.converter.UserConverter;
 import com.melissa.diary.domain.User;
+import com.melissa.diary.service.SocialLoginFacadeService;
 import com.melissa.diary.service.UserService;
 import com.melissa.diary.web.dto.UserRequestDTO;
 import com.melissa.diary.web.dto.UserResponseDTO;
@@ -28,6 +29,7 @@ import java.security.Principal;
 public class AuthController {
 
     private final UserService userService;
+    private final SocialLoginFacadeService socialLoginFacadeService;
 
     // 구글 로그인
     @PostMapping("/google")
@@ -44,7 +46,7 @@ public class AuthController {
             @RequestBody @Valid UserRequestDTO.GoogleOAuthDTO request
     ) {
         // 1) 소셜 로그인 처리
-        User user = userService.socialLoginGoogle(request);
+        User user = socialLoginFacadeService.socialLoginGoogle(request);
 
         // 2) JWT 발급
         String accessToken = userService.createAccessToken(user);
@@ -71,7 +73,7 @@ public class AuthController {
     public ApiResponse<UserResponseDTO.OAuthLoginResultDTO> kakaoLogin(
             @RequestBody @Valid UserRequestDTO.KakaoOAuthDTO request
     ) {
-        User user = userService.socialLoginKakao(request);
+        User user = socialLoginFacadeService.socialLoginKakao(request);
         String accessToken = userService.createAccessToken(user);
         String refreshToken = userService.createRefreshToken(user);
         UserResponseDTO.OAuthLoginResultDTO result =
@@ -93,7 +95,7 @@ public class AuthController {
     public ApiResponse<UserResponseDTO.OAuthLoginResultDTO> appleLogin(
             @RequestBody @Valid UserRequestDTO.AppleOAuthDTO request
     ) {
-        User user = userService.socialLoginApple(request);
+        User user = socialLoginFacadeService.socialLoginApple(request);
         String accessToken = userService.createAccessToken(user);
         String refreshToken = userService.createRefreshToken(user);
         UserResponseDTO.OAuthLoginResultDTO result =

--- a/src/main/java/com/melissa/diary/web/controller/DiaryController.java
+++ b/src/main/java/com/melissa/diary/web/controller/DiaryController.java
@@ -42,7 +42,7 @@ public class DiaryController {
             Principal principal) {
         
         Long userId = Long.parseLong(principal.getName());
-        DiaryResponseDTO.DiaryResponse response = diaryService.createChatDiary(userId, request);
+        DiaryResponseDTO.DiaryResponse response = diaryService.createChatDiarySeparated(userId, request);
         
         return ApiResponse.onSuccess(response);
     }
@@ -62,7 +62,7 @@ public class DiaryController {
             Principal principal) {
         
         Long userId = Long.parseLong(principal.getName());
-        DiaryResponseDTO.DiaryResponse response = diaryService.createManualDiary(userId, request);
+        DiaryResponseDTO.DiaryResponse response = diaryService.createManualDiarySeparated(userId, request);
         
         return ApiResponse.onSuccess(response);
     }
@@ -84,7 +84,7 @@ public class DiaryController {
             Principal principal) {
         
         Long userId = Long.parseLong(principal.getName());
-        DiaryResponseDTO.DiaryResponse response = diaryService.updateDiary(userId, diaryId, request);
+        DiaryResponseDTO.DiaryResponse response = diaryService.updateDiarySeparated(userId, diaryId, request);
         
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/melissa/diary/web/controller/ThreadController.java
+++ b/src/main/java/com/melissa/diary/web/controller/ThreadController.java
@@ -1,6 +1,8 @@
 package com.melissa.diary.web.controller;
 
 import com.melissa.diary.apiPayload.ApiResponse;
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
 import com.melissa.diary.service.ChatLogService;
 import com.melissa.diary.service.IdempotencyService;
 import com.melissa.diary.service.ThreadService;
@@ -101,25 +103,7 @@ public class ThreadController {
             @Valid @RequestBody ThreadRequestDTO.AiChatRequest request,
             @RequestHeader(value = IDEMPOTENCY_HEADER, required = false) String idempotencyKey,
             Principal principal) {
-        Long userId = Long.parseLong(principal.getName());
-
-        if (isBlank(idempotencyKey)) {
-            return threadService.messageToAi(
-                    userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent()
-            );
-        }
-
-        var claim = idempotencyService.claim(userId, V1_CHAT_MESSAGE_ENDPOINT, idempotencyKey, request);
-        if (claim.getAction() == IdempotencyService.ClaimAction.RETURN_CACHED) {
-            return buildCachedAiStream(claim.getRecord().getResponseBody());
-        }
-
-        return wrapIdempotentStream(
-                claim.getRecord().getId(),
-                threadService.messageToAi(
-                        userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent()
-                )
-        );
+        throw new ErrorHandler(ErrorStatus.CHAT_SSE_DISABLED);
     }
 
     @Operation(summary = "채팅 메시지 조회",
@@ -191,25 +175,7 @@ public class ThreadController {
             @RequestHeader(value = IDEMPOTENCY_HEADER, required = false) String idempotencyKey,
             Principal principal
     ) {
-        Long userId = Long.parseLong(principal.getName());
-
-        if (isBlank(idempotencyKey)) {
-            return threadService.messageToAiV2(
-                    userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent()
-            );
-        }
-
-        var claim = idempotencyService.claim(userId, V2_CHAT_MESSAGE_ENDPOINT, idempotencyKey, request);
-        if (claim.getAction() == IdempotencyService.ClaimAction.RETURN_CACHED) {
-            return buildCachedAiStream(claim.getRecord().getResponseBody());
-        }
-
-        return wrapIdempotentStream(
-                claim.getRecord().getId(),
-                threadService.messageToAiV2(
-                        userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent()
-                )
-        );
+        throw new ErrorHandler(ErrorStatus.CHAT_SSE_DISABLED);
     }
 
     @PostMapping("/v2/chats/message-test")
@@ -223,7 +189,7 @@ public class ThreadController {
         Long userId = Long.parseLong(principal.getName());
 
         if (isBlank(idempotencyKey)) {
-            ThreadResponseDTO.ChatResponse response = threadService.messageToAiTest(
+            ThreadResponseDTO.ChatResponse response = threadService.messageToAiTestSeparated(
                     userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent()
             );
             return ApiResponse.onSuccess(response);
@@ -239,7 +205,7 @@ public class ThreadController {
         }
 
         try {
-            ThreadResponseDTO.ChatResponse response = threadService.messageToAiTest(
+            ThreadResponseDTO.ChatResponse response = threadService.messageToAiTestSeparated(
                     userId, request.getAiProfileId(), request.getYear(), request.getMonth(), request.getDay(), request.getContent()
             );
             idempotencyService.markSucceeded(claim.getRecord().getId(), idempotencyService.serialize(response));


### PR DESCRIPTION

## 🧑🏻‍💻 PR 작업 내역 요약
`STAB-006` 범위에서 긴 트랜잭션 안에 섞여 있던 외부 API 호출 구간을 분리했습니다.
핵심 목표는 DB 트랜잭션을 짧게 유지하고, OAuth/LLM/Push 같은 외부 I/O를 트랜잭션 밖으로 빼는 것이었습니다.

이번 PR에서는 소셜 로그인, 테스트 채팅, 일기 생성/수정, 메모리 갱신, 알림 상태 저장 흐름을 `prepare -> external call -> persist` 구조로 정리했습니다.
단순 CRUD가 아닌 다단계 흐름은 `@Transactional` 대신 `TransactionTemplate`로 경계를 명시적으로 표현했습니다.

## 📋 변경 사항
- 소셜 로그인에서 외부 provider 토큰 검증을 트랜잭션 밖으로 분리하고, user upsert만 짧은 트랜잭션으로 처리하도록 `SocialLoginFacadeService`를 추가했습니다.
- 테스트용 채팅 API에서 quota 차감, thread/profile 검증, user message 저장과 OpenAI 호출, AI 응답 저장을 단계별로 분리했습니다.
- `SSE` 채팅 API는 현재 정책에 맞춰 `410 Gone`으로 비활성화하고, 테스트용 non-SSE 채팅 경로만 유지했습니다.
- 수동 일기 / 채팅 기반 일기 생성에서 사전 검증과 quota/day-limit 체크를 먼저 짧은 트랜잭션으로 처리한 뒤, LLM 요약/해시태그 생성은 트랜잭션 밖에서 수행하도록 변경했습니다.
- 일기 수정은 본문 수정 트랜잭션과 이미지 재생성 요청 상태 변경 트랜잭션을 분리했습니다.
- 메모리 스케줄러의 전체 트랜잭션을 제거하고, memory context 조회와 최종 저장만 짧은 트랜잭션으로 처리하도록 변경했습니다.
- 알림 배치 전체를 하나의 트랜잭션으로 묶지 않고, 성공 마킹 / 실패 retryCount 반영 / invalid token 처리만 작은 트랜잭션으로 저장하도록 변경했습니다.

## 🔍 Code Review
- 이번 PR 범위는 `STAB-006` 마감이며, 테스트 정상화 / 멱등성 확장 / S3 URL 비의존화는 포함하지 않았습니다.
- `TransactionTemplate`로 나눈 prepare/finalize 경계가 비즈니스 의도와 맞는지 확인 부탁드립니다.
- 로컬에서는 `./gradlew compileJava`까지 확인했습니다. 전체 테스트 정상화는 후속 이슈에서 진행 예정입니다.

## 📸 ScreenShot
- 백엔드 리팩터링 PR로 별도 스크린샷은 없습니다.