### PR TITLE
fix: migrate AWS SDK Java usage to v2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,11 +49,9 @@ dependencies {
 	implementation platform("org.springframework.ai:spring-ai-bom:1.1.0")
 	implementation "org.springframework.ai:spring-ai-starter-model-openai"
 
-	// S3
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
-
-	// SQS
+	// AWS SDK 2.x
 	implementation platform('software.amazon.awssdk:bom:2.44.7')
+	implementation 'software.amazon.awssdk:s3'
 	implementation 'software.amazon.awssdk:sqs'
 
 	// webFlux (Expo Push Notification 발송용 WebClient)

--- a/src/main/java/com/melissa/diary/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/melissa/diary/aws/s3/AmazonS3Manager.java
@@ -1,8 +1,5 @@
 package com.melissa.diary.aws.s3;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.melissa.diary.config.AmazonConfig;
 import com.melissa.diary.domain.Uuid;
 import com.melissa.diary.retry.RetryExecutor;
@@ -17,23 +14,38 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.Base64;
 import java.util.Optional;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class AmazonS3Manager {
 
-    private final AmazonS3 amazonS3;
+    private final S3Client s3Client;
 
     private final AmazonConfig amazonConfig;
 
     public String uploadFile(String keyName, MultipartFile file) {
-        ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentLength(file.getSize());
-        metadata.setContentType(file.getContentType());
-
         return RetryExecutor.execute("s3.uploadFile", RetryPolicy.S3_UPLOAD, () -> {
-            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
+            long contentLength = file.getSize();
+            PutObjectRequest.Builder requestBuilder = PutObjectRequest.builder()
+                    .bucket(amazonConfig.getBucket())
+                    .key(keyName)
+                    .contentLength(contentLength);
+
+            String contentType = file.getContentType();
+            if (contentType != null && !contentType.isBlank()) {
+                requestBuilder.contentType(contentType);
+            }
+
+            try (InputStream inputStream = file.getInputStream()) {
+                s3Client.putObject(
+                        requestBuilder.build(),
+                        RequestBody.fromInputStream(inputStream, contentLength)
+                );
+            }
             return keyName;
         });
     }

--- a/src/main/java/com/melissa/diary/config/AmazonConfig.java
+++ b/src/main/java/com/melissa/diary/config/AmazonConfig.java
@@ -1,23 +1,18 @@
 package com.melissa.diary.config;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 @Getter
 public class AmazonConfig {
-
-
-    private AWSCredentials awsCredentials;
 
     @Value("${cloud.aws.credentials.accessKey}")
     private String accessKey;
@@ -49,22 +44,16 @@ public class AmazonConfig {
     @Value("${cloud.aws.path.diary}")
     private String diary;
 
-    @PostConstruct
-    public void init() {
-        this.awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+    @Bean
+    public AwsCredentialsProvider awsCredentialsProvider() {
+        return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
     }
 
     @Bean
-    public AmazonS3 amazonS3() {
-        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
-        return AmazonS3ClientBuilder.standard()
-                .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+    public S3Client s3Client(AwsCredentialsProvider awsCredentialsProvider) {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(awsCredentialsProvider)
                 .build();
-    }
-
-    @Bean
-    public AWSCredentialsProvider awsCredentialsProvider() {
-        return new AWSStaticCredentialsProvider(awsCredentials);
     }
 }

--- a/src/main/java/com/melissa/diary/config/SqsConfig.java
+++ b/src/main/java/com/melissa/diary/config/SqsConfig.java
@@ -4,8 +4,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
 
@@ -15,15 +14,10 @@ public class SqsConfig {
 
     @Bean
     @ConditionalOnProperty(prefix = "melissa.sqs", name = "enabled", havingValue = "true")
-    public SqsClient sqsClient(AmazonConfig amazonConfig, SqsProperties sqsProperties) {
-        AwsBasicCredentials credentials = AwsBasicCredentials.create(
-                amazonConfig.getAccessKey(),
-                amazonConfig.getSecretKey()
-        );
-
+    public SqsClient sqsClient(AwsCredentialsProvider awsCredentialsProvider, SqsProperties sqsProperties) {
         return SqsClient.builder()
                 .region(Region.of(sqsProperties.getRegion()))
-                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .credentialsProvider(awsCredentialsProvider)
                 .build();
     }
 }

--- a/src/main/java/com/melissa/diary/retry/RetryClassifier.java
+++ b/src/main/java/com/melissa/diary/retry/RetryClassifier.java
@@ -1,12 +1,12 @@
 package com.melissa.diary.retry;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.SdkClientException;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.reactive.function.client.WebClientRequestException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
 
 import java.io.IOException;
 import java.net.ConnectException;
@@ -53,18 +53,13 @@ public final class RetryClassifier {
             return classifyHttpStatus(e.getStatusCode());
         }
 
-        if (throwable instanceof AmazonServiceException e) {
-            return classifyAmazonServiceException(e);
-        }
-
-        if (throwable instanceof software.amazon.awssdk.awscore.exception.AwsServiceException e) {
+        if (throwable instanceof AwsServiceException e) {
             return classifyAwsSdkV2ServiceException(e);
         }
 
         if (throwable instanceof WebClientRequestException
                 || throwable instanceof ResourceAccessException
                 || throwable instanceof SdkClientException
-                || throwable instanceof software.amazon.awssdk.core.exception.SdkClientException
                 || throwable instanceof SocketTimeoutException
                 || throwable instanceof ConnectException
                 || throwable instanceof TimeoutException) {
@@ -89,30 +84,7 @@ public final class RetryClassifier {
         return RetryDecision.RETRYABLE;
     }
 
-    private static RetryDecision classifyAmazonServiceException(AmazonServiceException exception) {
-        int status = exception.getStatusCode();
-        String errorCode = exception.getErrorCode() == null
-                ? ""
-                : exception.getErrorCode().toLowerCase(Locale.ROOT);
-
-        if (status == 429
-                || status >= 500
-                || errorCode.contains("throttl")
-                || errorCode.contains("requestlimit")
-                || errorCode.contains("slowdown")) {
-            return RetryDecision.RETRYABLE;
-        }
-
-        if (status >= 400) {
-            return RetryDecision.NON_RETRYABLE;
-        }
-
-        return RetryDecision.RETRYABLE;
-    }
-
-    private static RetryDecision classifyAwsSdkV2ServiceException(
-            software.amazon.awssdk.awscore.exception.AwsServiceException exception
-    ) {
+    private static RetryDecision classifyAwsSdkV2ServiceException(AwsServiceException exception) {
         int status = exception.statusCode();
         String errorCode = exception.awsErrorDetails() == null || exception.awsErrorDetails().errorCode() == null
                 ? ""

--- a/src/test/java/com/melissa/diary/aws/s3/AmazonS3ManagerTest.java
+++ b/src/test/java/com/melissa/diary/aws/s3/AmazonS3ManagerTest.java
@@ -1,21 +1,22 @@
 package com.melissa.diary.aws.s3;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.sun.net.httpserver.HttpServer;
 import com.melissa.diary.config.AmazonConfig;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.ByteArrayInputStream;
 import java.net.InetSocketAddress;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentCaptor.forClass;
-import org.mockito.ArgumentCaptor;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,31 +25,33 @@ class AmazonS3ManagerTest {
 
     @Test
     void uploadFilePropagatesNonRetryableS3Failure() throws Exception {
-        AmazonS3 amazonS3 = mock(AmazonS3.class);
+        S3Client s3Client = mock(S3Client.class);
         AmazonConfig amazonConfig = mock(AmazonConfig.class);
         MultipartFile multipartFile = mock(MultipartFile.class);
-        AmazonS3Manager manager = new AmazonS3Manager(amazonS3, amazonConfig);
+        AmazonS3Manager manager = new AmazonS3Manager(s3Client, amazonConfig);
 
-        AmazonServiceException exception = new AmazonServiceException("forbidden");
-        exception.setStatusCode(403);
+        AwsServiceException exception = AwsServiceException.builder()
+                .message("forbidden")
+                .statusCode(403)
+                .build();
 
         when(amazonConfig.getBucket()).thenReturn("bucket");
         when(multipartFile.getSize()).thenReturn(4L);
         when(multipartFile.getContentType()).thenReturn("image/png");
         when(multipartFile.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[]{1, 2, 3, 4}));
-        when(amazonS3.putObject(any())).thenThrow(exception);
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).thenThrow(exception);
 
         assertThatThrownBy(() -> manager.uploadFile("key.png", multipartFile))
                 .isSameAs(exception);
 
-        verify(amazonS3).putObject(any());
+        verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
     }
 
     @Test
     void uploadFileFromUrlDownloadsAndUploadsImage() throws Exception {
-        AmazonS3 amazonS3 = mock(AmazonS3.class);
+        S3Client s3Client = mock(S3Client.class);
         AmazonConfig amazonConfig = mock(AmazonConfig.class);
-        AmazonS3Manager manager = new AmazonS3Manager(amazonS3, amazonConfig);
+        AmazonS3Manager manager = new AmazonS3Manager(s3Client, amazonConfig);
         byte[] imageBytes = new byte[]{1, 2, 3, 4};
 
         when(amazonConfig.getBucket()).thenReturn("bucket");
@@ -70,9 +73,9 @@ class AmazonS3ManagerTest {
             assertThat(result).isEqualTo("diary/key.png");
 
             ArgumentCaptor<PutObjectRequest> captor = forClass(PutObjectRequest.class);
-            verify(amazonS3).putObject(captor.capture());
-            assertThat(captor.getValue().getMetadata().getContentLength()).isEqualTo(imageBytes.length);
-            assertThat(captor.getValue().getMetadata().getContentType()).isEqualTo("image/png");
+            verify(s3Client).putObject(captor.capture(), any(RequestBody.class));
+            assertThat(captor.getValue().contentLength()).isEqualTo(imageBytes.length);
+            assertThat(captor.getValue().contentType()).isEqualTo("image/png");
         } finally {
             server.stop(0);
         }

--- a/src/test/java/com/melissa/diary/retry/RetryClassifierTest.java
+++ b/src/test/java/com/melissa/diary/retry/RetryClassifierTest.java
@@ -1,9 +1,10 @@
 package com.melissa.diary.retry;
 
-import com.amazonaws.AmazonServiceException;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 
 import java.net.SocketTimeoutException;
 
@@ -35,9 +36,13 @@ class RetryClassifierTest {
 
     @Test
     void classifiesAwsThrottlingAsRetryable() {
-        AmazonServiceException exception = new AmazonServiceException("throttled");
-        exception.setStatusCode(400);
-        exception.setErrorCode("Throttling");
+        AwsServiceException exception = AwsServiceException.builder()
+                .message("throttled")
+                .statusCode(400)
+                .awsErrorDetails(AwsErrorDetails.builder()
+                        .errorCode("Throttling")
+                        .build())
+                .build();
 
         assertThat(RetryClassifier.classify(exception)).isEqualTo(RetryDecision.RETRYABLE);
     }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
AWS Health에서 감지된 AWS SDK for Java 1.x 사용을 제거하기 위해 S3 연동을 AWS SDK 2.x로 마이그레이션했습니다.

## 📋 변경 사항
- `spring-cloud-starter-aws:2.2.6.RELEASE` 제거
- AWS SDK 2.x `software.amazon.awssdk:s3` 추가
- S3 클라이언트를 v1 `AmazonS3`에서 v2 `S3Client`로 변경
- S3 업로드 로직을 v2 `putObject` + `RequestBody` 기반으로 변경
- SQS 설정은 기존 v2 `SqsClient`를 유지하되 공통 `AwsCredentialsProvider`를 재사용하도록 정리
- 재시도 분류 로직에서 v1 `AmazonServiceException`, `SdkClientException` 참조 제거
- S3/Retry 관련 테스트를 AWS SDK 2.x 타입 기준으로 수정

## 🔍 Code Review
- 런타임 클래스패스에서 `aws-java-sdk-*`, `spring-cloud-aws-*`, `com.amazonaws`가 제거됐는지 확인했습니다.
- bootJar 내부 `BOOT-INF/lib`에 `aws-java-sdk-*`, `spring-cloud-aws-*`, `jmespath-java-*`가 포함되지 않는 것을 확인했습니다.
- 소스 코드에서 `com.amazonaws` 참조가 남아 있지 않은 것을 확인
- 검증 명령:
```powershell
$env:JAVA_HOME='C:\Program Files\Java\jdk-17'
.\gradlew.bat compileJava compileTestJava
.\gradlew.bat test --tests com.melissa.diary.aws.s3.AmazonS3ManagerTest --tests com.melissa.diary.retry.RetryClassifierTest
.\gradlew.bat bootJar -x test