### PR TITLE
Feat: 결제 기반 DB, 광고 제거 권한 조회, 관리자 권한 모델 구축

### DIFF
--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -78,7 +78,11 @@ public enum ErrorStatus implements BaseErrorCode {
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY4001", "해당 일기를 찾을 수 없습니다."),
     DIARY_FORBIDDEN(HttpStatus.FORBIDDEN, "DIARY4002", "해당 일기에 접근할 권한이 없습니다."),
     DIARY_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "DIARY4003", "이미 삭제된 일기입니다."),
-    DIARY_MAX_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "DIARY4004", "하루 최대 3개까지만 일기를 작성할 수 있습니다.");
+    DIARY_MAX_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "DIARY4004", "하루 최대 3개까지만 일기를 작성할 수 있습니다."),
+
+    // Payment
+    PAYMENT_ADMIN_REQUIRED(HttpStatus.FORBIDDEN, "PAYMENT4031", "관리자 권한이 필요합니다."),
+    PAYMENT_USER_DELETE_BLOCKED(HttpStatus.CONFLICT, "PAYMENT4092", "결제 이력이 있어 현재 회원탈퇴를 처리할 수 없습니다. 관리자에게 문의해주세요.");
 
 
 

--- a/src/main/java/com/melissa/diary/config/PaymentConfig.java
+++ b/src/main/java/com/melissa/diary/config/PaymentConfig.java
@@ -1,0 +1,9 @@
+package com.melissa.diary.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(PaymentProperties.class)
+public class PaymentConfig {
+}

--- a/src/main/java/com/melissa/diary/config/PaymentProperties.java
+++ b/src/main/java/com/melissa/diary/config/PaymentProperties.java
@@ -1,0 +1,51 @@
+package com.melissa.diary.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "payment")
+public class PaymentProperties {
+
+    private Iap iap = new Iap();
+    private Google google = new Google();
+    private Apple apple = new Apple();
+
+    @Getter
+    @Setter
+    public static class Iap {
+        private boolean enabled = false;
+        private long verifyTimeoutMs = 5000;
+        private StoreProduct storeProduct = new StoreProduct();
+    }
+
+    @Getter
+    @Setter
+    public static class StoreProduct {
+        private String removeAds = "remove_ads";
+    }
+
+    @Getter
+    @Setter
+    public static class Google {
+        private boolean enabled = false;
+        private String packageName = "com.melissa.melissaFE";
+        private String productRemoveAds = "premium";
+        private String serviceAccountJsonBase64 = "";
+        private String tokenHashSalt = "";
+    }
+
+    @Getter
+    @Setter
+    public static class Apple {
+        private boolean enabled = false;
+        private String bundleId = "com.melissa.melissaFE";
+        private String productRemoveAds = "com.melissa.melissaFE.premium";
+        private String issuerId = "";
+        private String keyId = "";
+        private String privateKeyP8Base64 = "";
+        private String environment = "SANDBOX";
+    }
+}

--- a/src/main/java/com/melissa/diary/domain/Entitlement.java
+++ b/src/main/java/com/melissa/diary/domain/Entitlement.java
@@ -1,0 +1,70 @@
+package com.melissa.diary.domain;
+
+import com.melissa.diary.domain.common.BaseEntity;
+import com.melissa.diary.domain.enums.EntitlementSourceType;
+import com.melissa.diary.domain.enums.EntitlementType;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "entitlement",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_entitlement_user_type", columnNames = {"user_id", "entitlement_type"})
+        },
+        indexes = {
+                @Index(name = "idx_entitlement_active", columnList = "active"),
+                @Index(name = "idx_entitlement_source_payment", columnList = "source_payment_id")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Entitlement extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "entitlement_type", nullable = false, length = 50)
+    private EntitlementType entitlementType;
+
+    @Column(nullable = false)
+    private Boolean active;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", nullable = false, length = 30)
+    private EntitlementSourceType sourceType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_platform", length = 20)
+    private PaymentPlatform sourcePlatform;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_payment_id")
+    private Payment sourcePayment;
+
+    @Column(name = "granted_at", nullable = false)
+    private LocalDateTime grantedAt;
+
+    @Column(name = "revoked_at")
+    private LocalDateTime revokedAt;
+
+    @Column(name = "revocation_reason", length = 100)
+    private String revocationReason;
+
+    @Version
+    @Column(nullable = false)
+    @Builder.Default
+    private Long version = 0L;
+}

