### PR TITLE
Feat: Google/Apple remove_ads 구매 검증과 복원 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 
 	// 애플 jwt 토큰 검증용
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.37.2'
+	implementation 'com.google.auth:google-auth-library-oauth2-http:1.30.1'
 
 	// json
 	//implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'

--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -82,7 +82,18 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Payment
     PAYMENT_ADMIN_REQUIRED(HttpStatus.FORBIDDEN, "PAYMENT4031", "관리자 권한이 필요합니다."),
-    PAYMENT_USER_DELETE_BLOCKED(HttpStatus.CONFLICT, "PAYMENT4092", "결제 이력이 있어 현재 회원탈퇴를 처리할 수 없습니다. 관리자에게 문의해주세요.");
+    PAYMENT_PRODUCT_NOT_FOUND(HttpStatus.BAD_REQUEST, "PAYMENT4001", "결제 상품이 존재하지 않거나 비활성화되어 있습니다."),
+    PAYMENT_PRODUCT_MISMATCH(HttpStatus.BAD_REQUEST, "PAYMENT4002", "요청한 결제 상품이 서버 설정과 일치하지 않습니다."),
+    PAYMENT_PURCHASE_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "PAYMENT4003", "구매가 완료 상태가 아닙니다."),
+    PAYMENT_STORE_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT4004", "스토어 구매 검증에 실패했습니다."),
+    PAYMENT_PURCHASE_OWNER_MISMATCH(HttpStatus.BAD_REQUEST, "PAYMENT4005", "구매 소유자 또는 앱 식별자가 일치하지 않습니다."),
+    PAYMENT_PURCHASE_REVOKED(HttpStatus.BAD_REQUEST, "PAYMENT4006", "환불 또는 취소된 구매입니다."),
+    PAYMENT_ALREADY_OWNED_BY_OTHER_USER(HttpStatus.CONFLICT, "PAYMENT4091", "같은 구매가 다른 사용자에게 이미 연결되어 있습니다."),
+    PAYMENT_USER_DELETE_BLOCKED(HttpStatus.CONFLICT, "PAYMENT4092", "결제 이력이 있어 현재 회원탈퇴를 처리할 수 없습니다. 관리자에게 문의해주세요."),
+    PAYMENT_DISABLED(HttpStatus.SERVICE_UNAVAILABLE, "PAYMENT5031", "인앱결제 검증 기능이 비활성화되어 있습니다."),
+    PAYMENT_STORE_API_FAILED(HttpStatus.BAD_GATEWAY, "PAYMENT5001", "스토어 API 호출에 실패했습니다."),
+    PAYMENT_GRANT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT5002", "결제 권한 부여에 실패했습니다."),
+    PAYMENT_ACKNOWLEDGE_FAILED(HttpStatus.BAD_GATEWAY, "PAYMENT5003", "Google 구매 acknowledge 처리에 실패했습니다.");
 
 
 

--- a/src/main/java/com/melissa/diary/config/PaymentProperties.java
+++ b/src/main/java/com/melissa/diary/config/PaymentProperties.java
@@ -35,6 +35,8 @@ public class PaymentProperties {
         private String productRemoveAds = "premium";
         private String serviceAccountJsonBase64 = "";
         private String tokenHashSalt = "";
+        private long acknowledgeRetryFixedDelayMs = 600000;
+        private int acknowledgeRetryBatchSize = 20;
     }
 
     @Getter

--- a/src/main/java/com/melissa/diary/repository/EntitlementRepository.java
+++ b/src/main/java/com/melissa/diary/repository/EntitlementRepository.java
@@ -2,7 +2,11 @@ package com.melissa.diary.repository;
 
 import com.melissa.diary.domain.Entitlement;
 import com.melissa.diary.domain.enums.EntitlementType;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,4 +16,16 @@ public interface EntitlementRepository extends JpaRepository<Entitlement, Long> 
     List<Entitlement> findByUserIdAndActiveTrue(Long userId);
 
     Optional<Entitlement> findByUserIdAndEntitlementType(Long userId, EntitlementType entitlementType);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT e
