### PR TITLE
feat: 실패 재시도 정책 표준화

### DIFF
--- a/src/main/java/com/melissa/diary/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/melissa/diary/aws/s3/AmazonS3Manager.java
@@ -5,12 +5,13 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.melissa.diary.config.AmazonConfig;
 import com.melissa.diary.domain.Uuid;
+import com.melissa.diary.retry.RetryExecutor;
+import com.melissa.diary.retry.RetryPolicy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
 import java.util.Base64;
 
 @Slf4j
@@ -26,13 +27,11 @@ public class AmazonS3Manager{
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(file.getSize());
         metadata.setContentType(file.getContentType());
-        try {
-            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
-        }catch (IOException e){
-            log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
-        }
 
-        return keyName;
+        return RetryExecutor.execute("s3.uploadFile", RetryPolicy.S3_UPLOAD, () -> {
+            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
+            return keyName;
+        });
     }
 
     public String uploadFileFromBase64(String keyName, String base64Data, String contentType){

--- a/src/main/java/com/melissa/diary/retry/RetryClassifier.java
+++ b/src/main/java/com/melissa/diary/retry/RetryClassifier.java
@@ -1,0 +1,107 @@
+package com.melissa.diary.retry;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.util.Locale;
+import java.util.concurrent.TimeoutException;
+
+public final class RetryClassifier {
+
+    private RetryClassifier() {
+    }
+
+    public static RetryDecision classify(Throwable throwable) {
+        if (throwable == null) {
+            return RetryDecision.NON_RETRYABLE;
+        }
+
+        Throwable current = throwable;
+        while (current != null) {
+            RetryDecision decision = classifySingle(current);
+            if (decision != null) {
+                return decision;
+            }
+            current = current.getCause();
+        }
+
+        return RetryDecision.RETRYABLE;
+    }
+
+    public static boolean isRetryable(Throwable throwable) {
+        return classify(throwable) == RetryDecision.RETRYABLE;
+    }
+
+    private static RetryDecision classifySingle(Throwable throwable) {
+        if (throwable instanceof IllegalArgumentException) {
+            return RetryDecision.NON_RETRYABLE;
+        }
+
+        if (throwable instanceof WebClientResponseException e) {
+            return classifyHttpStatus(e.getStatusCode());
+        }
+
+        if (throwable instanceof HttpStatusCodeException e) {
+            return classifyHttpStatus(e.getStatusCode());
+        }
+
+        if (throwable instanceof AmazonServiceException e) {
+            return classifyAmazonServiceException(e);
+        }
+
+        if (throwable instanceof WebClientRequestException
+                || throwable instanceof ResourceAccessException
+                || throwable instanceof SdkClientException
+                || throwable instanceof SocketTimeoutException
+                || throwable instanceof ConnectException
+                || throwable instanceof TimeoutException) {
+            return RetryDecision.RETRYABLE;
+        }
+
+        if (throwable instanceof IOException) {
+            return RetryDecision.RETRYABLE;
+        }
+
+        return null;
+    }
+
+    private static RetryDecision classifyHttpStatus(HttpStatusCode statusCode) {
+        int status = statusCode.value();
+        if (status == 408 || status == 409 || status == 425 || status == 429 || status >= 500) {
+            return RetryDecision.RETRYABLE;
+        }
+        if (status >= 400) {
+            return RetryDecision.NON_RETRYABLE;
+        }
+        return RetryDecision.RETRYABLE;
+    }
+
+    private static RetryDecision classifyAmazonServiceException(AmazonServiceException exception) {
+        int status = exception.getStatusCode();
+        String errorCode = exception.getErrorCode() == null
+                ? ""
+                : exception.getErrorCode().toLowerCase(Locale.ROOT);
+
+        if (status == 429
+                || status >= 500
+                || errorCode.contains("throttl")
+                || errorCode.contains("requestlimit")
+                || errorCode.contains("slowdown")) {
+            return RetryDecision.RETRYABLE;
+        }
+
+        if (status >= 400) {
+            return RetryDecision.NON_RETRYABLE;
+        }
+
+        return RetryDecision.RETRYABLE;
+    }
+}

--- a/src/main/java/com/melissa/diary/retry/RetryDecision.java
+++ b/src/main/java/com/melissa/diary/retry/RetryDecision.java
@@ -1,0 +1,6 @@
+package com.melissa.diary.retry;
+
+public enum RetryDecision {
+    RETRYABLE,
+    NON_RETRYABLE
+}

--- a/src/main/java/com/melissa/diary/retry/RetryExecutor.java
+++ b/src/main/java/com/melissa/diary/retry/RetryExecutor.java
@@ -1,0 +1,78 @@
+package com.melissa.diary.retry;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+public final class RetryExecutor {
+
+    private RetryExecutor() {
+    }
+
+    public static <T> T execute(String operationName, RetryPolicy policy, RetryableOperation<T> operation) {
+        RuntimeException lastFailure = null;
+
+        for (int attempt = 1; attempt <= policy.maxAttempts(); attempt++) {
+            try {
+                return operation.run();
+            } catch (Exception e) {
+                RuntimeException failure = toRuntimeException(e);
+                lastFailure = failure;
+
+                boolean retryable = RetryClassifier.isRetryable(failure);
+                boolean hasRemainingAttempt = attempt < policy.maxAttempts();
+
+                if (!retryable || !hasRemainingAttempt) {
+                    log.warn("[Retry] operation failed final. operation={}, attempt={}, maxAttempts={}, retryable={}",
+                            operationName, attempt, policy.maxAttempts(), retryable, failure);
+                    throw failure;
+                }
+
+                Duration delay = applyJitter(policy.backoffForAttempt(attempt), policy.jitterRatio());
+                log.warn("[Retry] operation failed. operation={}, attempt={}, maxAttempts={}, nextDelayMs={}",
+                        operationName, attempt, policy.maxAttempts(), delay.toMillis(), failure);
+                sleep(delay);
+            }
+        }
+
+        throw lastFailure != null ? lastFailure : new IllegalStateException("retry operation failed");
+    }
+
+    private static RuntimeException toRuntimeException(Exception exception) {
+        if (exception instanceof RuntimeException runtimeException) {
+            return runtimeException;
+        }
+        return new RuntimeException(exception);
+    }
+
+    private static Duration applyJitter(Duration baseDelay, double jitterRatio) {
+        if (baseDelay.isZero() || baseDelay.isNegative() || jitterRatio <= 0) {
+            return baseDelay;
+        }
+
+        long baseMillis = baseDelay.toMillis();
+        long jitterMillis = Math.round(baseMillis * jitterRatio);
+        long offset = ThreadLocalRandom.current().nextLong(-jitterMillis, jitterMillis + 1);
+        return Duration.ofMillis(Math.max(0, baseMillis + offset));
+    }
+
+    private static void sleep(Duration delay) {
+        if (delay.isZero() || delay.isNegative()) {
+            return;
+        }
+
+        try {
+            Thread.sleep(delay.toMillis());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("retry interrupted", e);
+        }
+    }
+
+    @FunctionalInterface
+    public interface RetryableOperation<T> {
+        T run() throws Exception;
+    }
+}

--- a/src/main/java/com/melissa/diary/retry/RetryPolicy.java
+++ b/src/main/java/com/melissa/diary/retry/RetryPolicy.java
@@ -1,0 +1,47 @@
+package com.melissa.diary.retry;
+
+import java.time.Duration;
+import java.util.List;
+
+public record RetryPolicy(
+        int maxAttempts,
+        List<Duration> backoffs,
+        double jitterRatio
+) {
+    public static final RetryPolicy S3_UPLOAD = new RetryPolicy(
+            3,
+            List.of(Duration.ofMillis(500), Duration.ofSeconds(2)),
+            0.2
+    );
+
+    public static final RetryPolicy DIARY_IMAGE = new RetryPolicy(
+            5,
+            List.of(
+                    Duration.ofMinutes(1),
+                    Duration.ofMinutes(5),
+                    Duration.ofMinutes(15),
+                    Duration.ofHours(1)
+            ),
+            0.2
+    );
+
+    public static final RetryPolicy MEMORY_BATCH = new RetryPolicy(
+            3,
+            List.of(Duration.ofMinutes(15), Duration.ofHours(1)),
+            0.2
+    );
+
+    public static final RetryPolicy EXPO_PUSH = new RetryPolicy(
+            6,
+            List.of(Duration.ofMinutes(10)),
+            0.0
+    );
+
+    public Duration backoffForAttempt(int attemptNumber) {
+        if (attemptNumber <= 0 || backoffs.isEmpty()) {
+            return Duration.ZERO;
+        }
+        int index = Math.min(attemptNumber - 1, backoffs.size() - 1);
+        return backoffs.get(index);
+    }
+}

--- a/src/main/java/com/melissa/diary/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/melissa/diary/scheduler/NotificationScheduler.java
@@ -2,6 +2,7 @@ package com.melissa.diary.scheduler;
 
 import com.melissa.diary.domain.UserSetting;
 import com.melissa.diary.repository.UserSettingRepository;
+import com.melissa.diary.retry.RetryPolicy;
 import com.melissa.diary.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,8 +27,8 @@ import java.util.List;
 public class NotificationScheduler {
 
     private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
-    private static final int RETRY_INTERVAL_MINUTES = 10;
-    private static final int MAX_RETRY_COUNT = 6;
+    private static final int RETRY_INTERVAL_MINUTES = (int) RetryPolicy.EXPO_PUSH.backoffForAttempt(1).toMinutes();
+    private static final int MAX_RETRY_COUNT = RetryPolicy.EXPO_PUSH.maxAttempts();
 
     private final UserSettingRepository userSettingRepository;
     private final NotificationService notificationService;

--- a/src/main/java/com/melissa/diary/service/NotificationService.java
+++ b/src/main/java/com/melissa/diary/service/NotificationService.java
@@ -4,6 +4,8 @@ import com.melissa.diary.domain.ExpoPushToken;
 import com.melissa.diary.domain.UserSetting;
 import com.melissa.diary.repository.ExpoPushTokenRepository;
 import com.melissa.diary.repository.UserSettingRepository;
+import com.melissa.diary.retry.RetryClassifier;
+import com.melissa.diary.retry.RetryPolicy;
 import com.melissa.diary.web.dto.ExpoPushNotificationDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -12,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -28,6 +29,7 @@ public class NotificationService {
 
     private static final int BATCH_SIZE = 100;
     private static final ZoneId KST_ZONE_ID = ZoneId.of("Asia/Seoul");
+    private static final int MAX_RETRY_COUNT = RetryPolicy.EXPO_PUSH.maxAttempts();
 
     private final UserSettingRepository userSettingRepository;
     private final ExpoPushTokenRepository expoPushTokenRepository;
@@ -131,6 +133,7 @@ public class NotificationService {
 
         int tokenSuccessCount = 0;
         int tokenFailCount = 0;
+        int retryableFailCount = 0;
 
         String title = buildNotificationTitle(userSetting);
         String body = buildNotificationBody(userSetting);
@@ -144,8 +147,13 @@ public class NotificationService {
                 markTokenAsInvalidInternal(token);
                 tokenFailCount++;
                 log.warn("[Notification] invalid token disabled. userId={}, tokenId={}", userId, token.getId());
+            } catch (NonRetryablePushException e) {
+                tokenFailCount++;
+                log.warn("[Notification] non-retryable token send failed. userId={}, tokenId={}, reason={}",
+                        userId, token.getId(), e.getMessage());
             } catch (Exception e) {
                 tokenFailCount++;
+                retryableFailCount++;
                 log.error("[Notification] token send failed. userId={}, tokenId={}", userId, token.getId(), e);
             }
         }
@@ -157,7 +165,11 @@ public class NotificationService {
             return true;
         }
 
-        markNotificationAttemptFailedInternal(userSetting, today, now, "ALL_TOKEN_SEND_FAILED");
+        if (retryableFailCount > 0) {
+            markNotificationAttemptFailedInternal(userSetting, today, now, "ALL_TOKEN_SEND_FAILED");
+        } else {
+            markNotificationFinalFailedInternal(userSetting, now, "NON_RETRYABLE_TOKEN_FAILURES");
+        }
         log.warn("[Notification] user notification failed. userId={}, success={}, fail={}",
                 userId, tokenSuccessCount, tokenFailCount);
         return false;
@@ -177,10 +189,6 @@ public class NotificationService {
                     .bodyValue(request)
                     .retrieve()
                     .bodyToMono(ExpoPushNotificationDTO.PushResponse.class)
-                    .onErrorResume(e -> {
-                        log.error("[Notification] Expo API call failed. token={}", token, e);
-                        return Mono.error(new RuntimeException("Expo API call failed", e));
-                    })
                     .block();
 
             if (response != null && response.getData() != null && !response.getData().isEmpty()) {
@@ -193,19 +201,25 @@ public class NotificationService {
                         throw new InvalidTokenException(ticket.getMessage());
                     }
 
-                    throw new RuntimeException("Expo push failed: " + ticket.getMessage());
+                    if ("MessageRateExceeded".equals(errorType) || "ProviderError".equals(errorType)) {
+                        throw new RetryablePushException("Expo push retryable ticket error: " + ticket.getMessage());
+                    }
+
+                    throw new NonRetryablePushException("Expo push non-retryable ticket error: " + ticket.getMessage());
                 }
             }
 
         } catch (InvalidTokenException e) {
             throw e;
+        } catch (RetryablePushException | NonRetryablePushException e) {
+            throw e;
         } catch (WebClientResponseException e) {
             log.error("[Notification] Expo API response error. token={}, status={}, body={}",
                     token, e.getStatusCode(), e.getResponseBodyAsString(), e);
-            throw new RuntimeException("Expo API response error", e);
+            throw classifyPushException("Expo API response error", e);
         } catch (Exception e) {
             log.error("[Notification] notification send exception. token={}", token, e);
-            throw new RuntimeException("Notification send failed", e);
+            throw classifyPushException("Notification send failed", e);
         }
     }
 
@@ -247,6 +261,24 @@ public class NotificationService {
         }
     }
 
