### PR TITLE
feat: #273 S3 URL 비의존화 및 asset key 저장 전환

### DIFF
--- a/src/main/java/com/melissa/diary/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/melissa/diary/aws/s3/AmazonS3Manager.java
@@ -1,17 +1,17 @@
 package com.melissa.diary.aws.s3;
 
-        import com.amazonaws.services.s3.AmazonS3;
-        import com.amazonaws.services.s3.model.ObjectMetadata;
-        import com.amazonaws.services.s3.model.PutObjectRequest;
-        import com.melissa.diary.config.AmazonConfig;
-        import com.melissa.diary.domain.Uuid;
-        import lombok.RequiredArgsConstructor;
-        import lombok.extern.slf4j.Slf4j;
-        import org.springframework.stereotype.Component;
-        import org.springframework.web.multipart.MultipartFile;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.melissa.diary.config.AmazonConfig;
+import com.melissa.diary.domain.Uuid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
-        import java.io.IOException;
-        import java.util.Base64;
+import java.io.IOException;
+import java.util.Base64;
 
 @Slf4j
 @Component
@@ -32,7 +32,7 @@ public class AmazonS3Manager{
             log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
         }
 
-        return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+        return keyName;
     }
 
     public String uploadFileFromBase64(String keyName, String base64Data, String contentType){

--- a/src/main/java/com/melissa/diary/aws/s3/S3AssetUrlResolver.java
+++ b/src/main/java/com/melissa/diary/aws/s3/S3AssetUrlResolver.java
@@ -1,0 +1,146 @@
+package com.melissa.diary.aws.s3;
+
+import com.melissa.diary.config.AmazonConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+@Component
+@RequiredArgsConstructor
+public class S3AssetUrlResolver {
+
+    private final AmazonConfig amazonConfig;
+
+    public String resolve(String storedValue) {
+        if (!StringUtils.hasText(storedValue)) {
+            return null;
+        }
+
+        String normalized = storedValue.trim();
+
+        if (isHttpUrl(normalized)) {
+            String extractedKey = extractKeyFromUrl(normalized);
+            return StringUtils.hasText(extractedKey) ? buildPublicUrl(extractedKey) : normalized;
+        }
+
+        if (normalized.startsWith("s3://")) {
+            String extractedKey = extractKeyFromS3Uri(normalized);
+            return StringUtils.hasText(extractedKey) ? buildPublicUrl(extractedKey) : normalized;
+        }
+
+        return buildPublicUrl(normalized);
+    }
+
+    public String toStorageKey(String storedValue) {
+        if (!StringUtils.hasText(storedValue)) {
+            return null;
+        }
+
+        String normalized = storedValue.trim();
+
+        if (isHttpUrl(normalized)) {
+            String extractedKey = extractKeyFromUrl(normalized);
+            return StringUtils.hasText(extractedKey) ? extractedKey : normalized;
+        }
+
+        if (normalized.startsWith("s3://")) {
+            String extractedKey = extractKeyFromS3Uri(normalized);
+            return StringUtils.hasText(extractedKey) ? extractedKey : normalized;
+        }
+
+        return stripLeadingSlash(normalized);
+    }
+
+    private String buildPublicUrl(String key) {
+        String normalizedKey = stripLeadingSlash(key);
+        String baseUrl = StringUtils.hasText(amazonConfig.getPublicBaseUrl())
+                ? amazonConfig.getPublicBaseUrl().trim()
+                : "https://%s.s3.%s.amazonaws.com".formatted(amazonConfig.getBucket(), amazonConfig.getRegion());
+
+        if (baseUrl.endsWith("/")) {
+            return baseUrl + normalizedKey;
+        }
+        return baseUrl + "/" + normalizedKey;
+    }
+
+    private String extractKeyFromUrl(String absoluteUrl) {
+        try {
+            URI uri = new URI(absoluteUrl);
+            String host = uri.getHost();
+            if (!StringUtils.hasText(host)) {
+                return null;
+            }
+
+            String path = stripLeadingSlash(uri.getPath());
+            if (!StringUtils.hasText(path)) {
+                return null;
+            }
+
+            if (isPathStyleS3Host(host)) {
+                return removeFirstPathSegment(path);
+            }
+
+            if (path.startsWith(amazonConfig.getBucket() + "/")) {
+                return path.substring(amazonConfig.getBucket().length() + 1);
+            }
+
+            if (host.equalsIgnoreCase(getConfiguredPublicHost()) || host.contains(".amazonaws.com")) {
+                return path;
+            }
+
+            return null;
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
+    private String extractKeyFromS3Uri(String s3Uri) {
+        String withoutScheme = s3Uri.substring("s3://".length());
+        int firstSlash = withoutScheme.indexOf('/');
+        if (firstSlash < 0 || firstSlash == withoutScheme.length() - 1) {
+            return null;
+        }
+        return stripLeadingSlash(withoutScheme.substring(firstSlash + 1));
+    }
+
+    private String getConfiguredPublicHost() {
+        String publicBaseUrl = amazonConfig.getPublicBaseUrl();
+        if (!StringUtils.hasText(publicBaseUrl)) {
+            return "%s.s3.%s.amazonaws.com".formatted(amazonConfig.getBucket(), amazonConfig.getRegion());
+        }
+
+        try {
+            return new URI(publicBaseUrl).getHost();
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+
+    private boolean isHttpUrl(String value) {
+        return value.startsWith("http://") || value.startsWith("https://");
+    }
+
+    private boolean isPathStyleS3Host(String host) {
+        return "s3.amazonaws.com".equalsIgnoreCase(host)
+                || host.startsWith("s3.")
+                || host.startsWith("s3-");
+    }
+
+    private String removeFirstPathSegment(String value) {
+        int firstSlash = value.indexOf('/');
+        if (firstSlash < 0 || firstSlash == value.length() - 1) {
+            return value;
+        }
+        return value.substring(firstSlash + 1);
+    }
+
+    private String stripLeadingSlash(String value) {
+        if (!StringUtils.hasText(value)) {
+            return value;
+        }
+        return value.startsWith("/") ? value.substring(1) : value;
+    }
+}

--- a/src/main/java/com/melissa/diary/config/AmazonConfig.java
+++ b/src/main/java/com/melissa/diary/config/AmazonConfig.java
@@ -31,6 +31,12 @@ public class AmazonConfig {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+    @Value("${cloud.aws.s3.public-base-url:}")
+    private String publicBaseUrl;
+
+    @Value("${cloud.aws.s3.default-image-key:default.png}")
+    private String defaultImageKey;
+
     @Value("${cloud.aws.path.ai-profile}")
     private String aiProfile;
 

--- a/src/main/java/com/melissa/diary/converter/AiProfileConverter.java
+++ b/src/main/java/com/melissa/diary/converter/AiProfileConverter.java
@@ -1,11 +1,18 @@
 package com.melissa.diary.converter;
 
+import com.melissa.diary.aws.s3.S3AssetUrlResolver;
 import com.melissa.diary.domain.AiProfile;
 import com.melissa.diary.web.dto.AiProfileResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
+@Component
+@RequiredArgsConstructor
 public class AiProfileConverter {
 
-    public static AiProfileResponseDTO.AiProfileResponse toResponse(AiProfile aiProfile){
+    private final S3AssetUrlResolver s3AssetUrlResolver;
+
+    public AiProfileResponseDTO.AiProfileResponse toResponse(AiProfile aiProfile){
         return AiProfileResponseDTO.AiProfileResponse.builder()
                 .aiProfileId(aiProfile.getId())
                 .profileName(aiProfile.getProfileName())
@@ -14,13 +21,13 @@ public class AiProfileConverter {
                 .feature3(aiProfile.getFeature3())
                 .hashTag1(aiProfile.getHashTag1())
                 .hashTag2(aiProfile.getHashTag2())
-                .imageUrl(aiProfile.getImageS3())
+                .imageUrl(s3AssetUrlResolver.resolve(aiProfile.getImageS3()))
                 .createdAt(aiProfile.getCreatedAt())
                 .isDefault(true)
                 .build();
     }
 
-    public static AiProfileResponseDTO.AiProfileQuestionResponse toQuestion(AiProfile aiProfile){
+    public AiProfileResponseDTO.AiProfileQuestionResponse toQuestion(AiProfile aiProfile){
         return AiProfileResponseDTO.AiProfileQuestionResponse.builder()
                 .q1(aiProfile.getQ1())
                 .q2(aiProfile.getQ2())

--- a/src/main/java/com/melissa/diary/converter/DiaryConverter.java
+++ b/src/main/java/com/melissa/diary/converter/DiaryConverter.java
@@ -1,19 +1,24 @@
 package com.melissa.diary.converter;
 
+import com.melissa.diary.aws.s3.S3AssetUrlResolver;
 import com.melissa.diary.domain.Diary;
 import com.melissa.diary.web.dto.CalendarResponseDTO;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 /**
  * Diary 엔티티를 DTO로 변환하는 컨버터
  */
 @Component
+@RequiredArgsConstructor
 public class DiaryConverter {
+
+    private final S3AssetUrlResolver s3AssetUrlResolver;
     
     /**
      * Diary -> DiaryDetailDTO 변환 (상세 정보)
      */
-    public static CalendarResponseDTO.DiaryDetailDTO toDiaryDetailDTO(Diary diary) {
+    public CalendarResponseDTO.DiaryDetailDTO toDiaryDetailDTO(Diary diary) {
         return CalendarResponseDTO.DiaryDetailDTO.builder()
                 .diaryId(diary.getId())
                 .aiProfileId(diary.getThread().getAiProfile().getId())
@@ -23,7 +28,7 @@ public class DiaryConverter {
                 .type(diary.getType().name())
                 .hashtag1(diary.getHashtag1())
                 .hashtag2(diary.getHashtag2())
-                .imageUrl(diary.getImageUrl())
+                .imageUrl(s3AssetUrlResolver.resolve(diary.getImageUrl()))
                 .imageStatus(diary.getImageStatus() != null ? diary.getImageStatus().name() : null)
                 .version(diary.getVersion())
                 .createdAt(diary.getCreatedAt())
@@ -33,14 +38,14 @@ public class DiaryConverter {
     /**
      * Diary -> DiaryPreviewDTO 변환 (미리보기)
      */
-    public static CalendarResponseDTO.DiaryPreviewDTO toDiaryPreviewDTO(Diary diary) {
+    public CalendarResponseDTO.DiaryPreviewDTO toDiaryPreviewDTO(Diary diary) {
         return CalendarResponseDTO.DiaryPreviewDTO.builder()
                 .diaryId(diary.getId())
                 .aiProfileId(diary.getThread().getAiProfile().getId())
                 .type(diary.getType().name())
                 .hashtag1(diary.getHashtag1())
                 .hashtag2(diary.getHashtag2())
-                .imageUrl(diary.getImageUrl())
+                .imageUrl(s3AssetUrlResolver.resolve(diary.getImageUrl()))
                 .imageStatus(diary.getImageStatus() != null ? diary.getImageStatus().name() : null)
                 .build();
     }

--- a/src/main/java/com/melissa/diary/service/AiProfileService.java
+++ b/src/main/java/com/melissa/diary/service/AiProfileService.java
@@ -23,6 +23,7 @@ public class AiProfileService {
     private final AiProfileRepository aiProfileRepository;
     private final DailyChatLogRepository dailyChatLogRepository;
     private final UserRepository userRepository;
+    private final AiProfileConverter aiProfileConverter;
 
     @Transactional(readOnly = true)
     public AiProfileResponseDTO.AiProfileResponse getAiProfile(Long userId, Long aiProfileId){
@@ -32,7 +33,7 @@ public class AiProfileService {
         AiProfile aiProfile = aiProfileRepository.findByIdAndActiveIsTrue(aiProfileId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.PROFILE_NOT_FOUND));
 
-        return AiProfileConverter.toResponse(aiProfile);
+        return aiProfileConverter.toResponse(aiProfile);
     }
 
     @Transactional(readOnly = true)
@@ -43,7 +44,7 @@ public class AiProfileService {
         AiProfile aiProfile = aiProfileRepository.findByIdAndActiveIsTrue(aiProfileId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.PROFILE_NOT_FOUND));
         
-        return AiProfileConverter.toQuestion(aiProfile);
+        return aiProfileConverter.toQuestion(aiProfile);
     }
 
     @Transactional(readOnly = true)
@@ -53,7 +54,7 @@ public class AiProfileService {
 
         List<AiProfile> aiProfileList = aiProfileRepository.findByActiveIsTrueOrderByIdAsc();
 
-        return aiProfileList.stream().map(AiProfileConverter::toResponse).toList();
+        return aiProfileList.stream().map(aiProfileConverter::toResponse).toList();
     }
 
     @Transactional(readOnly = true)
@@ -65,13 +66,13 @@ public class AiProfileService {
             // 채팅 기록이 없으면 첫 번째 프로필 반환
             List<AiProfile> profiles = aiProfileRepository.findByActiveIsTrueOrderByIdAsc();
             if (profiles.isEmpty()) throw new ErrorHandler(ErrorStatus.PROFILE_NOT_FOUND);
-            return AiProfileConverter.toResponse(profiles.get(0));
+            return aiProfileConverter.toResponse(profiles.get(0));
         }
         
         AiProfile recentProfile = recentChatLog.get().getThread().getAiProfile();
         if (!recentProfile.isActive()) {
             throw new ErrorHandler(ErrorStatus.PROFILE_NOT_FOUND);
         }
-        return AiProfileConverter.toResponse(recentProfile);
+        return aiProfileConverter.toResponse(recentProfile);
     }
 }

--- a/src/main/java/com/melissa/diary/service/CalendarService.java
+++ b/src/main/java/com/melissa/diary/service/CalendarService.java
@@ -30,6 +30,7 @@ public class CalendarService {
 
     private final DiaryRepository diaryRepository;
     private final UserRepository userRepository;
+    private final DiaryConverter diaryConverter;
 
     /**
      * 특정 날짜의 일기 상세 조회 (최대 3개)
@@ -50,7 +51,7 @@ public class CalendarService {
         // 일기가 없어도 빈 배열로 반환 (에러 발생하지 않음)
         List<CalendarResponseDTO.DiaryDetailDTO> diaryDetails = diaries.stream()
                 .limit(3) // 최대 3개로 제한
-                .map(DiaryConverter::toDiaryDetailDTO)
+                .map(diaryConverter::toDiaryDetailDTO)
                 .collect(Collectors.toList());
 
         return CalendarResponseDTO.DailySummaryResponseDTO.builder()
@@ -94,7 +95,7 @@ public class CalendarService {
                     // 최대 3개로 제한하고 DiaryPreviewDTO로 변환
                     List<CalendarResponseDTO.DiaryPreviewDTO> previews = dayDiaries.stream()
                             .limit(3)
-                            .map(DiaryConverter::toDiaryPreviewDTO)
+                            .map(diaryConverter::toDiaryPreviewDTO)
                             .collect(Collectors.toList());
 
                     return CalendarResponseDTO.DailyPreviewResponseDTO.builder()
@@ -140,7 +141,7 @@ public class CalendarService {
                     // 최대 3개로 제한하고 DiaryDetailDTO로 변환
                     List<CalendarResponseDTO.DiaryDetailDTO> details = dayDiaries.stream()
                             .limit(3)
-                            .map(DiaryConverter::toDiaryDetailDTO)
+                            .map(diaryConverter::toDiaryDetailDTO)
                             .collect(Collectors.toList());
 
                     return CalendarResponseDTO.DailySummaryResponseDTO.builder()
@@ -210,7 +211,7 @@ public class CalendarService {
                 
                 // 각 날짜별 최대 3개까지만 추가
                 if (diaryList.size() < 3) {
-                    diaryList.add(DiaryConverter.toDiaryDetailDTO(diary));
+                    diaryList.add(diaryConverter.toDiaryDetailDTO(diary));
                     dayParts.putIfAbsent(key, new int[]{diary.getYear(), diary.getMonth(), diary.getDay()});
                 }
                 

--- a/src/main/java/com/melissa/diary/service/DiaryImageService.java
+++ b/src/main/java/com/melissa/diary/service/DiaryImageService.java
@@ -1,6 +1,8 @@
 package com.melissa.diary.service;
 
 import com.melissa.diary.ai.ImageGenerator;
+import com.melissa.diary.aws.s3.S3AssetUrlResolver;
+import com.melissa.diary.config.AmazonConfig;
 import com.melissa.diary.domain.Diary;
 import com.melissa.diary.domain.enums.DiaryImageStatus;
 import com.melissa.diary.repository.DiaryRepository;
@@ -15,12 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DiaryImageService {
 
-    private static final String DEFAULT_IMG =
-            "https://melissa-s3.s3.ap-northeast-2.amazonaws.com/default.png";
-
     private final DiaryRepository diaryRepository;
     private final ImageGenerator imageGenerator;
     private final DiaryImagePromptRefinerService refiner;
+    private final AmazonConfig amazonConfig;
+    private final S3AssetUrlResolver s3AssetUrlResolver;
 
     public void generateAndSaveImage(Long diaryId) {
         Diary diary = diaryRepository.findById(diaryId).orElse(null);
@@ -44,34 +45,34 @@ public class DiaryImageService {
         String finalPrompt = refiner.refine(rawPrompt);
 
         try {
-            String url = imageGenerator.genDiaryImage(finalPrompt);
-            markImageReady(diaryId, url);
-            log.info("[Async-DiaryImage] image generation completed. diaryId={}, url={}", diaryId, url);
+            String imageKey = imageGenerator.genDiaryImage(finalPrompt);
+            markImageReady(diaryId, imageKey);
+            log.info("[Async-DiaryImage] image generation completed. diaryId={}, key={}", diaryId, imageKey);
         } catch (Exception e) {
             log.error("[Async-DiaryImage] diaryId={} processing failed", diaryId, e);
-            markImageFailed(diaryId, DEFAULT_IMG);
+            markImageFailed(diaryId, amazonConfig.getDefaultImageKey());
         }
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void markImageReady(Long diaryId, String url) {
+    public void markImageReady(Long diaryId, String imageKey) {
         Diary diary = diaryRepository.findById(diaryId).orElse(null);
         if (diary == null || diary.getImageStatus() != DiaryImageStatus.PENDING) {
             return;
         }
 
-        diary.markImageReady(url);
+        diary.markImageReady(s3AssetUrlResolver.toStorageKey(imageKey));
         diaryRepository.save(diary);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void markImageFailed(Long diaryId, String fallbackUrl) {
+    public void markImageFailed(Long diaryId, String fallbackImageKey) {
         Diary diary = diaryRepository.findById(diaryId).orElse(null);
         if (diary == null || diary.getImageStatus() != DiaryImageStatus.PENDING) {
             return;
         }
 
-        diary.markImageFailed(fallbackUrl);
+        diary.markImageFailed(s3AssetUrlResolver.toStorageKey(fallbackImageKey));
         diaryRepository.save(diary);
     }
 
@@ -107,4 +108,3 @@ public class DiaryImageService {
         return prompt.toString();
     }
 }
-

--- a/src/main/java/com/melissa/diary/service/DiaryService.java
+++ b/src/main/java/com/melissa/diary/service/DiaryService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.melissa.diary.apiPayload.code.status.ErrorStatus;
 import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.aws.s3.S3AssetUrlResolver;
 import com.melissa.diary.domain.AiProfile;
 import com.melissa.diary.domain.DailyChatLog;
 import com.melissa.diary.domain.Diary;
@@ -49,6 +50,7 @@ public class DiaryService {
     private final ChatClient summaryClient;
     private final ChatClient hashtagClient;
     private final TransactionTemplate transactionTemplate;
+    private final S3AssetUrlResolver s3AssetUrlResolver;
     private final ObjectMapper objectMapper = new ObjectMapper();
     
     public DiaryService(DiaryRepository diaryRepository, 
@@ -59,7 +61,8 @@ public class DiaryService {
                        ApplicationEventPublisher publisher,
                        @Qualifier("summaryClient") ChatClient summaryClient,
                        @Qualifier("hashtagClient") ChatClient hashtagClient,
-                       TransactionTemplate transactionTemplate) {
+                       TransactionTemplate transactionTemplate,
+                       S3AssetUrlResolver s3AssetUrlResolver) {
         this.diaryRepository = diaryRepository;
         this.userRepository = userRepository;
         this.threadRepository = threadRepository;
@@ -69,6 +72,7 @@ public class DiaryService {
         this.summaryClient = summaryClient;
         this.hashtagClient = hashtagClient;
         this.transactionTemplate = transactionTemplate;
+        this.s3AssetUrlResolver = s3AssetUrlResolver;
     }
     
     /**
@@ -396,7 +400,7 @@ public class DiaryService {
                 .type(diary.getType().name())
                 .hashtag1(diary.getHashtag1())
                 .hashtag2(diary.getHashtag2())
-                .imageUrl(diary.getImageUrl())
+                .imageUrl(s3AssetUrlResolver.resolve(diary.getImageUrl()))
                 .imageStatus(diary.getImageStatus() != null ? diary.getImageStatus().name() : null)
                 .version(diary.getVersion())
                 .createdAt(diary.getCreatedAt())

--- a/src/main/java/com/melissa/diary/service/ThreadService.java
+++ b/src/main/java/com/melissa/diary/service/ThreadService.java
@@ -2,6 +2,7 @@ package com.melissa.diary.service;
 
 import com.melissa.diary.apiPayload.code.status.ErrorStatus;
 import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.aws.s3.S3AssetUrlResolver;
 import com.melissa.diary.domain.AiProfile;
 import com.melissa.diary.domain.DailyChatLog;
 import com.melissa.diary.domain.User;
@@ -50,12 +51,13 @@ public class ThreadService {
     private final UserMemoryService userMemoryService;
     private final JailbreakDetector jailbreakDetector;
     private final TransactionTemplate transactionTemplate;
+    private final S3AssetUrlResolver s3AssetUrlResolver;
 
     public ThreadService(ThreadRepository threadRepository, UserRepository userRepository, 
                         AiProfileRepository aiProfileRepository, DailyChatLogRepository dailyChatLogRepository, 
                         @Qualifier("aiChatClient") ChatClient chatClient, QuotaService quotaService, 
                         JailbreakDetector jailbreakDetector, UserMemoryService userMemoryService,
-                        TransactionTemplate transactionTemplate) {
+                        TransactionTemplate transactionTemplate, S3AssetUrlResolver s3AssetUrlResolver) {
         this.threadRepository = threadRepository;
         this.userRepository = userRepository;
         this.aiProfileRepository = aiProfileRepository;
@@ -65,6 +67,7 @@ public class ThreadService {
         this.jailbreakDetector = jailbreakDetector;
         this.userMemoryService = userMemoryService;
         this.transactionTemplate = transactionTemplate;
+        this.s3AssetUrlResolver = s3AssetUrlResolver;
     }
 
     @Transactional
@@ -464,6 +467,7 @@ public class ThreadService {
                                 .orElse(""))  // aiProfile이 null이면 빈 문자열
                         .aiProfileImageS3(Optional.ofNullable(log.getAiProfile())
                                 .map(AiProfile::getImageS3)
+                                .map(s3AssetUrlResolver::resolve)
                                 .orElse(""))  // aiProfile이 null이면 빈 문자열
                         .content(log.getContent())
                         .createAt(log.getCreatedAt())
@@ -473,7 +477,7 @@ public class ThreadService {
         // 최종 Response
         return ThreadResponseDTO.ChatListResponse.builder()
                 .aiProfileName(thread.getAiProfile().getProfileName())
-                .aiProfileImageS3(thread.getAiProfile().getImageS3())
+                .aiProfileImageS3(s3AssetUrlResolver.resolve(thread.getAiProfile().getImageS3()))
                 .chats(mappedChats)
                 .build();
     }
@@ -529,7 +533,7 @@ public class ThreadService {
                     .content(rejectMsg)
                     .createAt(LocalDateTime.now())
                     .aiProfileName(aiProfile.getProfileName())
-                    .aiProfileImageS3(aiProfile.getImageS3())
+                    .aiProfileImageS3(s3AssetUrlResolver.resolve(aiProfile.getImageS3()))
                     .build();
         }
         
@@ -572,7 +576,7 @@ public class ThreadService {
                     .content(cleanAnswer)
                     .createAt(LocalDateTime.now())
                     .aiProfileName(aiProfile.getProfileName())
-                    .aiProfileImageS3(aiProfile.getImageS3())
+                    .aiProfileImageS3(s3AssetUrlResolver.resolve(aiProfile.getImageS3()))
                     .build();
 
         } catch (Exception e) {
@@ -593,7 +597,7 @@ public class ThreadService {
                     .content(errorMsg)
                     .createAt(LocalDateTime.now())
                     .aiProfileName(aiProfile.getProfileName())
-                    .aiProfileImageS3(aiProfile.getImageS3())
+                    .aiProfileImageS3(s3AssetUrlResolver.resolve(aiProfile.getImageS3()))
                     .build();
         }
     }
@@ -692,7 +696,7 @@ public class ThreadService {
                     .content(content)
                     .createAt(createdAt)
                     .aiProfileName(context.getAiProfile().getProfileName())
-                    .aiProfileImageS3(context.getAiProfile().getImageS3())
+                    .aiProfileImageS3(s3AssetUrlResolver.resolve(context.getAiProfile().getImageS3()))
                     .build();
         });
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,7 +49,7 @@ cloud:
   aws:
     s3:
       bucket: melissa-s3
-      public-base-url:
+      public-base-url: ${AWS_S3_PUBLIC_BASE_URL:}
       default-image-key: default.png
     path:
       day-summary: day-summary

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,6 +49,8 @@ cloud:
   aws:
     s3:
       bucket: melissa-s3
+      public-base-url:
+      default-image-key: default.png
     path:
       day-summary: day-summary
       month-summary: month-summary


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
AWS 계정 이전 전에 S3 bucket URL에 대한 DB 의존성을 줄이기 위해, 이미지 저장값을 absolute URL 중심 구조에서 asset key 중심 구조로 전환했습니다.

이번 PR에서는 새로 생성되는 diary / ai profile 이미지 저장값은 key만 저장하도록 변경했고, 기존 운영 데이터에 남아 있는 absolute URL 값도 앱 레이어에서 key를 추출한 뒤 현재 `public-base-url` 기준으로 다시 조합해 응답하도록 정리했습니다.

## 📋 변경 사항
- S3 업로드 결과를 absolute URL이 아닌 object key로 반환하도록 변경했습니다.
- `S3AssetUrlResolver`를 추가해 `absolute URL / s3:// / key` 형태를 모두 읽고 현재 공개 URL로 재조합하도록 구현했습니다.
- diary 이미지 비동기 생성 완료/실패 시 DB에는 key만 저장하도록 변경했습니다.
- diary / ai profile 응답 변환 경로에서 저장값을 그대로 노출하지 않고 resolver를 거쳐 URL을 반환하도록 변경했습니다.
- `application.yml`에 `cloud.aws.s3.public-base-url` 설정을 추가하고 `AWS_S3_PUBLIC_BASE_URL` 환경변수로 주입받도록 정리했습니다.

## 🔍 Code Review
- 기존 운영 DB에 저장된 absolute URL 데이터가 그대로 있어도 정상적으로 응답 URL이 재조합되는지 확인(로컬 테스트 완료)
- 새로 생성되는 이미지 저장값이 DB에 absolute URL이 아닌 key로 저장되는지 확인
- `AWS_S3_PUBLIC_BASE_URL`만 변경하면 이후 AWS 계정 이전 시 응답 URL이 의도대로 전환되는지 확인
- 이번 PR은 스키마 변경이나 필수 SQL 마이그레이션을 포함하지 않습니다. 기존 absolute URL 데이터는 앱에서 호환 처리

## 📸 ScreenShot
- 백엔드 리팩터링 및 설정 변경 PR로 별도 스크린샷은 없습니다.