+            FROM Entitlement e
+            WHERE e.user.id = :userId
+              AND e.entitlementType = :entitlementType
+            """)
+    Optional<Entitlement> findByUserIdAndEntitlementTypeForUpdate(
+            @Param("userId") Long userId,
+            @Param("entitlementType") EntitlementType entitlementType
+    );
 }

--- a/src/main/java/com/melissa/diary/repository/PaymentRepository.java
+++ b/src/main/java/com/melissa/diary/repository/PaymentRepository.java
@@ -1,9 +1,49 @@
 package com.melissa.diary.repository;
 
 import com.melissa.diary.domain.Payment;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import com.melissa.diary.domain.enums.PaymentStatus;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     boolean existsByUserId(Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT p
+            FROM Payment p
+            WHERE p.platform = :platform
+              AND p.googlePurchaseTokenHash = :tokenHash
+            """)
+    Optional<Payment> findByPlatformAndGooglePurchaseTokenHashForUpdate(
+            @Param("platform") PaymentPlatform platform,
+            @Param("tokenHash") String tokenHash
+    );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT p
+            FROM Payment p
+            WHERE p.platform = :platform
+              AND p.appleTransactionId = :transactionId
+            """)
+    Optional<Payment> findByPlatformAndAppleTransactionIdForUpdate(
+            @Param("platform") PaymentPlatform platform,
+            @Param("transactionId") String transactionId
+    );
+
+    @EntityGraph(attributePaths = "product")
+    List<Payment> findTop20ByPlatformAndStatusAndAcknowledgedAtIsNullAndGooglePurchaseTokenEncryptedIsNotNullOrderByCreatedAtAsc(
+            PaymentPlatform platform,
+            PaymentStatus status
+    );
 }

--- a/src/main/java/com/melissa/diary/service/payment/GoogleAcknowledgeRetryScheduler.java
+++ b/src/main/java/com/melissa/diary/service/payment/GoogleAcknowledgeRetryScheduler.java
@@ -1,0 +1,63 @@
+package com.melissa.diary.service.payment;
+
+import com.melissa.diary.config.PaymentProperties;
+import com.melissa.diary.domain.Payment;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import com.melissa.diary.domain.enums.PaymentStatus;
+import com.melissa.diary.repository.PaymentRepository;
+import com.melissa.diary.security.EncryptionManager;
+import com.melissa.diary.service.payment.store.GoogleAcknowledgeCommand;
+import com.melissa.diary.service.payment.store.GooglePlayPurchaseVerifier;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoogleAcknowledgeRetryScheduler {
+
+    private final PaymentProperties paymentProperties;
+    private final PaymentRepository paymentRepository;
+    private final EncryptionManager encryptionManager;
+    private final GooglePlayPurchaseVerifier googlePlayPurchaseVerifier;
+    private final PaymentGrantService paymentGrantService;
+
+    @Scheduled(fixedDelayString = "${payment.google.acknowledge-retry-fixed-delay-ms:600000}")
+    public void retryPendingAcknowledgements() {
+        if (!paymentProperties.getIap().isEnabled() || !paymentProperties.getGoogle().isEnabled()) {
+            return;
+        }
+
+        List<Payment> pendingPayments = paymentRepository
+                .findTop20ByPlatformAndStatusAndAcknowledgedAtIsNullAndGooglePurchaseTokenEncryptedIsNotNullOrderByCreatedAtAsc(
+                        PaymentPlatform.GOOGLE,
+                        PaymentStatus.PURCHASED
+                )
+                .stream()
+                .limit(paymentProperties.getGoogle().getAcknowledgeRetryBatchSize())
+                .toList();
+
+        for (Payment payment : pendingPayments) {
+            retryOne(payment);
+        }
+    }
+
+    private void retryOne(Payment payment) {
+        try {
+            String purchaseToken = encryptionManager.decrypt(payment.getGooglePurchaseTokenEncrypted());
+            googlePlayPurchaseVerifier.acknowledge(new GoogleAcknowledgeCommand(
+                    paymentProperties.getGoogle().getPackageName(),
+                    payment.getProduct().getStoreProductId(),
+                    purchaseToken
+            ));
+            paymentGrantService.markGoogleAcknowledged(payment.getId());
+        } catch (RuntimeException e) {
+            log.warn("[GoogleAcknowledgeRetryScheduler] retry failed. paymentId={}", payment.getId(), e);
+            paymentGrantService.markGoogleAcknowledgeFailed(payment.getId(), e);
+        }
+    }
+}

--- a/src/main/java/com/melissa/diary/service/payment/PaymentGrantResult.java
+++ b/src/main/java/com/melissa/diary/service/payment/PaymentGrantResult.java
@@ -1,0 +1,14 @@
+package com.melissa.diary.service.payment;
+
+import com.melissa.diary.domain.Entitlement;
+import com.melissa.diary.domain.Payment;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PaymentGrantResult {
+    private Payment payment;
+    private Entitlement entitlement;
+    private boolean alreadyProcessed;
+}

--- a/src/main/java/com/melissa/diary/service/payment/PaymentGrantService.java
+++ b/src/main/java/com/melissa/diary/service/payment/PaymentGrantService.java
@@ -1,0 +1,231 @@
+package com.melissa.diary.service.payment;
+
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.config.PaymentProperties;
+import com.melissa.diary.domain.Entitlement;
+import com.melissa.diary.domain.Payment;
+import com.melissa.diary.domain.PaymentProduct;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.enums.EntitlementSourceType;
+import com.melissa.diary.domain.enums.EntitlementType;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import com.melissa.diary.domain.enums.PaymentStatus;
+import com.melissa.diary.repository.EntitlementRepository;
+import com.melissa.diary.repository.PaymentProductRepository;
+import com.melissa.diary.repository.PaymentRepository;
+import com.melissa.diary.repository.UserRepository;
+import com.melissa.diary.security.EncryptionManager;
+import com.melissa.diary.service.payment.store.VerifiedPurchase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.LocalDateTime;
+import java.util.HexFormat;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentGrantService {
+
+    private final PaymentProperties paymentProperties;
+    private final UserRepository userRepository;
+    private final PaymentProductRepository paymentProductRepository;
+    private final PaymentRepository paymentRepository;
+    private final EntitlementRepository entitlementRepository;
+    private final EncryptionManager encryptionManager;
+
+    @Transactional
+    public PaymentGrantResult grantGooglePurchase(Long userId, VerifiedPurchase purchase, String purchaseToken) {
+        if (purchase.isRevoked()) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_PURCHASE_REVOKED);
+        }
+
+        String tokenHash = hashGooglePurchaseToken(purchaseToken);
+        return paymentRepository
+                .findByPlatformAndGooglePurchaseTokenHashForUpdate(PaymentPlatform.GOOGLE, tokenHash)
+                .map(existing -> existingGrantResult(userId, existing))
+                .orElseGet(() -> createGooglePayment(userId, purchase, purchaseToken, tokenHash));
+    }
+
+    @Transactional
+    public PaymentGrantResult grantApplePurchase(Long userId, VerifiedPurchase purchase) {
+        if (purchase.isRevoked()) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_PURCHASE_REVOKED);
+        }
+
+        return paymentRepository
+                .findByPlatformAndAppleTransactionIdForUpdate(PaymentPlatform.APPLE, purchase.getAppleTransactionId())
+                .map(existing -> existingGrantResult(userId, existing))
+                .orElseGet(() -> createApplePayment(userId, purchase));
+    }
+
+    @Transactional
+    public void markGoogleAcknowledged(Long paymentId) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.PAYMENT_PRODUCT_NOT_FOUND));
+        payment.setAcknowledgedAt(LocalDateTime.now());
+        payment.setFailureReason(null);
+    }
+
+    @Transactional
+    public void markGoogleAcknowledgeFailed(Long paymentId, Exception exception) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.PAYMENT_PRODUCT_NOT_FOUND));
+        payment.setFailureReason(truncate("Google acknowledge failed: " + exception.getMessage(), 500));
+    }
+
+    String hashGooglePurchaseToken(String purchaseToken) {
+        String salt = paymentProperties.getGoogle().getTokenHashSalt();
+        if (isBlank(salt)) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_GRANT_FAILED);
+        }
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest((salt + ":" + purchaseToken).getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hashed);
+        } catch (Exception e) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_GRANT_FAILED);
+        }
+    }
+
+    private PaymentGrantResult createGooglePayment(
+            Long userId,
+            VerifiedPurchase purchase,
+            String purchaseToken,
+            String tokenHash
+    ) {
+        User user = findUser(userId);
+        PaymentProduct product = findProduct(PaymentPlatform.GOOGLE, purchase.getStoreProductId());
+        LocalDateTime now = LocalDateTime.now();
+
+        Payment payment = Payment.builder()
+                .user(user)
+                .platform(PaymentPlatform.GOOGLE)
+                .product(product)
+                .storeProductId(product.getStoreProductId())
+                .productType(product.getProductType())
+                .status(PaymentStatus.PURCHASED)
+                .amountMicros(purchase.getAmountMicros())
+                .currency(purchase.getCurrency())
+                .googlePurchaseTokenHash(tokenHash)
+                .googlePurchaseTokenEncrypted(encryptionManager.encrypt(purchaseToken))
+                .googleOrderId(firstNonBlank(purchase.getOrderId(), null))
+                .purchasedAt(purchase.getPurchasedAt())
+                .verifiedAt(now)
+                .acknowledgedAt(purchase.isAcknowledged() ? now : null)
+                .rawVerifiedPayload(purchase.getRawPayload())
+                .build();
+        Payment saved = paymentRepository.save(payment);
+        Entitlement entitlement = upsertEntitlement(user, product, saved, now);
+
+        return PaymentGrantResult.builder()
+                .payment(saved)
+                .entitlement(entitlement)
+                .alreadyProcessed(false)
+                .build();
+    }
+
+    private PaymentGrantResult createApplePayment(Long userId, VerifiedPurchase purchase) {
+        User user = findUser(userId);
+        PaymentProduct product = findProduct(PaymentPlatform.APPLE, purchase.getStoreProductId());
+        LocalDateTime now = LocalDateTime.now();
+
+        Payment payment = Payment.builder()
+                .user(user)
+                .platform(PaymentPlatform.APPLE)
+                .product(product)
+                .storeProductId(product.getStoreProductId())
+                .productType(product.getProductType())
+                .status(PaymentStatus.PURCHASED)
+                .amountMicros(purchase.getAmountMicros())
+                .currency(purchase.getCurrency())
+                .appleTransactionId(purchase.getAppleTransactionId())
+                .appleOriginalTransactionId(purchase.getAppleOriginalTransactionId())
+                .appleEnvironment(purchase.getAppleEnvironment())
+                .purchasedAt(purchase.getPurchasedAt())
+                .verifiedAt(now)
+                .rawVerifiedPayload(purchase.getRawPayload())
+                .build();
+        Payment saved = paymentRepository.save(payment);
+        Entitlement entitlement = upsertEntitlement(user, product, saved, now);
+
+        return PaymentGrantResult.builder()
+                .payment(saved)
+                .entitlement(entitlement)
+                .alreadyProcessed(false)
+                .build();
+    }
+
+    private PaymentGrantResult existingGrantResult(Long userId, Payment existing) {
+        if (!existing.getUser().getId().equals(userId)) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_ALREADY_OWNED_BY_OTHER_USER);
+        }
+
+        Entitlement entitlement = null;
+        EntitlementType entitlementType = existing.getProduct().getEntitlementType();
+        if (entitlementType != null) {
+            entitlement = entitlementRepository
+                    .findByUserIdAndEntitlementTypeForUpdate(userId, entitlementType)
+                    .orElse(null);
+        }
+
+        return PaymentGrantResult.builder()
+                .payment(existing)
+                .entitlement(entitlement)
+                .alreadyProcessed(true)
+                .build();
+    }
+
+    private Entitlement upsertEntitlement(User user, PaymentProduct product, Payment payment, LocalDateTime now) {
+        EntitlementType entitlementType = product.getEntitlementType();
+        if (entitlementType == null) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_GRANT_FAILED);
+        }
+
+        Entitlement entitlement = entitlementRepository
+                .findByUserIdAndEntitlementTypeForUpdate(user.getId(), entitlementType)
+                .orElseGet(() -> Entitlement.builder()
+                        .user(user)
+                        .entitlementType(entitlementType)
+                        .build());
+
+        entitlement.setActive(true);
+        entitlement.setSourceType(EntitlementSourceType.PAYMENT);
+        entitlement.setSourcePlatform(payment.getPlatform());
+        entitlement.setSourcePayment(payment);
+        entitlement.setGrantedAt(now);
+        entitlement.setRevokedAt(null);
+        entitlement.setRevocationReason(null);
+
+        return entitlementRepository.save(entitlement);
+    }
+
+    private PaymentProduct findProduct(PaymentPlatform platform, String storeProductId) {
+        return paymentProductRepository
+                .findByPlatformAndStoreProductIdAndActiveTrue(platform, storeProductId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.PAYMENT_PRODUCT_NOT_FOUND));
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    private String firstNonBlank(String value, String fallback) {
+        return isBlank(value) ? fallback : value;
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null || value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/src/main/java/com/melissa/diary/service/payment/PaymentVerificationService.java
+++ b/src/main/java/com/melissa/diary/service/payment/PaymentVerificationService.java
@@ -1,0 +1,273 @@
+package com.melissa.diary.service.payment;
+
+import com.melissa.diary.apiPayload.code.ErrorReasonDTO;
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.GeneralException;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.config.PaymentProperties;
+import com.melissa.diary.domain.Entitlement;
+import com.melissa.diary.domain.Payment;
+import com.melissa.diary.domain.enums.EntitlementType;
+import com.melissa.diary.repository.EntitlementRepository;
+import com.melissa.diary.service.payment.store.ApplePurchaseVerifyCommand;
+import com.melissa.diary.service.payment.store.AppleStorePurchaseVerifier;
+import com.melissa.diary.service.payment.store.GoogleAcknowledgeCommand;
+import com.melissa.diary.service.payment.store.GooglePlayPurchaseVerifier;
+import com.melissa.diary.service.payment.store.GooglePurchaseVerifyCommand;
+import com.melissa.diary.service.payment.store.VerifiedPurchase;
+import com.melissa.diary.web.dto.EntitlementResponseDTO;
+import com.melissa.diary.web.dto.PaymentRequestDTO;
+import com.melissa.diary.web.dto.PaymentResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentVerificationService {
+
+    private final PaymentProperties paymentProperties;
+    private final GooglePlayPurchaseVerifier googlePlayPurchaseVerifier;
+    private final AppleStorePurchaseVerifier appleStorePurchaseVerifier;
+    private final PaymentGrantService paymentGrantService;
+    private final EntitlementRepository entitlementRepository;
+
+    public PaymentResponseDTO.VerifyResponse verifyGoogle(
+            Long userId,
+            PaymentRequestDTO.GoogleVerifyRequest request
+    ) {
+        assertIapEnabled();
+        assertGoogleEnabled();
+        assertEquals(paymentProperties.getGoogle().getPackageName(), request.getPackageName(),
+                ErrorStatus.PAYMENT_PURCHASE_OWNER_MISMATCH);
+        assertEquals(paymentProperties.getGoogle().getProductRemoveAds(), request.getProductId(),
+                ErrorStatus.PAYMENT_PRODUCT_MISMATCH);
+
+        VerifiedPurchase verified = googlePlayPurchaseVerifier.verify(new GooglePurchaseVerifyCommand(
+                request.getPackageName(),
+                request.getProductId(),
+                request.getPurchaseToken(),
+                request.getOrderId()
+        ));
+
+        PaymentGrantResult grantResult = paymentGrantService.grantGooglePurchase(
+                userId,
+                verified,
+                request.getPurchaseToken()
+        );
+
+        boolean acknowledged = isAcknowledged(grantResult.getPayment());
+        if (!acknowledged) {
+            acknowledged = acknowledgeGooglePurchase(request, verified, grantResult);
+        }
+
+        return toVerifyResponse(grantResult, acknowledged, null);
+    }
+
+    public PaymentResponseDTO.VerifyResponse verifyApple(
+            Long userId,
+            PaymentRequestDTO.AppleVerifyRequest request
+    ) {
+        assertIapEnabled();
+        assertAppleEnabled();
+        assertEquals(paymentProperties.getApple().getBundleId(), request.getBundleId(),
+                ErrorStatus.PAYMENT_PURCHASE_OWNER_MISMATCH);
+        assertEquals(paymentProperties.getApple().getProductRemoveAds(), request.getProductId(),
+                ErrorStatus.PAYMENT_PRODUCT_MISMATCH);
+        assertEquals(normalizeEnvironment(paymentProperties.getApple().getEnvironment()), normalizeEnvironment(request.getEnvironment()),
+                ErrorStatus.PAYMENT_PURCHASE_OWNER_MISMATCH);
+
+        VerifiedPurchase verified = appleStorePurchaseVerifier.verify(new ApplePurchaseVerifyCommand(
+                request.getProductId(),
+                request.getTransactionId(),
+                request.getOriginalTransactionId(),
+                request.getEnvironment(),
+                request.getBundleId()
+        ));
+
+        PaymentGrantResult grantResult = paymentGrantService.grantApplePurchase(userId, verified);
+        return toVerifyResponse(grantResult, null, true);
+    }
+
+    public PaymentResponseDTO.RestoreResponse restoreGoogle(
+            Long userId,
+            PaymentRequestDTO.GoogleRestoreRequest request
+    ) {
+        List<PaymentResponseDTO.RestoredPurchase> restored = new ArrayList<>();
+        List<PaymentResponseDTO.FailedPurchase> failed = new ArrayList<>();
+
+        for (PaymentRequestDTO.GoogleVerifyRequest purchase : request.getPurchases()) {
+            try {
+                PaymentResponseDTO.VerifyResponse response = verifyGoogle(userId, purchase);
+                restored.add(toRestoredPurchase(response));
+            } catch (RuntimeException e) {
+                failed.add(toFailedPurchase("GOOGLE", purchase.getProductId(), safeIdentifier(purchase.getOrderId()), e));
+            }
+        }
+
+        return PaymentResponseDTO.RestoreResponse.builder()
+                .restored(restored)
+                .failed(failed)
+                .features(featureSummary(userId))
+                .build();
+    }
+
+    public PaymentResponseDTO.RestoreResponse restoreApple(
+            Long userId,
+            PaymentRequestDTO.AppleRestoreRequest request
+    ) {
+        List<PaymentResponseDTO.RestoredPurchase> restored = new ArrayList<>();
+        List<PaymentResponseDTO.FailedPurchase> failed = new ArrayList<>();
+
+        for (PaymentRequestDTO.AppleVerifyRequest transaction : request.getTransactions()) {
+            try {
+                PaymentResponseDTO.VerifyResponse response = verifyApple(userId, transaction);
+                restored.add(toRestoredPurchase(response));
+            } catch (RuntimeException e) {
+                failed.add(toFailedPurchase("APPLE", transaction.getProductId(), transaction.getTransactionId(), e));
+            }
+        }
+
+        return PaymentResponseDTO.RestoreResponse.builder()
+                .restored(restored)
+                .failed(failed)
+                .features(featureSummary(userId))
+                .build();
+    }
+
+    private boolean acknowledgeGooglePurchase(
+            PaymentRequestDTO.GoogleVerifyRequest request,
+            VerifiedPurchase verified,
+            PaymentGrantResult grantResult
+    ) {
+        Long paymentId = grantResult.getPayment().getId();
+        if (verified.isAcknowledged()) {
+            paymentGrantService.markGoogleAcknowledged(paymentId);
+            return true;
+        }
+
+        try {
+            googlePlayPurchaseVerifier.acknowledge(new GoogleAcknowledgeCommand(
+                    request.getPackageName(),
+                    request.getProductId(),
+                    request.getPurchaseToken()
+            ));
+            paymentGrantService.markGoogleAcknowledged(paymentId);
+            return true;
+        } catch (RuntimeException e) {
+            log.warn("[PaymentVerificationService] Google acknowledge will be retried. paymentId={}", paymentId, e);
+            paymentGrantService.markGoogleAcknowledgeFailed(paymentId, e);
+            return false;
+        }
+    }
+
+    private PaymentResponseDTO.VerifyResponse toVerifyResponse(
+            PaymentGrantResult grantResult,
+            Boolean acknowledged,
+            Boolean finishRequired
+    ) {
+        Payment payment = grantResult.getPayment();
+        Entitlement entitlement = grantResult.getEntitlement();
+
+        return PaymentResponseDTO.VerifyResponse.builder()
+                .paymentId(payment.getId())
+                .platform(payment.getPlatform().name())
+                .productId(payment.getProduct().getProductId())
+                .status(payment.getStatus().name())
+                .entitlement(PaymentResponseDTO.EntitlementSummary.builder()
+                        .type(entitlement == null ? null : entitlement.getEntitlementType().name())
+                        .active(entitlement != null && Boolean.TRUE.equals(entitlement.getActive()))
+                        .build())
+                .acknowledged(acknowledged)
+                .finishRequired(finishRequired)
+                .alreadyProcessed(grantResult.isAlreadyProcessed())
+                .purchasedAt(payment.getPurchasedAt())
+                .verifiedAt(payment.getVerifiedAt())
+                .build();
+    }
+
+    private PaymentResponseDTO.RestoredPurchase toRestoredPurchase(PaymentResponseDTO.VerifyResponse response) {
+        return PaymentResponseDTO.RestoredPurchase.builder()
+                .paymentId(response.getPaymentId())
+                .platform(response.getPlatform())
+                .productId(response.getProductId())
+                .status(response.getStatus())
+                .entitlementType(response.getEntitlement() == null ? null : response.getEntitlement().getType())
+                .build();
+    }
+
+    private PaymentResponseDTO.FailedPurchase toFailedPurchase(
+            String platform,
+            String productId,
+            String identifier,
+            RuntimeException exception
+    ) {
+        ErrorReasonDTO reason = exception instanceof GeneralException generalException
+                ? generalException.getErrorReasonHttpStatus()
+                : ErrorStatus._INTERNAL_SERVER_ERROR.getReasonHttpStatus();
+
+        return PaymentResponseDTO.FailedPurchase.builder()
+                .platform(platform)
+                .productId(productId)
+                .identifier(identifier)
+                .code(reason.getCode())
+                .message(reason.getMessage())
+                .build();
+    }
+
+    private EntitlementResponseDTO.FeatureSummary featureSummary(Long userId) {
+        boolean adRemoved = entitlementRepository.findByUserIdAndActiveTrue(userId).stream()
+                .anyMatch(entitlement -> entitlement.getEntitlementType() == EntitlementType.REMOVE_ADS);
+        return EntitlementResponseDTO.FeatureSummary.builder()
+                .adRemoved(adRemoved)
+                .build();
+    }
+
+    private void assertIapEnabled() {
+        if (!paymentProperties.getIap().isEnabled()) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_DISABLED);
+        }
+    }
+
+    private void assertGoogleEnabled() {
+        if (!paymentProperties.getGoogle().isEnabled()) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_DISABLED);
+        }
+    }
+
+    private void assertAppleEnabled() {
+        if (!paymentProperties.getApple().isEnabled()) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_DISABLED);
+        }
+    }
+
+    private void assertEquals(String expected, String actual, ErrorStatus errorStatus) {
+        if (!normalize(expected).equals(normalize(actual))) {
+            throw new ErrorHandler(errorStatus);
+        }
+    }
+
+    private boolean isAcknowledged(Payment payment) {
+        return payment.getAcknowledgedAt() != null;
+    }
+
+    private String safeIdentifier(String orderId) {
+        return isBlank(orderId) ? "purchaseToken" : orderId;
+    }
+
+    private String normalizeEnvironment(String value) {
+        return normalize(value).replace("-", "_");
+    }
+
+    private String normalize(String value) {
+        return value == null ? "" : value.trim().toUpperCase();
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/src/main/java/com/melissa/diary/service/payment/store/AppleAppStoreServerPurchaseVerifier.java
+++ b/src/main/java/com/melissa/diary/service/payment/store/AppleAppStoreServerPurchaseVerifier.java
@@ -1,0 +1,328 @@
+package com.melissa.diary.service.payment.store;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.config.PaymentProperties;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import com.melissa.diary.domain.enums.ProductType;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.MessageDigest;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Date;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Set;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppleAppStoreServerPurchaseVerifier implements AppleStorePurchaseVerifier {
+
+    private static final String APP_STORE_AUDIENCE = "appstoreconnect-v1";
+    private static final String SANDBOX_BASE_URL = "https://api.storekit-sandbox.itunes.apple.com";
+    private static final String PRODUCTION_BASE_URL = "https://api.storekit.itunes.apple.com";
+    private static final Set<String> TRUSTED_APPLE_ROOT_SHA256_FINGERPRINTS = Set.of(
+            "63343ABFB89A6A03EBB57E9B3F5FA7BE7C4F5C756F3017B3A8C488C3653E9179",
+            "C2B9B042DD57830E7D117DAC55AC8AE19407D38E41D88F3215BC3A890444A050",
+            "B0B1730ECBC7FF4505142C49F1295E6EDA6BCAED7E2C68C5BE91B5A11001F024"
+    );
+
+    private final PaymentProperties paymentProperties;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public VerifiedPurchase verify(ApplePurchaseVerifyCommand command) {
+        try {
+            TransactionPayload payload = loadTransactionPayload(command);
+            JsonNode transaction = payload.transaction();
+            assertTransactionMatches(command, transaction);
+
+            ObjectNode rawPayload = objectMapper.createObjectNode();
+            rawPayload.put("source", payload.source());
+            if (payload.serverResponse() != null) {
+                rawPayload.set("serverResponse", payload.serverResponse());
+            }
+            rawPayload.set("transaction", transaction);
+
+            return VerifiedPurchase.builder()
+                    .platform(PaymentPlatform.APPLE)
+                    .storeProductId(transaction.path("productId").asText())
+                    .productType(ProductType.NON_CONSUMABLE)
+                    .appleTransactionId(transaction.path("transactionId").asText())
+                    .appleOriginalTransactionId(firstText(transaction, "originalTransactionId", command.originalTransactionId()))
+                    .appleEnvironment(normalizeEnvironment(transaction.path("environment").asText()))
+                    .purchasedAt(readMillisTime(transaction, "purchaseDate"))
+                    .revokedAt(readMillisTime(transaction, "revocationDate"))
+                    .amountMicros(readApplePriceAsMicros(transaction))
+                    .currency(transaction.path("currency").asText(null))
+                    .revoked(hasField(transaction, "revocationDate"))
+                    .rawPayload(objectMapper.writeValueAsString(rawPayload))
+                    .build();
+        } catch (ErrorHandler e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("[AppleAppStoreServerPurchaseVerifier] verify failed. transactionId={}, productId={}",
+                    command.transactionId(), command.productId(), e);
+            throw new ErrorHandler(ErrorStatus.PAYMENT_STORE_API_FAILED);
+        }
+    }
+
+    private TransactionPayload loadTransactionPayload(ApplePurchaseVerifyCommand command) throws Exception {
+        HttpResponse<String> response = sendGetTransactionInfoRequest(command.transactionId());
+        if (!isSuccess(response.statusCode())) {
+            log.warn("[AppleAppStoreServerPurchaseVerifier] getTransactionInfo failed. statusCode={}, transactionId={}",
+                    response.statusCode(), command.transactionId());
+            throw statusError(response.statusCode());
+        }
+
+        JsonNode root = objectMapper.readTree(response.body());
+        String signedTransactionInfo = root.path("signedTransactionInfo").asText(null);
+        if (isBlank(signedTransactionInfo)) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_STORE_VERIFICATION_FAILED);
+        }
+
+        return new TransactionPayload(
+                "APP_STORE_SERVER_API",
+                verifyAndDecodeSignedTransaction(signedTransactionInfo),
+                root
+        );
+    }
+
+    private HttpResponse<String> sendGetTransactionInfoRequest(String transactionId) throws Exception {
+        String url = baseUrl()
+                + "/inApps/v1/transactions/"
+                + URLEncoder.encode(transactionId, StandardCharsets.UTF_8).replace("+", "%20");
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofMillis(paymentProperties.getIap().getVerifyTimeoutMs()))
+                .header("Authorization", "Bearer " + authorizationToken())
+                .GET()
+                .build();
+
+        return httpClient().send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private String authorizationToken() throws Exception {
+        PaymentProperties.Apple apple = paymentProperties.getApple();
+        if (isBlank(apple.getIssuerId()) || isBlank(apple.getKeyId()) || isBlank(apple.getPrivateKeyP8Base64())) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_STORE_API_FAILED);
+        }
+
+        Instant now = Instant.now();
+        JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+                .issuer(apple.getIssuerId())
+                .audience(APP_STORE_AUDIENCE)
+                .issueTime(Date.from(now))
+                .expirationTime(Date.from(now.plusSeconds(20 * 60)))
+                .claim("bid", apple.getBundleId())
+                .build();
+
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256)
+                .keyID(apple.getKeyId())
+                .type(JOSEObjectType.JWT)
+                .build();
+        SignedJWT jwt = new SignedJWT(header, claimsSet);
+        jwt.sign(new ECDSASigner(privateKey()));
+        return jwt.serialize();
+    }
+
+    private ECPrivateKey privateKey() throws Exception {
+        String pem = new String(
+                Base64.getDecoder().decode(paymentProperties.getApple().getPrivateKeyP8Base64()),
+                StandardCharsets.UTF_8
+        );
+        String encoded = pem
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+        byte[] keyBytes = Base64.getDecoder().decode(encoded);
+        return (ECPrivateKey) KeyFactory.getInstance("EC")
+                .generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
+    }
+
+    private JsonNode verifyAndDecodeSignedTransaction(String signedPayload) throws Exception {
+        JWSObject jwsObject = JWSObject.parse(signedPayload);
+        verifySignedTransaction(jwsObject);
+        return objectMapper.readTree(jwsObject.getPayload().toString());
+    }
+
+    private void verifySignedTransaction(JWSObject jwsObject) throws Exception {
+        if (!JWSAlgorithm.ES256.equals(jwsObject.getHeader().getAlgorithm())) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_STORE_VERIFICATION_FAILED);
+        }
+
+        List<X509Certificate> certificates = readX5cCertificates(jwsObject.getHeader());
+        if (certificates.size() < 2) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_STORE_VERIFICATION_FAILED);
+        }
+
+        verifyCertificateChain(certificates);
+        X509Certificate signingCertificate = certificates.get(0);
+        boolean verified = jwsObject.verify(new ECDSAVerifier((ECPublicKey) signingCertificate.getPublicKey()));
+        if (!verified) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_STORE_VERIFICATION_FAILED);
+        }
+    }
+
+    private List<X509Certificate> readX5cCertificates(JWSHeader header) throws Exception {
+        List<com.nimbusds.jose.util.Base64> encodedCertificates = header.getX509CertChain();
+        if (encodedCertificates == null || encodedCertificates.isEmpty()) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_STORE_VERIFICATION_FAILED);
+        }
+
+        CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+        List<X509Certificate> certificates = new ArrayList<>();
+        for (com.nimbusds.jose.util.Base64 encodedCertificate : encodedCertificates) {
+            byte[] certificateBytes = encodedCertificate.decode();
+            certificates.add((X509Certificate) certificateFactory.generateCertificate(
+                    new ByteArrayInputStream(certificateBytes)
+            ));
+        }
+        return certificates;
+    }
+
+    private void verifyCertificateChain(List<X509Certificate> certificates) throws Exception {
+        for (int i = 0; i < certificates.size(); i++) {
+            certificates.get(i).checkValidity();
+        }
+
+        for (int i = 0; i < certificates.size() - 1; i++) {
+            X509Certificate current = certificates.get(i);
+            X509Certificate issuer = certificates.get(i + 1);
+            if (!current.getIssuerX500Principal().equals(issuer.getSubjectX500Principal())) {
+                throw new ErrorHandler(ErrorStatus.PAYMENT_STORE_VERIFICATION_FAILED);
+            }
+            current.verify(issuer.getPublicKey());
+        }
+
+        X509Certificate root = certificates.get(certificates.size() - 1);
+        root.verify(root.getPublicKey());
+        String rootFingerprint = sha256Hex(root.getEncoded());
+        if (!TRUSTED_APPLE_ROOT_SHA256_FINGERPRINTS.contains(rootFingerprint)) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_STORE_VERIFICATION_FAILED);
+        }
+    }
+
+    private String sha256Hex(byte[] value) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        return HexFormat.of().formatHex(digest.digest(value)).toUpperCase();
+    }
+
+    private void assertTransactionMatches(ApplePurchaseVerifyCommand command, JsonNode transaction) {
+        if (!command.transactionId().equals(transaction.path("transactionId").asText())) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_STORE_VERIFICATION_FAILED);
+        }
+        if (!command.productId().equals(transaction.path("productId").asText())) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_PRODUCT_MISMATCH);
+        }
+        if (!command.bundleId().equals(transaction.path("bundleId").asText())) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_PURCHASE_OWNER_MISMATCH);
+        }
+        if (!normalizeEnvironment(command.environment()).equals(normalizeEnvironment(transaction.path("environment").asText()))) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_PURCHASE_OWNER_MISMATCH);
+        }
+        if (hasField(transaction, "revocationDate")) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_PURCHASE_REVOKED);
+        }
+    }
+
+    private LocalDateTime readMillisTime(JsonNode node, String fieldName) {
+        JsonNode value = node.get(fieldName);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        long millis = value.isNumber() ? value.asLong() : Long.parseLong(value.asText());
+        return LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC);
+    }
+
+    private Long readApplePriceAsMicros(JsonNode transaction) {
+        JsonNode price = transaction.get("price");
+        if (price == null || price.isNull()) {
+            return null;
+        }
+        return price.asLong() * 1000;
+    }
+
+    private boolean hasField(JsonNode node, String fieldName) {
+        JsonNode field = node.get(fieldName);
+        return field != null && !field.isNull();
+    }
+
+    private String firstText(JsonNode root, String fieldName, String fallback) {
+        String value = root.path(fieldName).asText(null);
+        return isBlank(value) ? fallback : value;
+    }
+
+    private String normalizeEnvironment(String value) {
+        if (isBlank(value)) {
+            return "";
+        }
+        return value.trim().replace("-", "_").toUpperCase();
+    }
+
+    private RuntimeException statusError(int statusCode) {
+        if (statusCode >= 500 || statusCode == 401 || statusCode == 403) {
+            return new ErrorHandler(ErrorStatus.PAYMENT_STORE_API_FAILED);
+        }
+        return new ErrorHandler(ErrorStatus.PAYMENT_STORE_VERIFICATION_FAILED);
+    }
+
+    private String baseUrl() {
+        String environment = normalizeEnvironment(paymentProperties.getApple().getEnvironment());
+        return "PRODUCTION".equals(environment) ? PRODUCTION_BASE_URL : SANDBOX_BASE_URL;
+    }
+
+    private HttpClient httpClient() {
+        return HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(paymentProperties.getIap().getVerifyTimeoutMs()))
+                .build();
+    }
+
+    private boolean isSuccess(int statusCode) {
+        return statusCode >= 200 && statusCode < 300;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    private record TransactionPayload(
+            String source,
+            JsonNode transaction,
+            JsonNode serverResponse
+    ) {
+    }
+}

--- a/src/main/java/com/melissa/diary/service/payment/store/ApplePurchaseVerifyCommand.java
+++ b/src/main/java/com/melissa/diary/service/payment/store/ApplePurchaseVerifyCommand.java
@@ -1,0 +1,10 @@
+package com.melissa.diary.service.payment.store;
+
+public record ApplePurchaseVerifyCommand(
+        String productId,
+        String transactionId,
+        String originalTransactionId,
+        String environment,
+        String bundleId
+) {
+}

--- a/src/main/java/com/melissa/diary/service/payment/store/AppleStorePurchaseVerifier.java
+++ b/src/main/java/com/melissa/diary/service/payment/store/AppleStorePurchaseVerifier.java
@@ -1,0 +1,6 @@
+package com.melissa.diary.service.payment.store;
+
+public interface AppleStorePurchaseVerifier {
+
+    VerifiedPurchase verify(ApplePurchaseVerifyCommand command);
+}

--- a/src/main/java/com/melissa/diary/service/payment/store/GoogleAcknowledgeCommand.java
+++ b/src/main/java/com/melissa/diary/service/payment/store/GoogleAcknowledgeCommand.java
@@ -1,0 +1,8 @@
+package com.melissa.diary.service.payment.store;
+
+public record GoogleAcknowledgeCommand(
+        String packageName,
+        String productId,
+        String purchaseToken
+) {
+}

--- a/src/main/java/com/melissa/diary/service/payment/store/GooglePlayPurchaseVerifier.java
+++ b/src/main/java/com/melissa/diary/service/payment/store/GooglePlayPurchaseVerifier.java
@@ -1,0 +1,8 @@
+package com.melissa.diary.service.payment.store;
+
+public interface GooglePlayPurchaseVerifier {
+
+    VerifiedPurchase verify(GooglePurchaseVerifyCommand command);
+
+    void acknowledge(GoogleAcknowledgeCommand command);
+}

--- a/src/main/java/com/melissa/diary/service/payment/store/GooglePlayRestPurchaseVerifier.java
+++ b/src/main/java/com/melissa/diary/service/payment/store/GooglePlayRestPurchaseVerifier.java
@@ -1,0 +1,207 @@
+package com.melissa.diary.service.payment.store;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.config.PaymentProperties;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import com.melissa.diary.domain.enums.ProductType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GooglePlayRestPurchaseVerifier implements GooglePlayPurchaseVerifier {
+
+    private static final String ANDROID_PUBLISHER_SCOPE = "https://www.googleapis.com/auth/androidpublisher";
+    private static final String GOOGLE_ANDROID_PUBLISHER_BASE_URL = "https://androidpublisher.googleapis.com";
+
+    private final PaymentProperties paymentProperties;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public VerifiedPurchase verify(GooglePurchaseVerifyCommand command) {
+        try {
+            HttpResponse<String> response = sendGetPurchaseRequest(command);
+            if (!isSuccess(response.statusCode())) {
+                log.warn("[GooglePlayRestPurchaseVerifier] getProductPurchase failed. statusCode={}, packageName={}, productId={}",
+                        response.statusCode(), command.packageName(), command.productId());
+                throw statusError(response.statusCode());
+            }
+
+            JsonNode root = objectMapper.readTree(response.body());
+            assertPurchased(root);
+
+            String responseProductId = readProductId(root);
+            if (responseProductId != null && !command.productId().equals(responseProductId)) {
+                throw new ErrorHandler(ErrorStatus.PAYMENT_PRODUCT_MISMATCH);
+            }
+
+            return VerifiedPurchase.builder()
+                    .platform(PaymentPlatform.GOOGLE)
+                    .storeProductId(command.productId())
+                    .productType(ProductType.NON_CONSUMABLE)
+                    .orderId(firstText(root, "orderId", command.orderId()))
+                    .purchasedAt(readPurchaseTime(root))
+                    .acknowledged(isAcknowledged(root))
+                    .rawPayload(objectMapper.writeValueAsString(root))
+                    .build();
+        } catch (ErrorHandler e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("[GooglePlayRestPurchaseVerifier] verify failed. packageName={}, productId={}",
+                    command.packageName(), command.productId(), e);
+            throw new ErrorHandler(ErrorStatus.PAYMENT_STORE_API_FAILED);
+        }
+    }
+
+    @Override
+    public void acknowledge(GoogleAcknowledgeCommand command) {
+        try {
+            HttpResponse<String> response = sendAcknowledgeRequest(command);
+            if (!isSuccess(response.statusCode())) {
+                log.warn("[GooglePlayRestPurchaseVerifier] acknowledge failed. statusCode={}, packageName={}, productId={}",
+                        response.statusCode(), command.packageName(), command.productId());
+                throw statusError(response.statusCode());
+            }
+        } catch (ErrorHandler e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("[GooglePlayRestPurchaseVerifier] acknowledge failed. packageName={}, productId={}",
+                    command.packageName(), command.productId(), e);
+            throw new ErrorHandler(ErrorStatus.PAYMENT_ACKNOWLEDGE_FAILED);
+        }
+    }
+
+    private HttpResponse<String> sendGetPurchaseRequest(GooglePurchaseVerifyCommand command) throws Exception {
+        String url = GOOGLE_ANDROID_PUBLISHER_BASE_URL
+                + "/androidpublisher/v3/applications/" + encodePath(command.packageName())
+                + "/purchases/productsv2/tokens/" + encodePath(command.purchaseToken());
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofMillis(paymentProperties.getIap().getVerifyTimeoutMs()))
+                .header("Authorization", "Bearer " + accessToken())
+                .GET()
+                .build();
+
+        return httpClient().send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private HttpResponse<String> sendAcknowledgeRequest(GoogleAcknowledgeCommand command) throws Exception {
+        String url = GOOGLE_ANDROID_PUBLISHER_BASE_URL
+                + "/androidpublisher/v3/applications/" + encodePath(command.packageName())
+                + "/purchases/products/" + encodePath(command.productId())
+                + "/tokens/" + encodePath(command.purchaseToken())
+                + ":acknowledge";
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .timeout(Duration.ofMillis(paymentProperties.getIap().getVerifyTimeoutMs()))
+                .header("Authorization", "Bearer " + accessToken())
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString("{}"))
+                .build();
+
+        return httpClient().send(request, HttpResponse.BodyHandlers.ofString());
+    }
+
+    private String accessToken() throws Exception {
+        String encodedJson = paymentProperties.getGoogle().getServiceAccountJsonBase64();
+        if (isBlank(encodedJson)) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_STORE_API_FAILED);
+        }
+
+        byte[] json = Base64.getDecoder().decode(encodedJson);
+        GoogleCredentials credentials = GoogleCredentials
+                .fromStream(new ByteArrayInputStream(json))
+                .createScoped(List.of(ANDROID_PUBLISHER_SCOPE));
+        credentials.refreshIfExpired();
+        return credentials.getAccessToken().getTokenValue();
+    }
+
+    private void assertPurchased(JsonNode root) {
+        String purchaseState = root.path("purchaseStateContext").path("purchaseState").asText("");
+        if (!isBlank(purchaseState)
+                && !"PURCHASED".equalsIgnoreCase(purchaseState)
+                && !"PURCHASE_STATE_PURCHASED".equalsIgnoreCase(purchaseState)) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_PURCHASE_NOT_COMPLETED);
+        }
+    }
+
+    private String readProductId(JsonNode root) {
+        JsonNode lineItems = root.path("productLineItem");
+        if (lineItems.isArray() && !lineItems.isEmpty()) {
+            return lineItems.get(0).path("productId").asText(null);
+        }
+        return null;
+    }
+
+    private boolean isAcknowledged(JsonNode root) {
+        String acknowledgementState = root.path("acknowledgementState").asText("");
+        return "ACKNOWLEDGEMENT_STATE_ACKNOWLEDGED".equalsIgnoreCase(acknowledgementState)
+                || "ACKNOWLEDGED".equalsIgnoreCase(acknowledgementState);
+    }
+
+    private LocalDateTime readPurchaseTime(JsonNode root) {
+        String completionTime = root.path("purchaseCompletionTime").asText(null);
+        if (!isBlank(completionTime)) {
+            return LocalDateTime.ofInstant(Instant.parse(completionTime), ZoneOffset.UTC);
+        }
+
+        String purchaseTimeMillis = root.path("purchaseTimeMillis").asText(null);
+        if (!isBlank(purchaseTimeMillis)) {
+            return LocalDateTime.ofInstant(Instant.ofEpochMilli(Long.parseLong(purchaseTimeMillis)), ZoneOffset.UTC);
+        }
+
+        return null;
+    }
+
+    private String firstText(JsonNode root, String fieldName, String fallback) {
+        String value = root.path(fieldName).asText(null);
+        return isBlank(value) ? fallback : value;
+    }
+
+    private RuntimeException statusError(int statusCode) {
+        if (statusCode >= 500 || statusCode == 401 || statusCode == 403) {
+            return new ErrorHandler(ErrorStatus.PAYMENT_STORE_API_FAILED);
+        }
+        return new ErrorHandler(ErrorStatus.PAYMENT_STORE_VERIFICATION_FAILED);
+    }
+
+    private HttpClient httpClient() {
+        return HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(paymentProperties.getIap().getVerifyTimeoutMs()))
+                .build();
+    }
+
+    private boolean isSuccess(int statusCode) {
+        return statusCode >= 200 && statusCode < 300;
+    }
+
+    private String encodePath(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/src/main/java/com/melissa/diary/service/payment/store/GooglePurchaseVerifyCommand.java
+++ b/src/main/java/com/melissa/diary/service/payment/store/GooglePurchaseVerifyCommand.java
@@ -1,0 +1,9 @@
+package com.melissa.diary.service.payment.store;
+
+public record GooglePurchaseVerifyCommand(
+        String packageName,
+        String productId,
+        String purchaseToken,
+        String orderId
+) {
+}

--- a/src/main/java/com/melissa/diary/service/payment/store/VerifiedPurchase.java
+++ b/src/main/java/com/melissa/diary/service/payment/store/VerifiedPurchase.java
@@ -1,0 +1,27 @@
+package com.melissa.diary.service.payment.store;
+
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import com.melissa.diary.domain.enums.ProductType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class VerifiedPurchase {
+    private PaymentPlatform platform;
+    private String storeProductId;
+    private ProductType productType;
+    private String orderId;
+    private String appleTransactionId;
+    private String appleOriginalTransactionId;
+    private String appleEnvironment;
+    private LocalDateTime purchasedAt;
+    private LocalDateTime revokedAt;
+    private Long amountMicros;
+    private String currency;
+    private boolean acknowledged;
+    private boolean revoked;
+    private String rawPayload;
+}

--- a/src/main/java/com/melissa/diary/web/controller/PaymentController.java
+++ b/src/main/java/com/melissa/diary/web/controller/PaymentController.java
@@ -1,0 +1,65 @@
+package com.melissa.diary.web.controller;
+
+import com.melissa.diary.apiPayload.ApiResponse;
+import com.melissa.diary.service.payment.PaymentVerificationService;
+import com.melissa.diary.web.dto.PaymentRequestDTO;
+import com.melissa.diary.web.dto.PaymentResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@Tag(name = "PaymentAPI", description = "In-app purchase verification API")
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentVerificationService paymentVerificationService;
+
+    @Operation(summary = "Verify Google Play remove_ads purchase")
+    @PostMapping("/google/verify")
+    public ApiResponse<PaymentResponseDTO.VerifyResponse> verifyGoogle(
+            Principal principal,
+            @Valid @RequestBody PaymentRequestDTO.GoogleVerifyRequest request
+    ) {
+        Long userId = Long.parseLong(principal.getName());
+        return ApiResponse.onSuccess(paymentVerificationService.verifyGoogle(userId, request));
+    }
+
+    @Operation(summary = "Restore Google Play remove_ads purchases")
+    @PostMapping("/google/restore")
+    public ApiResponse<PaymentResponseDTO.RestoreResponse> restoreGoogle(
+            Principal principal,
+            @Valid @RequestBody PaymentRequestDTO.GoogleRestoreRequest request
+    ) {
+        Long userId = Long.parseLong(principal.getName());
+        return ApiResponse.onSuccess(paymentVerificationService.restoreGoogle(userId, request));
+    }
+
+    @Operation(summary = "Verify Apple App Store remove_ads transaction")
+    @PostMapping("/apple/verify")
+    public ApiResponse<PaymentResponseDTO.VerifyResponse> verifyApple(
+            Principal principal,
+            @Valid @RequestBody PaymentRequestDTO.AppleVerifyRequest request
+    ) {
+        Long userId = Long.parseLong(principal.getName());
+        return ApiResponse.onSuccess(paymentVerificationService.verifyApple(userId, request));
+    }
+
+    @Operation(summary = "Restore Apple App Store remove_ads transactions")
+    @PostMapping("/apple/restore")
+    public ApiResponse<PaymentResponseDTO.RestoreResponse> restoreApple(
+            Principal principal,
+            @Valid @RequestBody PaymentRequestDTO.AppleRestoreRequest request
+    ) {
+        Long userId = Long.parseLong(principal.getName());
+        return ApiResponse.onSuccess(paymentVerificationService.restoreApple(userId, request));
+    }
+}

--- a/src/main/java/com/melissa/diary/web/dto/PaymentRequestDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/PaymentRequestDTO.java
@@ -1,0 +1,91 @@
+package com.melissa.diary.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+public class PaymentRequestDTO {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "Google Play one-time product verify request")
+    public static class GoogleVerifyRequest {
+
+        @NotBlank
+        @Schema(description = "Google Play product id", example = "premium", requiredMode = Schema.RequiredMode.REQUIRED)
+        private String productId;
+
+        @NotBlank
+        @Schema(description = "Android package name", example = "com.melissa.melissaFE", requiredMode = Schema.RequiredMode.REQUIRED)
+        private String packageName;
+
+        @NotBlank
+        @Schema(description = "Google Play Billing purchase token", requiredMode = Schema.RequiredMode.REQUIRED)
+        private String purchaseToken;
+
+        @Schema(description = "Google order id", example = "GPA.1234-5678-9012-34567", nullable = true)
+        private String orderId;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "Google Play restore request")
+    public static class GoogleRestoreRequest {
+
+        @Valid
+        @NotEmpty
+        private List<GoogleVerifyRequest> purchases;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @Schema(description = "Apple App Store transaction verify request")
+    public static class AppleVerifyRequest {
+
+        @NotBlank
+        @Schema(description = "Apple product id", example = "com.melissa.melissaFE.premium", requiredMode = Schema.RequiredMode.REQUIRED)
+        private String productId;
+
+        @NotBlank
+        @Schema(description = "Apple transaction id", example = "2000000123456789", requiredMode = Schema.RequiredMode.REQUIRED)
+        private String transactionId;
+
+        @Schema(description = "Apple original transaction id", example = "2000000123456789", nullable = true)
+        private String originalTransactionId;
+
+        @NotBlank
+        @Schema(description = "Apple transaction environment", example = "SANDBOX", requiredMode = Schema.RequiredMode.REQUIRED)
+        private String environment;
+
+        @NotBlank
+        @Schema(description = "iOS bundle id", example = "com.melissa.melissaFE", requiredMode = Schema.RequiredMode.REQUIRED)
+        private String bundleId;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "Apple App Store restore request")
+    public static class AppleRestoreRequest {
+
+        @Valid
+        @NotEmpty
+        private List<AppleVerifyRequest> transactions;
+    }
+}

--- a/src/main/java/com/melissa/diary/web/dto/PaymentResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/PaymentResponseDTO.java
@@ -1,0 +1,78 @@
+package com.melissa.diary.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class PaymentResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "Store purchase verify response")
+    public static class VerifyResponse {
+        private Long paymentId;
+        private String platform;
+        private String productId;
+        private String status;
+        private EntitlementSummary entitlement;
+        private Boolean acknowledged;
+        private Boolean finishRequired;
+        private Boolean alreadyProcessed;
+        private LocalDateTime purchasedAt;
+        private LocalDateTime verifiedAt;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "Payment entitlement summary")
+    public static class EntitlementSummary {
+        private String type;
+        private Boolean active;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "Store restore response")
+    public static class RestoreResponse {
+        private List<RestoredPurchase> restored;
+        private List<FailedPurchase> failed;
+        private EntitlementResponseDTO.FeatureSummary features;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "Restored purchase summary")
+    public static class RestoredPurchase {
+        private Long paymentId;
+        private String platform;
+        private String productId;
+        private String status;
+        private String entitlementType;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "Failed restore item summary")
+    public static class FailedPurchase {
+        private String platform;
+        private String productId;
+        private String identifier;
+        private String code;
+        private String message;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -92,6 +92,8 @@ payment:
     product-remove-ads: ${PAYMENT_GOOGLE_PRODUCT_REMOVE_ADS:premium}
     service-account-json-base64: ${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64:}
     token-hash-salt: ${PAYMENT_TOKEN_HASH_SALT:}
+    acknowledge-retry-fixed-delay-ms: ${PAYMENT_GOOGLE_ACKNOWLEDGE_RETRY_FIXED_DELAY_MS:600000}
+    acknowledge-retry-batch-size: ${PAYMENT_GOOGLE_ACKNOWLEDGE_RETRY_BATCH_SIZE:20}
   apple:
     enabled: ${PAYMENT_APPLE_ENABLED:false}
     bundle-id: ${PAYMENT_APPLE_BUNDLE_ID:com.melissa.melissaFE}

--- a/src/test/java/com/melissa/diary/service/payment/PaymentGrantServiceTest.java
+++ b/src/test/java/com/melissa/diary/service/payment/PaymentGrantServiceTest.java
@@ -1,0 +1,155 @@
+package com.melissa.diary.service.payment;
+
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.config.PaymentProperties;
+import com.melissa.diary.domain.Entitlement;
+import com.melissa.diary.domain.Payment;
+import com.melissa.diary.domain.PaymentProduct;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.enums.EntitlementType;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import com.melissa.diary.domain.enums.ProductType;
+import com.melissa.diary.repository.EntitlementRepository;
+import com.melissa.diary.repository.PaymentProductRepository;
+import com.melissa.diary.repository.PaymentRepository;
+import com.melissa.diary.repository.UserRepository;
+import com.melissa.diary.security.EncryptionManager;
+import com.melissa.diary.service.payment.store.VerifiedPurchase;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentGrantServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PaymentProductRepository paymentProductRepository;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private EntitlementRepository entitlementRepository;
+
+    @Mock
+    private EncryptionManager encryptionManager;
+
+    private PaymentGrantService paymentGrantService;
+
+    @BeforeEach
+    void setUp() {
+        PaymentProperties paymentProperties = new PaymentProperties();
+        paymentProperties.getGoogle().setTokenHashSalt("test-salt");
+        paymentGrantService = new PaymentGrantService(
+                paymentProperties,
+                userRepository,
+                paymentProductRepository,
+                paymentRepository,
+                entitlementRepository,
+                encryptionManager
+        );
+    }
+
+    @Test
+    void grantGooglePurchaseCreatesPaymentAndEntitlement() {
+        Long userId = 1L;
+        User user = user(userId);
+        PaymentProduct product = removeAdsProduct(PaymentPlatform.GOOGLE, "premium");
+        VerifiedPurchase purchase = googlePurchase("premium");
+
+        when(paymentRepository.findByPlatformAndGooglePurchaseTokenHashForUpdate(PaymentPlatform.GOOGLE, paymentGrantService.hashGooglePurchaseToken("token-1")))
+                .thenReturn(Optional.empty());
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(paymentProductRepository.findByPlatformAndStoreProductIdAndActiveTrue(PaymentPlatform.GOOGLE, "premium"))
+                .thenReturn(Optional.of(product));
+        when(encryptionManager.encrypt("token-1")).thenReturn("encrypted-token");
+        when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> {
+            Payment payment = invocation.getArgument(0);
+            payment.setId(100L);
+            return payment;
+        });
+        when(entitlementRepository.findByUserIdAndEntitlementTypeForUpdate(userId, EntitlementType.REMOVE_ADS))
+                .thenReturn(Optional.empty());
+        when(entitlementRepository.save(any(Entitlement.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PaymentGrantResult result = paymentGrantService.grantGooglePurchase(userId, purchase, "token-1");
+
+        assertThat(result.isAlreadyProcessed()).isFalse();
+        assertThat(result.getPayment().getId()).isEqualTo(100L);
+        assertThat(result.getPayment().getGooglePurchaseTokenHash()).hasSize(64);
+        assertThat(result.getPayment().getGooglePurchaseTokenEncrypted()).isEqualTo("encrypted-token");
+        assertThat(result.getEntitlement().getActive()).isTrue();
+        assertThat(result.getEntitlement().getEntitlementType()).isEqualTo(EntitlementType.REMOVE_ADS);
+        verify(entitlementRepository).save(any(Entitlement.class));
+    }
+
+    @Test
+    void grantGooglePurchaseRejectsPurchaseAlreadyOwnedByAnotherUser() {
+        Long userId = 1L;
+        User otherUser = user(2L);
+        Payment existing = Payment.builder()
+                .user(otherUser)
+                .platform(PaymentPlatform.GOOGLE)
+                .product(removeAdsProduct(PaymentPlatform.GOOGLE, "premium"))
+                .storeProductId("premium")
+                .productType(ProductType.NON_CONSUMABLE)
+                .build();
+
+        when(paymentRepository.findByPlatformAndGooglePurchaseTokenHashForUpdate(PaymentPlatform.GOOGLE, paymentGrantService.hashGooglePurchaseToken("token-1")))
+                .thenReturn(Optional.of(existing));
+
+        ErrorHandler error = assertThrows(
+                ErrorHandler.class,
+                () -> paymentGrantService.grantGooglePurchase(userId, googlePurchase("premium"), "token-1")
+        );
+
+        assertThat(error.getErrorCode()).isEqualTo(ErrorStatus.PAYMENT_ALREADY_OWNED_BY_OTHER_USER);
+    }
+
+    private User user(Long id) {
+        return User.builder()
+                .id(id)
+                .provider("GOOGLE")
+                .nickname("user")
+                .build();
+    }
+
+    private PaymentProduct removeAdsProduct(PaymentPlatform platform, String storeProductId) {
+        return PaymentProduct.builder()
+                .id(10L)
+                .productId("remove_ads")
+                .platform(platform)
+                .storeProductId(storeProductId)
+                .productType(ProductType.NON_CONSUMABLE)
+                .entitlementType(EntitlementType.REMOVE_ADS)
+                .active(true)
+                .displayName("광고 제거")
+                .build();
+    }
+
+    private VerifiedPurchase googlePurchase(String productId) {
+        return VerifiedPurchase.builder()
+                .platform(PaymentPlatform.GOOGLE)
+                .storeProductId(productId)
+                .productType(ProductType.NON_CONSUMABLE)
+                .orderId("GPA.1")
+                .purchasedAt(LocalDateTime.of(2026, 6, 15, 10, 0))
+                .rawPayload("{}")
+                .build();
+    }
+}

--- a/src/test/java/com/melissa/diary/service/payment/PaymentVerificationServiceTest.java
+++ b/src/test/java/com/melissa/diary/service/payment/PaymentVerificationServiceTest.java
@@ -1,0 +1,235 @@
+package com.melissa.diary.service.payment;
+
+import com.melissa.diary.config.PaymentProperties;
+import com.melissa.diary.domain.Entitlement;
+import com.melissa.diary.domain.Payment;
+import com.melissa.diary.domain.PaymentProduct;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.enums.EntitlementSourceType;
+import com.melissa.diary.domain.enums.EntitlementType;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import com.melissa.diary.domain.enums.PaymentStatus;
+import com.melissa.diary.domain.enums.ProductType;
+import com.melissa.diary.repository.EntitlementRepository;
+import com.melissa.diary.service.payment.store.ApplePurchaseVerifyCommand;
+import com.melissa.diary.service.payment.store.AppleStorePurchaseVerifier;
+import com.melissa.diary.service.payment.store.GoogleAcknowledgeCommand;
+import com.melissa.diary.service.payment.store.GooglePlayPurchaseVerifier;
+import com.melissa.diary.service.payment.store.GooglePurchaseVerifyCommand;
+import com.melissa.diary.service.payment.store.VerifiedPurchase;
+import com.melissa.diary.web.dto.PaymentRequestDTO;
+import com.melissa.diary.web.dto.PaymentResponseDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentVerificationServiceTest {
+
+    @Mock
+    private GooglePlayPurchaseVerifier googlePlayPurchaseVerifier;
+
+    @Mock
+    private AppleStorePurchaseVerifier appleStorePurchaseVerifier;
+
+    @Mock
+    private PaymentGrantService paymentGrantService;
+
+    @Mock
+    private EntitlementRepository entitlementRepository;
+
+    private PaymentVerificationService paymentVerificationService;
+
+    @BeforeEach
+    void setUp() {
+        PaymentProperties paymentProperties = new PaymentProperties();
+        paymentProperties.getIap().setEnabled(true);
+        paymentProperties.getGoogle().setEnabled(true);
+        paymentProperties.getApple().setEnabled(true);
+        paymentProperties.getGoogle().setPackageName("com.melissa.melissaFE");
+        paymentProperties.getGoogle().setProductRemoveAds("premium");
+        paymentProperties.getApple().setBundleId("com.melissa.melissaFE");
+        paymentProperties.getApple().setProductRemoveAds("com.melissa.melissaFE.premium");
+        paymentProperties.getApple().setEnvironment("SANDBOX");
+
+        paymentVerificationService = new PaymentVerificationService(
+                paymentProperties,
+                googlePlayPurchaseVerifier,
+                appleStorePurchaseVerifier,
+                paymentGrantService,
+                entitlementRepository
+        );
+    }
+
+    @Test
+    void verifyGoogleGrantsEntitlementThenAcknowledgesPurchase() {
+        Long userId = 1L;
+        PaymentRequestDTO.GoogleVerifyRequest request = new PaymentRequestDTO.GoogleVerifyRequest(
+                "premium",
+                "com.melissa.melissaFE",
+                "token-1",
+                "GPA.1"
+        );
+        VerifiedPurchase verified = verifiedGoogle(false);
+        PaymentGrantResult grantResult = grantResult(PaymentPlatform.GOOGLE, false, null);
+
+        when(googlePlayPurchaseVerifier.verify(any(GooglePurchaseVerifyCommand.class))).thenReturn(verified);
+        when(paymentGrantService.grantGooglePurchase(userId, verified, "token-1")).thenReturn(grantResult);
+
+        PaymentResponseDTO.VerifyResponse response = paymentVerificationService.verifyGoogle(userId, request);
+
+        assertThat(response.getAcknowledged()).isTrue();
+        assertThat(response.getEntitlement().getActive()).isTrue();
+        assertThat(response.getAlreadyProcessed()).isFalse();
+        verify(googlePlayPurchaseVerifier).acknowledge(any(GoogleAcknowledgeCommand.class));
+        verify(paymentGrantService).markGoogleAcknowledged(100L);
+    }
+
+    @Test
+    void verifyGoogleKeepsGrantWhenAcknowledgeFails() {
+        Long userId = 1L;
+        PaymentRequestDTO.GoogleVerifyRequest request = new PaymentRequestDTO.GoogleVerifyRequest(
+                "premium",
+                "com.melissa.melissaFE",
+                "token-1",
+                "GPA.1"
+        );
+        VerifiedPurchase verified = verifiedGoogle(false);
+        PaymentGrantResult grantResult = grantResult(PaymentPlatform.GOOGLE, false, null);
+
+        when(googlePlayPurchaseVerifier.verify(any(GooglePurchaseVerifyCommand.class))).thenReturn(verified);
+        when(paymentGrantService.grantGooglePurchase(userId, verified, "token-1")).thenReturn(grantResult);
+        doThrow(new RuntimeException("ack failed"))
+                .when(googlePlayPurchaseVerifier).acknowledge(any(GoogleAcknowledgeCommand.class));
+
+        PaymentResponseDTO.VerifyResponse response = paymentVerificationService.verifyGoogle(userId, request);
+
+        assertThat(response.getAcknowledged()).isFalse();
+        assertThat(response.getEntitlement().getActive()).isTrue();
+        verify(paymentGrantService).markGoogleAcknowledgeFailed(any(), any(RuntimeException.class));
+    }
+
+    @Test
+    void verifyAppleReturnsFinishRequiredAfterServerVerification() {
+        Long userId = 1L;
+        PaymentRequestDTO.AppleVerifyRequest request = new PaymentRequestDTO.AppleVerifyRequest(
+                "com.melissa.melissaFE.premium",
+                "2000000123456789",
+                "2000000123456789",
+                "SANDBOX",
+                "com.melissa.melissaFE"
+        );
+        VerifiedPurchase verified = verifiedApple();
+        PaymentGrantResult grantResult = grantResult(PaymentPlatform.APPLE, true, null);
+
+        when(appleStorePurchaseVerifier.verify(any(ApplePurchaseVerifyCommand.class))).thenReturn(verified);
+        when(paymentGrantService.grantApplePurchase(userId, verified)).thenReturn(grantResult);
+
+        PaymentResponseDTO.VerifyResponse response = paymentVerificationService.verifyApple(userId, request);
+
+        assertThat(response.getFinishRequired()).isTrue();
+        assertThat(response.getAlreadyProcessed()).isTrue();
+        assertThat(response.getPlatform()).isEqualTo("APPLE");
+    }
+
+    @Test
+    void restoreGoogleReturnsFeatureSummaryAfterRestoredPurchase() {
+        Long userId = 1L;
+        PaymentRequestDTO.GoogleRestoreRequest request = new PaymentRequestDTO.GoogleRestoreRequest(List.of(
+                new PaymentRequestDTO.GoogleVerifyRequest("premium", "com.melissa.melissaFE", "token-1", "GPA.1")
+        ));
+        VerifiedPurchase verified = verifiedGoogle(true);
+        PaymentGrantResult grantResult = grantResult(PaymentPlatform.GOOGLE, true, LocalDateTime.now());
+
+        when(googlePlayPurchaseVerifier.verify(any(GooglePurchaseVerifyCommand.class))).thenReturn(verified);
+        when(paymentGrantService.grantGooglePurchase(userId, verified, "token-1")).thenReturn(grantResult);
+        when(entitlementRepository.findByUserIdAndActiveTrue(userId)).thenReturn(List.of(grantResult.getEntitlement()));
+
+        PaymentResponseDTO.RestoreResponse response = paymentVerificationService.restoreGoogle(userId, request);
+
+        assertThat(response.getRestored()).hasSize(1);
+        assertThat(response.getFailed()).isEmpty();
+        assertThat(response.getFeatures().getAdRemoved()).isTrue();
+    }
+
+    private VerifiedPurchase verifiedGoogle(boolean acknowledged) {
+        return VerifiedPurchase.builder()
+                .platform(PaymentPlatform.GOOGLE)
+                .storeProductId("premium")
+                .productType(ProductType.NON_CONSUMABLE)
+                .orderId("GPA.1")
+                .purchasedAt(LocalDateTime.of(2026, 6, 15, 10, 0))
+                .acknowledged(acknowledged)
+                .rawPayload("{}")
+                .build();
+    }
+
+    private VerifiedPurchase verifiedApple() {
+        return VerifiedPurchase.builder()
+                .platform(PaymentPlatform.APPLE)
+                .storeProductId("com.melissa.melissaFE.premium")
+                .productType(ProductType.NON_CONSUMABLE)
+                .appleTransactionId("2000000123456789")
+                .appleOriginalTransactionId("2000000123456789")
+                .appleEnvironment("SANDBOX")
+                .purchasedAt(LocalDateTime.of(2026, 6, 15, 10, 0))
+                .rawPayload("{}")
+                .build();
+    }
+
+    private PaymentGrantResult grantResult(PaymentPlatform platform, boolean alreadyProcessed, LocalDateTime acknowledgedAt) {
+        User user = User.builder()
+                .id(1L)
+                .provider("GOOGLE")
+                .nickname("user")
+                .build();
+        PaymentProduct product = PaymentProduct.builder()
+                .id(10L)
+                .productId("remove_ads")
+                .platform(platform)
+                .storeProductId(platform == PaymentPlatform.GOOGLE ? "premium" : "com.melissa.melissaFE.premium")
+                .productType(ProductType.NON_CONSUMABLE)
+                .entitlementType(EntitlementType.REMOVE_ADS)
+                .displayName("광고 제거")
+                .active(true)
+                .build();
+        Payment payment = Payment.builder()
+                .id(100L)
+                .user(user)
+                .platform(platform)
+                .product(product)
+                .storeProductId(product.getStoreProductId())
+                .productType(ProductType.NON_CONSUMABLE)
+                .status(PaymentStatus.PURCHASED)
+                .purchasedAt(LocalDateTime.of(2026, 6, 15, 10, 0))
+                .verifiedAt(LocalDateTime.of(2026, 6, 15, 10, 1))
+                .acknowledgedAt(acknowledgedAt)
+                .build();
+        Entitlement entitlement = Entitlement.builder()
+                .user(user)
+                .entitlementType(EntitlementType.REMOVE_ADS)
+                .active(true)
+                .sourceType(EntitlementSourceType.PAYMENT)
+                .sourcePlatform(platform)
+                .sourcePayment(payment)
+                .grantedAt(LocalDateTime.of(2026, 6, 15, 10, 1))
+                .build();
+
+        return PaymentGrantResult.builder()
+                .payment(payment)
+                .entitlement(entitlement)
+                .alreadyProcessed(alreadyProcessed)
+                .build();
+    }
+}

--- a/src/test/java/com/melissa/diary/service/payment/store/AppleAppStoreServerPurchaseVerifierLiveTest.java
+++ b/src/test/java/com/melissa/diary/service/payment/store/AppleAppStoreServerPurchaseVerifierLiveTest.java
@@ -1,0 +1,115 @@
+package com.melissa.diary.service.payment.store;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.melissa.diary.config.PaymentProperties;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import com.melissa.diary.web.dto.PaymentRequestDTO;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppleAppStoreServerPurchaseVerifierLiveTest {
+
+    @Test
+    void verifyAppleTransactionAgainstAppStoreServerApiWhenEnvIsPresent() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        PaymentRequestDTO.AppleVerifyRequest request = appleVerifyRequest(objectMapper);
+        String issuerId = env("APPLE_ISSUER_ID");
+        String keyId = env("APPLE_KEY_ID");
+        String privateKeyP8Base64 = privateKeyP8Base64();
+
+        Assumptions.assumeTrue(!isBlank(request.getTransactionId()), "Apple transactionId is not set");
+        Assumptions.assumeTrue(!isBlank(issuerId), "APPLE_ISSUER_ID is not set");
+        Assumptions.assumeTrue(!isBlank(keyId), "APPLE_KEY_ID is not set");
+        Assumptions.assumeTrue(!isBlank(privateKeyP8Base64), "Apple private key env is not set");
+
+        String bundleId = request.getBundleId();
+        String productId = request.getProductId();
+        String environment = request.getEnvironment();
+
+        PaymentProperties properties = new PaymentProperties();
+        properties.getIap().setVerifyTimeoutMs(15000);
+        properties.getApple().setIssuerId(issuerId);
+        properties.getApple().setKeyId(keyId);
+        properties.getApple().setPrivateKeyP8Base64(privateKeyP8Base64);
+        properties.getApple().setBundleId(bundleId);
+        properties.getApple().setProductRemoveAds(productId);
+        properties.getApple().setEnvironment(environment);
+
+        AppleAppStoreServerPurchaseVerifier verifier = new AppleAppStoreServerPurchaseVerifier(properties, objectMapper);
+        VerifiedPurchase purchase = verifier.verify(new ApplePurchaseVerifyCommand(
+                productId,
+                request.getTransactionId(),
+                request.getOriginalTransactionId(),
+                environment,
+                bundleId
+        ));
+
+        assertThat(purchase.getPlatform()).isEqualTo(PaymentPlatform.APPLE);
+        assertThat(purchase.getAppleTransactionId()).isEqualTo(request.getTransactionId());
+        assertThat(purchase.getStoreProductId()).isEqualTo(productId);
+    }
+
+    private PaymentRequestDTO.AppleVerifyRequest appleVerifyRequest(ObjectMapper objectMapper) throws Exception {
+        String payloadJson = payloadJson();
+        if (!isBlank(payloadJson)) {
+            return objectMapper.readValue(payloadJson, PaymentRequestDTO.AppleVerifyRequest.class);
+        }
+
+        return new PaymentRequestDTO.AppleVerifyRequest(
+                envOrDefault("PAYMENT_TEST_APPLE_PRODUCT_ID", "com.melissa.melissaFE.premium"),
+                env("PAYMENT_TEST_APPLE_TRANSACTION_ID"),
+                env("PAYMENT_TEST_APPLE_ORIGINAL_TRANSACTION_ID"),
+                envOrDefault("PAYMENT_TEST_APPLE_ENVIRONMENT", "SANDBOX"),
+                envOrDefault("PAYMENT_TEST_APPLE_BUNDLE_ID", "com.melissa.melissaFE")
+        );
+    }
+
+    private String payloadJson() throws Exception {
+        String json = env("PAYMENT_TEST_APPLE_VERIFY_REQUEST_JSON");
+        if (!isBlank(json)) {
+            return json;
+        }
+
+        String path = env("PAYMENT_TEST_APPLE_VERIFY_REQUEST_JSON_PATH");
+        if (isBlank(path)) {
+            return "";
+        }
+
+        return Files.readString(Path.of(path), StandardCharsets.UTF_8);
+    }
+
+    private String privateKeyP8Base64() throws Exception {
+        String encoded = env("APPLE_PRIVATE_KEY_P8_BASE64");
+        if (!isBlank(encoded)) {
+            return encoded;
+        }
+
+        String path = env("APPLE_PRIVATE_KEY_P8_PATH");
+        if (isBlank(path)) {
+            return "";
+        }
+
+        String pem = Files.readString(Path.of(path), StandardCharsets.UTF_8);
+        return Base64.getEncoder().encodeToString(pem.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String envOrDefault(String name, String defaultValue) {
+        String value = env(name);
+        return isBlank(value) ? defaultValue : value;
+    }
+
+    private String env(String name) {
+        return System.getenv(name);
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/src/test/java/com/melissa/diary/service/payment/store/GooglePlayRestPurchaseVerifierLiveTest.java
+++ b/src/test/java/com/melissa/diary/service/payment/store/GooglePlayRestPurchaseVerifierLiveTest.java
@@ -1,0 +1,71 @@
+package com.melissa.diary.service.payment.store;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.melissa.diary.config.PaymentProperties;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GooglePlayRestPurchaseVerifierLiveTest {
+
+    @Test
+    void verifyGooglePurchaseAgainstPlayDeveloperApiWhenEnvIsPresent() throws Exception {
+        String purchaseToken = env("PAYMENT_TEST_GOOGLE_PURCHASE_TOKEN");
+        String serviceAccountJsonBase64 = serviceAccountJsonBase64();
+
+        Assumptions.assumeTrue(!isBlank(purchaseToken), "PAYMENT_TEST_GOOGLE_PURCHASE_TOKEN is not set");
+        Assumptions.assumeTrue(!isBlank(serviceAccountJsonBase64), "Google service account env is not set");
+
+        String packageName = envOrDefault("PAYMENT_TEST_GOOGLE_PACKAGE_NAME", "com.melissa.melissaFE");
+        String productId = envOrDefault("PAYMENT_TEST_GOOGLE_PRODUCT_ID", "premium");
+
+        PaymentProperties properties = new PaymentProperties();
+        properties.getIap().setVerifyTimeoutMs(15000);
+        properties.getGoogle().setServiceAccountJsonBase64(serviceAccountJsonBase64);
+
+        GooglePlayRestPurchaseVerifier verifier = new GooglePlayRestPurchaseVerifier(properties, new ObjectMapper());
+        VerifiedPurchase purchase = verifier.verify(new GooglePurchaseVerifyCommand(
+                packageName,
+                productId,
+                purchaseToken,
+                env("PAYMENT_TEST_GOOGLE_ORDER_ID")
+        ));
+
+        assertThat(purchase.getPlatform()).isEqualTo(PaymentPlatform.GOOGLE);
+        assertThat(purchase.getStoreProductId()).isEqualTo(productId);
+    }
+
+    private String serviceAccountJsonBase64() throws Exception {
+        String encoded = env("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64");
+        if (!isBlank(encoded)) {
+            return encoded;
+        }
+
+        String path = env("GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_PATH");
+        if (isBlank(path)) {
+            return "";
+        }
+        String json = Files.readString(Path.of(path), StandardCharsets.UTF_8);
+        return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String envOrDefault(String name, String defaultValue) {
+        String value = env(name);
+        return isBlank(value) ? defaultValue : value;
+    }
+
+    private String env(String name) {
+        return System.getenv(name);
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
Google/Apple 인앱결제 기반 remove_ads 비소모성 1회 구매 검증과 복원 API를 구현했습니다.

Closes #284

## 📋 변경 사항
- Google Play remove_ads 구매 검증 API 추가
  - `POST /api/v1/payments/google/verify`
  - `POST /api/v1/payments/google/restore`
- Apple App Store remove_ads 거래 검증 API 추가
  - `POST /api/v1/payments/apple/verify`
  - `POST /api/v1/payments/apple/restore`
- 검증 성공 시 `Payment` 저장 및 `REMOVE_ADS` entitlement 부여 처리 추가
- 동일 구매 중복 처리 및 다른 사용자에게 이미 연결된 구매 차단 처리 추가
- Google 구매 acknowledge 처리 및 실패 시 재시도 스케줄러 추가
- 결제 검증용 환경변수 설정 추가
- 결제 검증/권한 부여 관련 테스트 추가

## 🔍 Code Review
- 기본값은 `PAYMENT_IAP_ENABLED=false`라서 환경변수 설정 전에는 결제 검증 기능이 비활성화됩니다.
- 실제 테스트 서버 활성화를 위해서는 Google/Apple 검증용 환경변수 설정이 필요합니다.
- DB 스키마와 상품 데이터는 선행 이슈의 `PAY-001` 적용 기준을 사용하며, 이번 PR에서 추가 DB 마이그레이션은 없습니다.
- Apple 기존 전달 샘플 transactionId는 App Store Server API에서 404가 반환되어, 프론트 테스트앱 기준 신규 결제로 검증 예정입니다.
- Google은 테스트앱 빌드에서 생성된 purchaseToken으로 검증 예정입니다.

## 📸 ScreenShot
백엔드 API 작업으로 별도 스크린샷은 없습니다.