+    private void markNotificationFinalFailedInternal(
+            UserSetting setting,
+            LocalDateTime now,
+            String reason
+    ) {
+        try {
+            transactionTemplate.executeWithoutResult(status -> {
+                setting.setRetryCount(MAX_RETRY_COUNT);
+                setting.setLastAttemptAt(now);
+                userSettingRepository.save(setting);
+            });
+            log.info("[Notification] delivery state marked final failure. userSettingId={}, reason={}",
+                    setting.getId(), reason);
+        } catch (Exception e) {
+            log.error("[Notification] failed to mark final failure state. userSettingId={}", setting.getId(), e);
+        }
+    }
+
     private int calculateNextRetryCount(UserSetting setting, LocalDate today) {
         Integer currentRetryCount = setting.getRetryCount() == null ? 0 : setting.getRetryCount();
         LocalDateTime lastAttemptAt = setting.getLastAttemptAt();
@@ -278,9 +310,36 @@ public class NotificationService {
         return "오늘 하루는 어떠셨나요? 멜리사와 대화하며 일기를 작성해보세요.";
     }
 
+    private RuntimeException classifyPushException(String message, Throwable throwable) {
+        if (RetryClassifier.isRetryable(throwable)) {
+            return new RetryablePushException(message, throwable);
+        }
+        return new NonRetryablePushException(message, throwable);
+    }
+
     public static class InvalidTokenException extends RuntimeException {
         public InvalidTokenException(String message) {
             super(message);
+        }
+    }
+
+    public static class RetryablePushException extends RuntimeException {
+        public RetryablePushException(String message) {
+            super(message);
+        }
+
+        public RetryablePushException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static class NonRetryablePushException extends RuntimeException {
+        public NonRetryablePushException(String message) {
+            super(message);
+        }
+
+        public NonRetryablePushException(String message, Throwable cause) {
+            super(message, cause);
         }
     }
 }

--- a/src/main/java/com/melissa/diary/service/SocialAuthService.java
+++ b/src/main/java/com/melissa/diary/service/SocialAuthService.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -25,12 +26,15 @@ import java.util.UUID;
 @Slf4j
 public class SocialAuthService {
 
+    private static final int CONNECT_TIMEOUT_MILLIS = 3000;
+    private static final int READ_TIMEOUT_MILLIS = 5000;
+
 
     // Google (ID Token 검증)
     public GooglePayload verifyGoogleToken(String idToken) {
         String url = "https://oauth2.googleapis.com/tokeninfo?id_token=" + idToken;
         try {
-            RestTemplate restTemplate = new RestTemplate();
+            RestTemplate restTemplate = createSocialAuthRestTemplate();
             GoogleIdTokenResponse response =
                     restTemplate.getForObject(url, GoogleIdTokenResponse.class);
 
@@ -53,7 +57,7 @@ public class SocialAuthService {
     // Kakao (accessToken 검증)
     public KakaoPayload verifyKakaoToken(String accessToken) {
         try {
-            RestTemplate restTemplate = new RestTemplate();
+            RestTemplate restTemplate = createSocialAuthRestTemplate();
             HttpHeaders headers = new HttpHeaders();
             headers.setBearerAuth(accessToken);
             HttpEntity<?> req = new HttpEntity<>(headers);
@@ -89,7 +93,7 @@ public class SocialAuthService {
         try {
             // 1. 애플의 공개키를 가져옵니다.
             String appleKeysUrl = "https://appleid.apple.com/auth/keys";
-            RestTemplate restTemplate = new RestTemplate();
+            RestTemplate restTemplate = createSocialAuthRestTemplate();
             String response = restTemplate.getForObject(appleKeysUrl, String.class);
             JWKSet jwkSet = JWKSet.parse(response);
 
@@ -154,6 +158,13 @@ public class SocialAuthService {
 
 
     // 내부 DTOs for Google, Kakao, Apple
+
+    private RestTemplate createSocialAuthRestTemplate() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
+        requestFactory.setReadTimeout(READ_TIMEOUT_MILLIS);
+        return new RestTemplate(requestFactory);
+    }
 
     // Google
     @Getter

--- a/src/test/java/com/melissa/diary/aws/s3/AmazonS3ManagerTest.java
+++ b/src/test/java/com/melissa/diary/aws/s3/AmazonS3ManagerTest.java
@@ -1,0 +1,40 @@
+package com.melissa.diary.aws.s3;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.melissa.diary.config.AmazonConfig;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AmazonS3ManagerTest {
+
+    @Test
+    void uploadFilePropagatesNonRetryableS3Failure() throws Exception {
+        AmazonS3 amazonS3 = mock(AmazonS3.class);
+        AmazonConfig amazonConfig = mock(AmazonConfig.class);
+        MultipartFile multipartFile = mock(MultipartFile.class);
+        AmazonS3Manager manager = new AmazonS3Manager(amazonS3, amazonConfig);
+
+        AmazonServiceException exception = new AmazonServiceException("forbidden");
+        exception.setStatusCode(403);
+
+        when(amazonConfig.getBucket()).thenReturn("bucket");
+        when(multipartFile.getSize()).thenReturn(4L);
+        when(multipartFile.getContentType()).thenReturn("image/png");
+        when(multipartFile.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[]{1, 2, 3, 4}));
+        when(amazonS3.putObject(any())).thenThrow(exception);
+
+        assertThatThrownBy(() -> manager.uploadFile("key.png", multipartFile))
+                .isSameAs(exception);
+
+        verify(amazonS3).putObject(any());
+    }
+}

--- a/src/test/java/com/melissa/diary/retry/RetryClassifierTest.java
+++ b/src/test/java/com/melissa/diary/retry/RetryClassifierTest.java
@@ -1,0 +1,54 @@
+package com.melissa.diary.retry;
+
+import com.amazonaws.AmazonServiceException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.net.SocketTimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RetryClassifierTest {
+
+    @Test
+    void classifiesTimeoutAsRetryable() {
+        assertThat(RetryClassifier.classify(new SocketTimeoutException("timeout")))
+                .isEqualTo(RetryDecision.RETRYABLE);
+    }
+
+    @Test
+    void classifiesHttp429And5xxAsRetryable() {
+        assertThat(RetryClassifier.classify(webClientException(HttpStatus.TOO_MANY_REQUESTS)))
+                .isEqualTo(RetryDecision.RETRYABLE);
+        assertThat(RetryClassifier.classify(webClientException(HttpStatus.BAD_GATEWAY)))
+                .isEqualTo(RetryDecision.RETRYABLE);
+    }
+
+    @Test
+    void classifiesHttp4xxAsNonRetryable() {
+        assertThat(RetryClassifier.classify(webClientException(HttpStatus.BAD_REQUEST)))
+                .isEqualTo(RetryDecision.NON_RETRYABLE);
+        assertThat(RetryClassifier.classify(webClientException(HttpStatus.FORBIDDEN)))
+                .isEqualTo(RetryDecision.NON_RETRYABLE);
+    }
+
+    @Test
+    void classifiesAwsThrottlingAsRetryable() {
+        AmazonServiceException exception = new AmazonServiceException("throttled");
+        exception.setStatusCode(400);
+        exception.setErrorCode("Throttling");
+
+        assertThat(RetryClassifier.classify(exception)).isEqualTo(RetryDecision.RETRYABLE);
+    }
+
+    private WebClientResponseException webClientException(HttpStatus status) {
+        return WebClientResponseException.create(
+                status.value(),
+                status.getReasonPhrase(),
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/src/test/java/com/melissa/diary/scheduler/NotificationSchedulerTest.java
+++ b/src/test/java/com/melissa/diary/scheduler/NotificationSchedulerTest.java
@@ -1,6 +1,7 @@
 package com.melissa.diary.scheduler;
 
 import com.melissa.diary.repository.UserSettingRepository;
+import com.melissa.diary.retry.RetryPolicy;
 import com.melissa.diary.service.NotificationService;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -47,6 +48,6 @@ class NotificationSchedulerTest {
 
         LocalDate expectedKstDate = LocalDate.now(ZoneId.of("Asia/Seoul"));
         assertThat(dateCaptor.getValue()).isEqualTo(expectedKstDate);
-        assertThat(retryCountCaptor.getValue()).isEqualTo(6);
+        assertThat(retryCountCaptor.getValue()).isEqualTo(RetryPolicy.EXPO_PUSH.maxAttempts());
     }
 }

--- a/src/test/java/com/melissa/diary/service/NotificationServiceStateModelTest.java
+++ b/src/test/java/com/melissa/diary/service/NotificationServiceStateModelTest.java
@@ -5,6 +5,11 @@ import com.melissa.diary.domain.UserSetting;
 import com.melissa.diary.repository.ExpoPushTokenRepository;
 import com.melissa.diary.repository.UserSettingRepository;
 import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.sql.Time;
@@ -26,7 +31,7 @@ class NotificationServiceStateModelTest {
         UserSettingRepository userSettingRepository = mock(UserSettingRepository.class);
         ExpoPushTokenRepository expoPushTokenRepository = mock(ExpoPushTokenRepository.class);
         WebClient webClient = mock(WebClient.class);
-        NotificationService service = new NotificationService(userSettingRepository, expoPushTokenRepository, webClient);
+        NotificationService service = new NotificationService(userSettingRepository, expoPushTokenRepository, webClient, transactionTemplate());
 
         User user = User.builder()
                 .id(1L)
@@ -54,7 +59,7 @@ class NotificationServiceStateModelTest {
         UserSettingRepository userSettingRepository = mock(UserSettingRepository.class);
         ExpoPushTokenRepository expoPushTokenRepository = mock(ExpoPushTokenRepository.class);
         WebClient webClient = mock(WebClient.class);
-        NotificationService service = new NotificationService(userSettingRepository, expoPushTokenRepository, webClient);
+        NotificationService service = new NotificationService(userSettingRepository, expoPushTokenRepository, webClient, transactionTemplate());
 
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         LocalDateTime yesterdayAttempt = today.minusDays(1).atTime(23, 0);
@@ -85,7 +90,7 @@ class NotificationServiceStateModelTest {
         UserSettingRepository userSettingRepository = mock(UserSettingRepository.class);
         ExpoPushTokenRepository expoPushTokenRepository = mock(ExpoPushTokenRepository.class);
         WebClient webClient = mock(WebClient.class);
-        NotificationService service = new NotificationService(userSettingRepository, expoPushTokenRepository, webClient);
+        NotificationService service = new NotificationService(userSettingRepository, expoPushTokenRepository, webClient, transactionTemplate());
 
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
@@ -108,5 +113,22 @@ class NotificationServiceStateModelTest {
         assertThat(setting.getRetryCount()).isEqualTo(3);
         verify(userSettingRepository, never()).save(any(UserSetting.class));
         verify(expoPushTokenRepository, never()).save(any());
+    }
+
+    private TransactionTemplate transactionTemplate() {
+        return new TransactionTemplate(new PlatformTransactionManager() {
+            @Override
+            public TransactionStatus getTransaction(TransactionDefinition definition) {
+                return new SimpleTransactionStatus();
+            }
+
+            @Override
+            public void commit(TransactionStatus status) {
+            }
+
+            @Override
+            public void rollback(TransactionStatus status) {
+            }
+        });
     }
 }

--- a/src/test/java/com/melissa/diary/service/ThreadServiceResponseLengthTest.java
+++ b/src/test/java/com/melissa/diary/service/ThreadServiceResponseLengthTest.java
@@ -18,7 +18,7 @@ class ThreadServiceResponseLengthTest {
     @BeforeEach
     void setUp() {
         // ThreadService의 의존성은 null이어도 됨 (calculateMaxTokens는 의존성 없는 순수 함수)
-        threadService = new ThreadService(null, null, null, null, null, null, null, null);
+        threadService = new ThreadService(null, null, null, null, null, null, null, null, null, null);
     }
 
     @Test


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
외부 API 및 비동기성 작업에서 실패를 일관되게 처리하기 위해 공통 재시도 정책을 추가했습니다.

기존에는 서비스별로 실패 처리 기준이 달랐고, 일부 경로에서는 실패를 감지하지 못한 채 성공처럼 처리될 수 있었습니다.  
이번 PR에서는 실패 원인을 `retryable / non-retryable`로 분류하고, S3 업로드와 Expo Push 알림에 표준 정책을 적용했습니다.

Resolves #256

## 📋 변경 사항
- 공통 재시도 패키지 추가
  - `RetryPolicy`
  - `RetryClassifier`
  - `RetryExecutor`
  - `RetryDecision`
- HTTP/AWS/네트워크 예외 기준 재시도 가능 여부 분류
  - retryable: timeout, connection error, 408, 409, 425, 429, 5xx, AWS throttling 계열
  - non-retryable: 400/403 등 일반 4xx, 잘못된 인자
- S3 업로드 실패 처리 개선
  - 기존: 업로드 실패를 catch한 뒤 key를 반환할 수 있음
  - 변경: retryable 실패는 제한적으로 재시도하고, 최종 실패는 예외로 전파
- Expo Push 실패 처리 개선
  - invalid token은 토큰 비활성화 후 재시도하지 않음
  - rate limit/provider error/timeout/5xx는 재시도 대상으로 분류
  - 모든 토큰 실패가 non-retryable이면 최종 실패 처리
- 알림 스케줄러의 최대 재시도 횟수/간격을 공통 정책에서 참조하도록 변경
- 소셜 로그인 외부 검증 요청에 timeout 설정 추가
  - connect timeout: 3초
  - read timeout: 5초
- 테스트 추가 및 기존 테스트 생성자 변경 반영
  - `RetryClassifierTest`
  - `AmazonS3ManagerTest`
  - `NotificationSchedulerTest`
  - `NotificationServiceStateModelTest`

## 🔍 Code Review
- retryable / non-retryable 분류 기준이 운영 상황에 적절한지 확인
- S3 업로드 실패가 더 이상 성공처럼 처리되지 않는지 확인
- Expo Push에서 invalid token과 일시 장애가 올바르게 분리되는지 확인
- Lightsail 프리티어 환경을 고려해 과도한 blocking retry가 발생하지 않는지 확인
- 프론트 API 응답 포맷이나 폴링 계약이 변경되지 않았는지 확인
- SQS/Outbox 기반 durable retry는 이 PR 범위가 아니며, 후속 #258에서 처리 예정

## ✅ 테스트
```powershell
.\gradlew.bat test --tests "com.melissa.diary.retry.RetryClassifierTest" --tests "com.melissa.diary.aws.s3.AmazonS3ManagerTest" --tests "com.melissa.diary.service.NotificationServiceStateModelTest" --tests "com.melissa.diary.scheduler.NotificationSchedulerTest"

.\gradlew.bat clean build -x test