--- a/src/main/java/com/melissa/diary/domain/Payment.java
+++ b/src/main/java/com/melissa/diary/domain/Payment.java
@@ -1,0 +1,110 @@
+package com.melissa.diary.domain;
+
+import com.melissa.diary.domain.common.BaseEntity;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import com.melissa.diary.domain.enums.PaymentStatus;
+import com.melissa.diary.domain.enums.ProductType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "payment",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_payment_google_token", columnNames = {"platform", "google_purchase_token_hash"}),
+                @UniqueConstraint(name = "uk_payment_apple_transaction", columnNames = {"platform", "apple_transaction_id"})
+        },
+        indexes = {
+                @Index(name = "idx_payment_user_status", columnList = "user_id,status"),
+                @Index(name = "idx_payment_user_product", columnList = "user_id,product_id"),
+                @Index(name = "idx_payment_google_order", columnList = "google_order_id"),
+                @Index(name = "idx_payment_apple_original_transaction", columnList = "apple_original_transaction_id"),
+                @Index(name = "idx_payment_created_at", columnList = "created_at")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Payment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PaymentPlatform platform;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id", nullable = false)
+    private PaymentProduct product;
+
+    @Column(name = "store_product_id", nullable = false, length = 150)
+    private String storeProductId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "product_type", nullable = false, length = 30)
+    private ProductType productType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private PaymentStatus status;
+
+    @Column(name = "amount_micros")
+    private Long amountMicros;
+
+    @Column(length = 10)
+    private String currency;
+
+    @Column(name = "google_purchase_token_hash", length = 64)
+    private String googlePurchaseTokenHash;
+
+    @Column(name = "google_purchase_token_encrypted", columnDefinition = "TEXT")
+    private String googlePurchaseTokenEncrypted;
+
+    @Column(name = "google_order_id", length = 100)
+    private String googleOrderId;
+
+    @Column(name = "apple_transaction_id", length = 100)
+    private String appleTransactionId;
+
+    @Column(name = "apple_original_transaction_id", length = 100)
+    private String appleOriginalTransactionId;
+
+    @Column(name = "apple_environment", length = 30)
+    private String appleEnvironment;
+
+    @Column(name = "purchased_at")
+    private LocalDateTime purchasedAt;
+
+    @Column(name = "verified_at")
+    private LocalDateTime verifiedAt;
+
+    @Column(name = "acknowledged_at")
+    private LocalDateTime acknowledgedAt;
+
+    @Column(name = "refunded_at")
+    private LocalDateTime refundedAt;
+
+    @Column(name = "revoked_at")
+    private LocalDateTime revokedAt;
+
+    @Column(name = "raw_verified_payload", columnDefinition = "JSON")
+    private String rawVerifiedPayload;
+
+    @Column(name = "failure_reason", length = 500)
+    private String failureReason;
+
+    @Version
+    @Column(nullable = false)
+    @Builder.Default
+    private Long version = 0L;
+}

--- a/src/main/java/com/melissa/diary/domain/PaymentEvent.java
+++ b/src/main/java/com/melissa/diary/domain/PaymentEvent.java
@@ -1,0 +1,72 @@
+package com.melissa.diary.domain;
+
+import com.melissa.diary.domain.enums.PaymentEventProcessingStatus;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "payment_event",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_payment_event_platform_event", columnNames = {"platform", "event_id"})
+        },
+        indexes = {
+                @Index(name = "idx_payment_event_processing", columnList = "processing_status,received_at"),
+                @Index(name = "idx_payment_event_payment", columnList = "payment_id"),
+                @Index(name = "idx_payment_event_actor_user", columnList = "actor_user_id")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PaymentPlatform platform;
+
+    @Column(name = "event_id", nullable = false, length = 200)
+    private String eventId;
+
+    @Column(name = "event_type", nullable = false, length = 100)
+    private String eventType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id")
+    private Payment payment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "actor_user_id")
+    private User actorUser;
+
+    @Column(name = "google_purchase_token_hash", length = 64)
+    private String googlePurchaseTokenHash;
+
+    @Column(name = "apple_transaction_id", length = 100)
+    private String appleTransactionId;
+
+    @Column(name = "raw_payload", columnDefinition = "JSON")
+    private String rawPayload;
+
+    @Column(name = "received_at", nullable = false)
+    private LocalDateTime receivedAt;
+
+    @Column(name = "processed_at")
+    private LocalDateTime processedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "processing_status", nullable = false, length = 30)
+    private PaymentEventProcessingStatus processingStatus;
+
+    @Column(name = "last_error", length = 500)
+    private String lastError;
+}

--- a/src/main/java/com/melissa/diary/domain/PaymentProduct.java
+++ b/src/main/java/com/melissa/diary/domain/PaymentProduct.java
@@ -1,0 +1,59 @@
+package com.melissa.diary.domain;
+
+import com.melissa.diary.domain.common.BaseEntity;
+import com.melissa.diary.domain.enums.EntitlementType;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import com.melissa.diary.domain.enums.ProductType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "payment_product",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_payment_product_platform_store_product",
+                        columnNames = {"platform", "store_product_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_payment_product_product_id", columnList = "product_id"),
+                @Index(name = "idx_payment_product_active", columnList = "active")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentProduct extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "product_id", nullable = false, length = 100)
+    private String productId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PaymentPlatform platform;
+
+    @Column(name = "store_product_id", nullable = false, length = 150)
+    private String storeProductId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "product_type", nullable = false, length = 30)
+    private ProductType productType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "entitlement_type", length = 50)
+    private EntitlementType entitlementType;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean active = true;
+
+    @Column(name = "display_name", nullable = false, length = 100)
+    private String displayName;
+}

--- a/src/main/java/com/melissa/diary/domain/User.java
+++ b/src/main/java/com/melissa/diary/domain/User.java
@@ -1,5 +1,6 @@
 package com.melissa.diary.domain;
 
+import com.melissa.diary.domain.enums.AccountRole;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -54,6 +55,11 @@ public class User {
     private Integer dailyQuota;     // 오늘 남은 수량
     private LocalDate quotaDate;    // 마지막 초기화 날짜
 
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    @Column(name = "account_role", nullable = false, length = 20)
+    private AccountRole accountRole = AccountRole.USER;
+
     @Version
     @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     @Builder.Default
@@ -64,6 +70,7 @@ public class User {
     public void initQuota() {          // 신규 가입 시
         if (dailyQuota == null) dailyQuota = 100;
         if (quotaDate  == null) quotaDate  = LocalDate.now();
+        if (accountRole == null) accountRole = AccountRole.USER;
     }
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)

--- a/src/main/java/com/melissa/diary/domain/enums/AccountRole.java
+++ b/src/main/java/com/melissa/diary/domain/enums/AccountRole.java
@@ -1,0 +1,6 @@
+package com.melissa.diary.domain.enums;
+
+public enum AccountRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/melissa/diary/domain/enums/EntitlementSourceType.java
+++ b/src/main/java/com/melissa/diary/domain/enums/EntitlementSourceType.java
@@ -1,0 +1,8 @@
+package com.melissa.diary.domain.enums;
+
+public enum EntitlementSourceType {
+    PAYMENT,
+    ADMIN_GRANT,
+    PROMOTION,
+    MIGRATION
+}

--- a/src/main/java/com/melissa/diary/domain/enums/EntitlementType.java
+++ b/src/main/java/com/melissa/diary/domain/enums/EntitlementType.java
@@ -1,0 +1,8 @@
+package com.melissa.diary.domain.enums;
+
+public enum EntitlementType {
+    REMOVE_ADS,
+    PREMIUM,
+    EXTRA_STORAGE,
+    AI_CREDIT
+}

--- a/src/main/java/com/melissa/diary/domain/enums/PaymentEventProcessingStatus.java
+++ b/src/main/java/com/melissa/diary/domain/enums/PaymentEventProcessingStatus.java
@@ -1,0 +1,9 @@
+package com.melissa.diary.domain.enums;
+
+public enum PaymentEventProcessingStatus {
+    RECEIVED,
+    PROCESSED,
+    FAILED_RETRYABLE,
+    FAILED_FINAL,
+    DUPLICATE
+}

--- a/src/main/java/com/melissa/diary/domain/enums/PaymentPlatform.java
+++ b/src/main/java/com/melissa/diary/domain/enums/PaymentPlatform.java
@@ -1,0 +1,6 @@
+package com.melissa.diary.domain.enums;
+
+public enum PaymentPlatform {
+    GOOGLE,
+    APPLE
+}

--- a/src/main/java/com/melissa/diary/domain/enums/PaymentStatus.java
+++ b/src/main/java/com/melissa/diary/domain/enums/PaymentStatus.java
@@ -1,0 +1,9 @@
+package com.melissa.diary.domain.enums;
+
+public enum PaymentStatus {
+    PENDING,
+    PURCHASED,
+    FAILED,
+    REFUNDED,
+    REVOKED
+}

--- a/src/main/java/com/melissa/diary/domain/enums/ProductType.java
+++ b/src/main/java/com/melissa/diary/domain/enums/ProductType.java
@@ -1,0 +1,7 @@
+package com.melissa.diary.domain.enums;
+
+public enum ProductType {
+    NON_CONSUMABLE,
+    CONSUMABLE,
+    SUBSCRIPTION
+}

--- a/src/main/java/com/melissa/diary/repository/EntitlementRepository.java
+++ b/src/main/java/com/melissa/diary/repository/EntitlementRepository.java
@@ -1,0 +1,15 @@
+package com.melissa.diary.repository;
+
+import com.melissa.diary.domain.Entitlement;
+import com.melissa.diary.domain.enums.EntitlementType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface EntitlementRepository extends JpaRepository<Entitlement, Long> {
+
+    List<Entitlement> findByUserIdAndActiveTrue(Long userId);
+
+    Optional<Entitlement> findByUserIdAndEntitlementType(Long userId, EntitlementType entitlementType);
+}

--- a/src/main/java/com/melissa/diary/repository/PaymentEventRepository.java
+++ b/src/main/java/com/melissa/diary/repository/PaymentEventRepository.java
@@ -1,0 +1,12 @@
+package com.melissa.diary.repository;
+
+import com.melissa.diary.domain.PaymentEvent;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentEventRepository extends JpaRepository<PaymentEvent, Long> {
+
+    Optional<PaymentEvent> findByPlatformAndEventId(PaymentPlatform platform, String eventId);
+}

--- a/src/main/java/com/melissa/diary/repository/PaymentProductRepository.java
+++ b/src/main/java/com/melissa/diary/repository/PaymentProductRepository.java
@@ -1,0 +1,15 @@
+package com.melissa.diary.repository;
+
+import com.melissa.diary.domain.PaymentProduct;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PaymentProductRepository extends JpaRepository<PaymentProduct, Long> {
+
+    Optional<PaymentProduct> findByPlatformAndStoreProductIdAndActiveTrue(
+            PaymentPlatform platform,
+            String storeProductId
+    );
+}

--- a/src/main/java/com/melissa/diary/repository/PaymentRepository.java
+++ b/src/main/java/com/melissa/diary/repository/PaymentRepository.java
@@ -1,0 +1,9 @@
+package com.melissa.diary.repository;
+
+import com.melissa.diary.domain.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    boolean existsByUserId(Long userId);
+}

--- a/src/main/java/com/melissa/diary/service/AdminAuthorizationService.java
+++ b/src/main/java/com/melissa/diary/service/AdminAuthorizationService.java
@@ -1,0 +1,27 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.enums.AccountRole;
+import com.melissa.diary.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAuthorizationService {
+
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public void assertAdmin(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        if (user.getAccountRole() != AccountRole.ADMIN) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_ADMIN_REQUIRED);
+        }
+    }
+}

--- a/src/main/java/com/melissa/diary/service/EntitlementService.java
+++ b/src/main/java/com/melissa/diary/service/EntitlementService.java
@@ -1,0 +1,51 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.Entitlement;
+import com.melissa.diary.domain.enums.EntitlementType;
+import com.melissa.diary.repository.EntitlementRepository;
+import com.melissa.diary.repository.UserRepository;
+import com.melissa.diary.web.dto.EntitlementResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EntitlementService {
+
+    private final UserRepository userRepository;
+    private final EntitlementRepository entitlementRepository;
+
+    @Transactional(readOnly = true)
+    public EntitlementResponseDTO.EntitlementsResponse getUserEntitlements(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+
+        List<Entitlement> activeEntitlements = entitlementRepository.findByUserIdAndActiveTrue(userId);
+        boolean adRemoved = activeEntitlements.stream()
+                .anyMatch(entitlement -> entitlement.getEntitlementType() == EntitlementType.REMOVE_ADS);
+
+        return EntitlementResponseDTO.EntitlementsResponse.builder()
+                .entitlements(activeEntitlements.stream()
+                        .map(this::toSummary)
+                        .toList())
+                .features(EntitlementResponseDTO.FeatureSummary.builder()
+                        .adRemoved(adRemoved)
+                        .build())
+                .build();
+    }
+
+    private EntitlementResponseDTO.EntitlementSummary toSummary(Entitlement entitlement) {
+        return EntitlementResponseDTO.EntitlementSummary.builder()
+                .type(entitlement.getEntitlementType().name())
+                .active(entitlement.getActive())
+                .sourcePlatform(entitlement.getSourcePlatform() == null ? null : entitlement.getSourcePlatform().name())
+                .grantedAt(entitlement.getGrantedAt())
+                .revokedAt(entitlement.getRevokedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/melissa/diary/service/UserService.java
+++ b/src/main/java/com/melissa/diary/service/UserService.java
@@ -4,6 +4,7 @@ import com.melissa.diary.apiPayload.code.status.ErrorStatus;
 import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
 import com.melissa.diary.converter.UserConverter;
 import com.melissa.diary.domain.User;
+import com.melissa.diary.repository.PaymentRepository;
 import com.melissa.diary.repository.ThreadRepository;
 import com.melissa.diary.repository.UserMemoryRepository;
 import com.melissa.diary.repository.UserRepository;
@@ -31,6 +32,7 @@ public class UserService {
     private final ThreadRepository threadRepository;
     private final UserSettingRepository userSettingRepository;
     private final UserMemoryRepository userMemoryRepository;
+    private final PaymentRepository paymentRepository;
 
 
     @Transactional
@@ -186,6 +188,10 @@ public class UserService {
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
 
         // 유저의 스레드 및 관련 채팅 내역 삭제
+        if (paymentRepository.existsByUserId(userId)) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_USER_DELETE_BLOCKED);
+        }
+
         threadRepository.deleteAllByUserId(userId);
 
         // 유저 설정 삭제

--- a/src/main/java/com/melissa/diary/web/controller/UserController.java
+++ b/src/main/java/com/melissa/diary/web/controller/UserController.java
@@ -1,7 +1,9 @@
 package com.melissa.diary.web.controller;
 
 import com.melissa.diary.apiPayload.ApiResponse;
+import com.melissa.diary.service.EntitlementService;
 import com.melissa.diary.service.UserService;
+import com.melissa.diary.web.dto.EntitlementResponseDTO;
 import com.melissa.diary.web.dto.UserResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -21,6 +23,7 @@ import java.security.Principal;
 public class UserController {
 
     private final UserService userService;
+    private final EntitlementService entitlementService;
 
     @Operation(description = "회원탈퇴하고, 유저 정보를 리턴합니다.")
     @DeleteMapping
@@ -50,6 +53,24 @@ public class UserController {
         Long userId = Long.parseLong(principal.getName());
 
         UserResponseDTO.MeResponseDTO response = userService.getMe(userId);
+
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(
+            summary = "Get current user's payment entitlements",
+            description = "Returns active payment entitlements and derived feature flags for the authenticated user."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Success"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Authentication failed"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: User not found")
+    })
+    @GetMapping("/me/entitlements")
+    public ApiResponse<EntitlementResponseDTO.EntitlementsResponse> getMyEntitlements(Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+
+        EntitlementResponseDTO.EntitlementsResponse response = entitlementService.getUserEntitlements(userId);
 
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/melissa/diary/web/dto/EntitlementResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/EntitlementResponseDTO.java
@@ -1,0 +1,53 @@
+package com.melissa.diary.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class EntitlementResponseDTO {
+
+    @Getter
+    @Builder
+    @Schema(description = "Current user's active entitlement response")
+    public static class EntitlementsResponse {
+
+        @Schema(description = "Active entitlement list")
+        private List<EntitlementSummary> entitlements;
+
+        @Schema(description = "Feature flags derived from active entitlements")
+        private FeatureSummary features;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "Active entitlement summary")
+    public static class EntitlementSummary {
+
+        @Schema(description = "Entitlement type", example = "REMOVE_ADS")
+        private String type;
+
+        @Schema(description = "Whether the entitlement is active", example = "true")
+        private Boolean active;
+
+        @Schema(description = "Source platform", example = "GOOGLE", nullable = true)
+        private String sourcePlatform;
+
+        @Schema(description = "Granted time")
+        private LocalDateTime grantedAt;
+
+        @Schema(description = "Revoked time", nullable = true)
+        private LocalDateTime revokedAt;
+    }
+
+    @Getter
+    @Builder
+    @Schema(description = "Feature flags")
+    public static class FeatureSummary {
+
+        @Schema(description = "Whether ads should be removed", example = "true")
+        private Boolean adRemoved;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,6 +80,27 @@ idempotency:
   ttl-hours: 24
   cleanup-cron: "0 0 * * * *"
 
+payment:
+  iap:
+    enabled: ${PAYMENT_IAP_ENABLED:false}
+    verify-timeout-ms: ${PAYMENT_IAP_VERIFY_TIMEOUT_MS:5000}
+    store-product:
+      remove-ads: ${PAYMENT_STORE_PRODUCT_REMOVE_ADS:remove_ads}
+  google:
+    enabled: ${PAYMENT_GOOGLE_ENABLED:false}
+    package-name: ${PAYMENT_GOOGLE_PACKAGE_NAME:com.melissa.melissaFE}
+    product-remove-ads: ${PAYMENT_GOOGLE_PRODUCT_REMOVE_ADS:premium}
+    service-account-json-base64: ${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64:}
+    token-hash-salt: ${PAYMENT_TOKEN_HASH_SALT:}
+  apple:
+    enabled: ${PAYMENT_APPLE_ENABLED:false}
+    bundle-id: ${PAYMENT_APPLE_BUNDLE_ID:com.melissa.melissaFE}
+    product-remove-ads: ${PAYMENT_APPLE_PRODUCT_REMOVE_ADS:com.melissa.melissaFE.premium}
+    issuer-id: ${APPLE_ISSUER_ID:}
+    key-id: ${APPLE_KEY_ID:}
+    private-key-p8-base64: ${APPLE_PRIVATE_KEY_P8_BASE64:}
+    environment: ${PAYMENT_APPLE_ENVIRONMENT:SANDBOX}
+
 melissa:
   sqs:
     enabled: ${MELISSA_SQS_ENABLED:false}

--- a/src/main/resources/db/migration/manual/PAY-001-apply.sql
+++ b/src/main/resources/db/migration/manual/PAY-001-apply.sql
@@ -1,0 +1,232 @@
+-- PAY-001 apply script
+-- Target DB: MySQL 8.x
+-- Purpose: add payment foundation, entitlement lookup, and account-role storage
+
+-- =========================
+-- A. user.account_role
+-- =========================
+SET @has_account_role := (
+    SELECT COUNT(*)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'user'
+      AND column_name = 'account_role'
+);
+
+SET @sql := IF(
+    @has_account_role = 0,
+    'ALTER TABLE `user` ADD COLUMN account_role VARCHAR(20) NOT NULL DEFAULT ''USER''',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx_user_account_role := (
+    SELECT COUNT(*)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'user'
+      AND index_name = 'idx_user_account_role'
+);
+
+SET @sql := IF(
+    @has_idx_user_account_role = 0,
+    'CREATE INDEX idx_user_account_role ON `user` (account_role)',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- B. payment_product
+-- =========================
+SET @has_payment_product := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'payment_product'
+);
+
+SET @sql := IF(
+    @has_payment_product = 0,
+    'CREATE TABLE payment_product (
+        id BIGINT NOT NULL AUTO_INCREMENT,
+        product_id VARCHAR(100) NOT NULL,
+        platform VARCHAR(20) NOT NULL,
+        store_product_id VARCHAR(150) NOT NULL,
+        product_type VARCHAR(30) NOT NULL,
+        entitlement_type VARCHAR(50) NULL,
+        active BOOLEAN NOT NULL DEFAULT TRUE,
+        display_name VARCHAR(100) NOT NULL,
+        created_at DATETIME(6) NOT NULL,
+        updated_at DATETIME(6) NOT NULL,
+        PRIMARY KEY (id),
+        UNIQUE KEY uk_payment_product_platform_store_product (platform, store_product_id),
+        KEY idx_payment_product_product_id (product_id),
+        KEY idx_payment_product_active (active)
+    )',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+INSERT INTO payment_product (
+    product_id,
+    platform,
+    store_product_id,
+    product_type,
+    entitlement_type,
+    active,
+    display_name,
+    created_at,
+    updated_at
+) VALUES
+('remove_ads', 'GOOGLE', 'premium', 'NON_CONSUMABLE', 'REMOVE_ADS', TRUE, '광고 제거', NOW(6), NOW(6)),
+('remove_ads', 'APPLE', 'com.melissa.melissaFE.premium', 'NON_CONSUMABLE', 'REMOVE_ADS', TRUE, '광고 제거', NOW(6), NOW(6))
+ON DUPLICATE KEY UPDATE
+    product_id = VALUES(product_id),
+    product_type = VALUES(product_type),
+    entitlement_type = VALUES(entitlement_type),
+    active = VALUES(active),
+    display_name = VALUES(display_name),
+    updated_at = NOW(6);
+
+-- =========================
+-- C. payment
+-- =========================
+SET @has_payment := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'payment'
+);
+
+SET @sql := IF(
+    @has_payment = 0,
+    'CREATE TABLE payment (
+        id BIGINT NOT NULL AUTO_INCREMENT,
+        user_id BIGINT NOT NULL,
+        platform VARCHAR(20) NOT NULL,
+        product_id BIGINT NOT NULL,
+        store_product_id VARCHAR(150) NOT NULL,
+        product_type VARCHAR(30) NOT NULL,
+        status VARCHAR(30) NOT NULL,
+        amount_micros BIGINT NULL,
+        currency VARCHAR(10) NULL,
+        google_purchase_token_hash CHAR(64) NULL,
+        google_purchase_token_encrypted TEXT NULL,
+        google_order_id VARCHAR(100) NULL,
+        apple_transaction_id VARCHAR(100) NULL,
+        apple_original_transaction_id VARCHAR(100) NULL,
+        apple_environment VARCHAR(30) NULL,
+        purchased_at DATETIME(6) NULL,
+        verified_at DATETIME(6) NULL,
+        acknowledged_at DATETIME(6) NULL,
+        refunded_at DATETIME(6) NULL,
+        revoked_at DATETIME(6) NULL,
+        raw_verified_payload JSON NULL,
+        failure_reason VARCHAR(500) NULL,
+        created_at DATETIME(6) NOT NULL,
+        updated_at DATETIME(6) NOT NULL,
+        version BIGINT NOT NULL DEFAULT 0,
+        PRIMARY KEY (id),
+        CONSTRAINT fk_payment_user FOREIGN KEY (user_id) REFERENCES `user` (id) ON DELETE RESTRICT,
+        CONSTRAINT fk_payment_product FOREIGN KEY (product_id) REFERENCES payment_product (id),
+        UNIQUE KEY uk_payment_google_token (platform, google_purchase_token_hash),
+        UNIQUE KEY uk_payment_apple_transaction (platform, apple_transaction_id),
+        KEY idx_payment_user_status (user_id, status),
+        KEY idx_payment_user_product (user_id, product_id),
+        KEY idx_payment_google_order (google_order_id),
+        KEY idx_payment_apple_original_transaction (apple_original_transaction_id),
+        KEY idx_payment_created_at (created_at)
+    )',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- D. entitlement
+-- =========================
+SET @has_entitlement := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'entitlement'
+);
+
+SET @sql := IF(
+    @has_entitlement = 0,
+    'CREATE TABLE entitlement (
+        id BIGINT NOT NULL AUTO_INCREMENT,
+        user_id BIGINT NOT NULL,
+        entitlement_type VARCHAR(50) NOT NULL,
+        active BOOLEAN NOT NULL,
+        source_type VARCHAR(30) NOT NULL,
+        source_platform VARCHAR(20) NULL,
+        source_payment_id BIGINT NULL,
+        granted_at DATETIME(6) NOT NULL,
+        revoked_at DATETIME(6) NULL,
+        revocation_reason VARCHAR(100) NULL,
+        created_at DATETIME(6) NOT NULL,
+        updated_at DATETIME(6) NOT NULL,
+        version BIGINT NOT NULL DEFAULT 0,
+        PRIMARY KEY (id),
+        CONSTRAINT fk_entitlement_user FOREIGN KEY (user_id) REFERENCES `user` (id) ON DELETE RESTRICT,
+        CONSTRAINT fk_entitlement_payment FOREIGN KEY (source_payment_id) REFERENCES payment (id),
+        UNIQUE KEY uk_entitlement_user_type (user_id, entitlement_type),
+        KEY idx_entitlement_active (active),
+        KEY idx_entitlement_source_payment (source_payment_id)
+    )',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================
+-- E. payment_event
+-- =========================
+SET @has_payment_event := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'payment_event'
+);
+
+SET @sql := IF(
+    @has_payment_event = 0,
+    'CREATE TABLE payment_event (
+        id BIGINT NOT NULL AUTO_INCREMENT,
+        platform VARCHAR(20) NOT NULL,
+        event_id VARCHAR(200) NOT NULL,
+        event_type VARCHAR(100) NOT NULL,
+        payment_id BIGINT NULL,
+        actor_user_id BIGINT NULL,
+        google_purchase_token_hash CHAR(64) NULL,
+        apple_transaction_id VARCHAR(100) NULL,
+        raw_payload JSON NULL,
+        received_at DATETIME(6) NOT NULL,
+        processed_at DATETIME(6) NULL,
+        processing_status VARCHAR(30) NOT NULL,
+        last_error VARCHAR(500) NULL,
+        PRIMARY KEY (id),
+        CONSTRAINT fk_payment_event_payment FOREIGN KEY (payment_id) REFERENCES payment (id),
+        CONSTRAINT fk_payment_event_actor_user FOREIGN KEY (actor_user_id) REFERENCES `user` (id) ON DELETE SET NULL,
+        UNIQUE KEY uk_payment_event_platform_event (platform, event_id),
+        KEY idx_payment_event_processing (processing_status, received_at),
+        KEY idx_payment_event_payment (payment_id),
+        KEY idx_payment_event_actor_user (actor_user_id)
+    )',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Admin account designation example:
+-- UPDATE `user` SET account_role = 'ADMIN' WHERE id = ?;

--- a/src/main/resources/db/migration/manual/PAY-001-precheck.sql
+++ b/src/main/resources/db/migration/manual/PAY-001-precheck.sql
@@ -1,0 +1,46 @@
+-- PAY-001 pre-check
+-- Target DB: MySQL 8.x
+-- Purpose: inspect payment foundation migration readiness
+
+SELECT COUNT(*) AS has_user_account_role_column
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'user'
+  AND column_name = 'account_role';
+
+SELECT table_name, table_rows
+FROM information_schema.tables
+WHERE table_schema = DATABASE()
+  AND table_name IN ('payment_product', 'payment', 'entitlement', 'payment_event')
+ORDER BY table_name;
+
+SELECT table_name, index_name, column_name, seq_in_index, non_unique
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+  AND table_name IN ('payment_product', 'payment', 'entitlement', 'payment_event')
+ORDER BY table_name, index_name, seq_in_index;
+
+SET @has_payment_product := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'payment_product'
+);
+
+SET @sql := IF(
+    @has_payment_product = 1,
+    'SELECT COUNT(*) AS google_remove_ads_product_count FROM payment_product WHERE platform = ''GOOGLE'' AND store_product_id = ''premium''',
+    'SELECT 0 AS google_remove_ads_product_count'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @sql := IF(
+    @has_payment_product = 1,
+    'SELECT COUNT(*) AS apple_remove_ads_product_count FROM payment_product WHERE platform = ''APPLE'' AND store_product_id = ''com.melissa.melissaFE.premium''',
+    'SELECT 0 AS apple_remove_ads_product_count'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/main/resources/db/migration/manual/PAY-001-rollback.sql
+++ b/src/main/resources/db/migration/manual/PAY-001-rollback.sql
@@ -1,0 +1,76 @@
+-- PAY-001 rollback script
+-- Target DB: MySQL 8.x
+
+SET @has_payment_event := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'payment_event'
+);
+
+SET @sql := IF(@has_payment_event > 0, 'DROP TABLE payment_event', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_entitlement := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'entitlement'
+);
+
+SET @sql := IF(@has_entitlement > 0, 'DROP TABLE entitlement', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_payment := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'payment'
+);
+
+SET @sql := IF(@has_payment > 0, 'DROP TABLE payment', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_payment_product := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'payment_product'
+);
+
+SET @sql := IF(@has_payment_product > 0, 'DROP TABLE payment_product', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_idx_user_account_role := (
+    SELECT COUNT(*)
+    FROM information_schema.statistics
+    WHERE table_schema = DATABASE()
+      AND table_name = 'user'
+      AND index_name = 'idx_user_account_role'
+);
+
+SET @sql := IF(@has_idx_user_account_role > 0, 'DROP INDEX idx_user_account_role ON `user`', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_account_role := (
+    SELECT COUNT(*)
+    FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = 'user'
+      AND column_name = 'account_role'
+);
+
+SET @sql := IF(@has_account_role > 0, 'ALTER TABLE `user` DROP COLUMN account_role', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/test/java/com/melissa/diary/service/AdminAuthorizationServiceTest.java
+++ b/src/test/java/com/melissa/diary/service/AdminAuthorizationServiceTest.java
@@ -1,0 +1,61 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.enums.AccountRole;
+import com.melissa.diary.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminAuthorizationServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private AdminAuthorizationService adminAuthorizationService;
+
+    @Test
+    void assertAdminAllowsAdminUser() {
+        Long userId = 1L;
+        User admin = User.builder()
+                .id(userId)
+                .provider("GOOGLE")
+                .nickname("admin")
+                .accountRole(AccountRole.ADMIN)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(admin));
+
+        assertDoesNotThrow(() -> adminAuthorizationService.assertAdmin(userId));
+    }
+
+    @Test
+    void assertAdminRejectsNormalUser() {
+        Long userId = 1L;
+        User user = User.builder()
+                .id(userId)
+                .provider("GOOGLE")
+                .nickname("user")
+                .accountRole(AccountRole.USER)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        ErrorHandler error = assertThrows(ErrorHandler.class, () -> adminAuthorizationService.assertAdmin(userId));
+
+        assertThat(error.getErrorCode()).isEqualTo(ErrorStatus.PAYMENT_ADMIN_REQUIRED);
+    }
+}

--- a/src/test/java/com/melissa/diary/service/EntitlementServiceTest.java
+++ b/src/test/java/com/melissa/diary/service/EntitlementServiceTest.java
@@ -1,0 +1,97 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.Entitlement;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.enums.EntitlementSourceType;
+import com.melissa.diary.domain.enums.EntitlementType;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import com.melissa.diary.repository.EntitlementRepository;
+import com.melissa.diary.repository.UserRepository;
+import com.melissa.diary.web.dto.EntitlementResponseDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EntitlementServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private EntitlementRepository entitlementRepository;
+
+    @InjectMocks
+    private EntitlementService entitlementService;
+
+    @Test
+    void getUserEntitlementsReturnsEmptyFeaturesWhenNoActiveEntitlements() {
+        Long userId = 1L;
+        User user = User.builder()
+                .id(userId)
+                .provider("GOOGLE")
+                .nickname("user")
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(entitlementRepository.findByUserIdAndActiveTrue(userId)).thenReturn(List.of());
+
+        EntitlementResponseDTO.EntitlementsResponse response = entitlementService.getUserEntitlements(userId);
+
+        assertThat(response.getEntitlements()).isEmpty();
+        assertThat(response.getFeatures().getAdRemoved()).isFalse();
+    }
+
+    @Test
+    void getUserEntitlementsMapsRemoveAdsToAdRemovedFeature() {
+        Long userId = 1L;
+        LocalDateTime grantedAt = LocalDateTime.of(2026, 6, 15, 10, 0);
+        User user = User.builder()
+                .id(userId)
+                .provider("APPLE")
+                .nickname("user")
+                .build();
+        Entitlement entitlement = Entitlement.builder()
+                .user(user)
+                .entitlementType(EntitlementType.REMOVE_ADS)
+                .active(true)
+                .sourceType(EntitlementSourceType.PAYMENT)
+                .sourcePlatform(PaymentPlatform.APPLE)
+                .grantedAt(grantedAt)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(entitlementRepository.findByUserIdAndActiveTrue(userId)).thenReturn(List.of(entitlement));
+
+        EntitlementResponseDTO.EntitlementsResponse response = entitlementService.getUserEntitlements(userId);
+
+        assertThat(response.getFeatures().getAdRemoved()).isTrue();
+        assertThat(response.getEntitlements()).hasSize(1);
+        assertThat(response.getEntitlements().get(0).getType()).isEqualTo("REMOVE_ADS");
+        assertThat(response.getEntitlements().get(0).getActive()).isTrue();
+        assertThat(response.getEntitlements().get(0).getSourcePlatform()).isEqualTo("APPLE");
+        assertThat(response.getEntitlements().get(0).getGrantedAt()).isEqualTo(grantedAt);
+    }
+
+    @Test
+    void getUserEntitlementsThrowsWhenUserDoesNotExist() {
+        Long userId = 404L;
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        ErrorHandler error = assertThrows(ErrorHandler.class, () -> entitlementService.getUserEntitlements(userId));
+
+        assertThat(error.getErrorCode()).isEqualTo(ErrorStatus.USER_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/melissa/diary/service/UserServiceTest.java
+++ b/src/test/java/com/melissa/diary/service/UserServiceTest.java
@@ -1,0 +1,104 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.repository.PaymentRepository;
+import com.melissa.diary.repository.ThreadRepository;
+import com.melissa.diary.repository.UserMemoryRepository;
+import com.melissa.diary.repository.UserRepository;
+import com.melissa.diary.repository.UserSettingRepository;
+import com.melissa.diary.security.JwtProvider;
+import com.melissa.diary.security.RefreshTokenHasher;
+import com.melissa.diary.web.dto.UserResponseDTO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SocialAuthService socialAuthService;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private RefreshTokenHasher refreshTokenHasher;
+
+    @Mock
+    private ThreadRepository threadRepository;
+
+    @Mock
+    private UserSettingRepository userSettingRepository;
+
+    @Mock
+    private UserMemoryRepository userMemoryRepository;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void deleteUserRejectsUserWithPaymentHistory() {
+        Long userId = 1L;
+        User user = User.builder()
+                .id(userId)
+                .provider("GOOGLE")
+                .providerId("google-1")
+                .email("user@example.com")
+                .nickname("user")
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(paymentRepository.existsByUserId(userId)).thenReturn(true);
+
+        ErrorHandler error = assertThrows(ErrorHandler.class, () -> userService.deleteUser(userId));
+
+        assertThat(error.getErrorCode()).isEqualTo(ErrorStatus.PAYMENT_USER_DELETE_BLOCKED);
+        verify(threadRepository, never()).deleteAllByUserId(userId);
+        verify(userSettingRepository, never()).deleteByUserId(userId);
+        verify(userMemoryRepository, never()).deleteByUserId(userId);
+        verify(userRepository, never()).delete(any(User.class));
+    }
+
+    @Test
+    void deleteUserDeletesUserWhenNoPaymentHistoryExists() {
+        Long userId = 1L;
+        User user = User.builder()
+                .id(userId)
+                .provider("GOOGLE")
+                .providerId("google-1")
+                .email("user@example.com")
+                .nickname("user")
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(paymentRepository.existsByUserId(userId)).thenReturn(false);
+
+        UserResponseDTO.DeleteResultDTO response = userService.deleteUser(userId);
+
+        assertThat(response.getUserId()).isEqualTo(userId);
+        verify(threadRepository).deleteAllByUserId(userId);
+        verify(userSettingRepository).deleteByUserId(userId);
+        verify(userMemoryRepository).deleteByUserId(userId);
+        verify(userRepository).delete(user);
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
결제 기반 DB 모델과 수동 마이그레이션, 광고 제거 권한 조회 API, 관리자 권한 모델을 추가했습니다.
내부 상품은 `remove_ads`, Google 상품은 `premium`, Apple 상품은 `com.melissa.melissaFE.premium`으로 매핑했습니다.

## 📋 변경 사항
- `payment_product`, `payment`, `entitlement`, `payment_event` JPA 모델/Repository 추가
- `user.account_role`, `AccountRole(USER, ADMIN)`, `AdminAuthorizationService` 추가
- `GET /api/v1/user/me/entitlements` 추가 및 `features.adRemoved` 응답 구현
- 결제 이력이 있는 사용자 hard delete 차단
- `PAY-001` precheck/apply/rollback SQL 추가 및 `payment.*` 설정 기본값 추가
- 관련 단위 테스트 추가

## 🔍 Code Review
- 기존 `Role(AI, USER)`, `Platform(ANDROID, IOS)` enum은 재사용하지 않고 결제/계정 권한 전용 enum으로 분리했습니다.
- 결제 테이블 FK는 감사 이력 보존을 위해 cascade delete를 걸지 않았고, 탈퇴 시 `PaymentRepository.existsByUserId`로 먼저 차단합니다.
- Google/Apple 실제 구매 검증, 복원, 환불 자동 반영은 다음 이슈 범위입니다.
- 검증: `./gradlew.bat test --tests com.melissa.diary.service.EntitlementServiceTest --tests com.melissa.diary.service.AdminAuthorizationServiceTest --tests com.melissa.diary.service.UserServiceTest` 통과.
- 전체 테스트는 기존 `ENC_SECRET_KEY` 미설정 시 `contextLoads`가 실패할 수 있습니다.

## 📸 ScreenShot
N/A (백엔드 API/DB 변경)