### PR TITLE
Feat: 관리자 수동 환불 fallback 구현

### DIFF
--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -88,6 +88,8 @@ public enum ErrorStatus implements BaseErrorCode {
     PAYMENT_STORE_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT4004", "스토어 구매 검증에 실패했습니다."),
     PAYMENT_PURCHASE_OWNER_MISMATCH(HttpStatus.BAD_REQUEST, "PAYMENT4005", "구매 소유자 또는 앱 식별자가 일치하지 않습니다."),
     PAYMENT_PURCHASE_REVOKED(HttpStatus.BAD_REQUEST, "PAYMENT4006", "환불 또는 취소된 구매입니다."),
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT4007", "결제 내역을 찾을 수 없습니다."),
+    PAYMENT_REFUND_INVALID_STATUS(HttpStatus.BAD_REQUEST, "PAYMENT4008", "환불 처리할 수 없는 결제 상태입니다."),
     PAYMENT_ALREADY_OWNED_BY_OTHER_USER(HttpStatus.CONFLICT, "PAYMENT4091", "같은 구매가 다른 사용자에게 이미 연결되어 있습니다."),
     PAYMENT_USER_DELETE_BLOCKED(HttpStatus.CONFLICT, "PAYMENT4092", "결제 이력이 있어 현재 회원탈퇴를 처리할 수 없습니다. 관리자에게 문의해주세요."),
     PAYMENT_DISABLED(HttpStatus.SERVICE_UNAVAILABLE, "PAYMENT5031", "인앱결제 검증 기능이 비활성화되어 있습니다."),

--- a/src/main/java/com/melissa/diary/repository/EntitlementRepository.java
+++ b/src/main/java/com/melissa/diary/repository/EntitlementRepository.java
@@ -28,4 +28,12 @@ public interface EntitlementRepository extends JpaRepository<Entitlement, Long> 
             @Param("userId") Long userId,
             @Param("entitlementType") EntitlementType entitlementType
     );
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT e
+            FROM Entitlement e
+            WHERE e.sourcePayment.id = :paymentId
+            """)
+    Optional<Entitlement> findBySourcePaymentIdForUpdate(@Param("paymentId") Long paymentId);
 }

--- a/src/main/java/com/melissa/diary/repository/PaymentRepository.java
+++ b/src/main/java/com/melissa/diary/repository/PaymentRepository.java
@@ -21,6 +21,16 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     @Query("""
             SELECT p
             FROM Payment p
+            JOIN FETCH p.user
+            JOIN FETCH p.product
+            WHERE p.id = :paymentId
+            """)
+    Optional<Payment> findByIdForUpdate(@Param("paymentId") Long paymentId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT p
+            FROM Payment p
             WHERE p.platform = :platform
               AND p.googlePurchaseTokenHash = :tokenHash
             """)

--- a/src/main/java/com/melissa/diary/service/payment/PaymentAdminRefundService.java
+++ b/src/main/java/com/melissa/diary/service/payment/PaymentAdminRefundService.java
@@ -1,0 +1,179 @@
+package com.melissa.diary.service.payment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.Entitlement;
+import com.melissa.diary.domain.Payment;
+import com.melissa.diary.domain.PaymentEvent;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.enums.PaymentEventProcessingStatus;
+import com.melissa.diary.domain.enums.PaymentStatus;
+import com.melissa.diary.repository.EntitlementRepository;
+import com.melissa.diary.repository.PaymentEventRepository;
+import com.melissa.diary.repository.PaymentRepository;
+import com.melissa.diary.repository.UserRepository;
+import com.melissa.diary.service.AdminAuthorizationService;
+import com.melissa.diary.web.dto.PaymentRequestDTO;
+import com.melissa.diary.web.dto.PaymentResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentAdminRefundService {
+
+    private static final String MANUAL_REFUND_EVENT_TYPE = "MANUAL_REFUND";
+
+    private final AdminAuthorizationService adminAuthorizationService;
+    private final UserRepository userRepository;
+    private final PaymentRepository paymentRepository;
+    private final EntitlementRepository entitlementRepository;
+    private final PaymentEventRepository paymentEventRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public PaymentResponseDTO.AdminManualRefundResponse refundManually(
+            Long adminUserId,
+            Long paymentId,
+            PaymentRequestDTO.AdminManualRefundRequest request
+    ) {
+        adminAuthorizationService.assertAdmin(adminUserId);
+
+        User adminUser = userRepository.findById(adminUserId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+        Payment payment = paymentRepository.findByIdForUpdate(paymentId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.PAYMENT_NOT_FOUND));
+        Entitlement entitlement = entitlementRepository
+                .findBySourcePaymentIdForUpdate(paymentId)
+                .orElse(null);
+
+        LocalDateTime processedAt = LocalDateTime.now();
+        boolean alreadyProcessed = isAlreadyRefunded(payment);
+        if (alreadyProcessed) {
+            if (entitlement != null && Boolean.TRUE.equals(entitlement.getActive())) {
+                LocalDateTime revokedAt = firstNonNull(payment.getRefundedAt(), payment.getRevokedAt(), processedAt);
+                revokeEntitlementIfOwnedByPayment(entitlement, request.getReason(), revokedAt);
+                saveManualRefundEvent(payment, adminUser, request.getReason(), revokedAt, processedAt);
+            }
+            return toResponse(payment, entitlement, true, processedAt);
+        }
+
+        if (payment.getStatus() != PaymentStatus.PURCHASED) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_REFUND_INVALID_STATUS);
+        }
+
+        LocalDateTime refundedAt = request.getRefundedAt() == null ? processedAt : request.getRefundedAt();
+        payment.setStatus(PaymentStatus.REFUNDED);
+        payment.setRefundedAt(refundedAt);
+        payment.setFailureReason(null);
+
+        revokeEntitlementIfOwnedByPayment(entitlement, request.getReason(), refundedAt);
+        saveManualRefundEvent(payment, adminUser, request.getReason(), refundedAt, processedAt);
+
+        return toResponse(payment, entitlement, false, processedAt);
+    }
+
+    private boolean isAlreadyRefunded(Payment payment) {
+        return payment.getStatus() == PaymentStatus.REFUNDED || payment.getStatus() == PaymentStatus.REVOKED;
+    }
+
+    private void revokeEntitlementIfOwnedByPayment(
+            Entitlement entitlement,
+            String reason,
+            LocalDateTime revokedAt
+    ) {
+        if (entitlement == null || !Boolean.TRUE.equals(entitlement.getActive())) {
+            return;
+        }
+
+        entitlement.setActive(false);
+        entitlement.setRevokedAt(revokedAt);
+        entitlement.setRevocationReason(truncate(reason, 100));
+    }
+
+    private void saveManualRefundEvent(
+            Payment payment,
+            User adminUser,
+            String reason,
+            LocalDateTime refundedAt,
+            LocalDateTime processedAt
+    ) {
+        String eventId = manualRefundEventId(payment.getId());
+        if (paymentEventRepository.findByPlatformAndEventId(payment.getPlatform(), eventId).isPresent()) {
+            return;
+        }
+
+        PaymentEvent event = PaymentEvent.builder()
+                .platform(payment.getPlatform())
+                .eventId(eventId)
+                .eventType(MANUAL_REFUND_EVENT_TYPE)
+                .payment(payment)
+                .actorUser(adminUser)
+                .googlePurchaseTokenHash(payment.getGooglePurchaseTokenHash())
+                .appleTransactionId(payment.getAppleTransactionId())
+                .rawPayload(rawPayload(payment, reason, refundedAt))
+                .receivedAt(processedAt)
+                .processedAt(processedAt)
+                .processingStatus(PaymentEventProcessingStatus.PROCESSED)
+                .build();
+
+        paymentEventRepository.save(event);
+    }
+
+    private String rawPayload(Payment payment, String reason, LocalDateTime refundedAt) {
+        try {
+            ObjectNode payload = objectMapper.createObjectNode();
+            payload.put("source", MANUAL_REFUND_EVENT_TYPE);
+            payload.put("paymentId", payment.getId());
+            payload.put("reason", reason);
+            payload.put("refundedAt", refundedAt.toString());
+            return objectMapper.writeValueAsString(payload);
+        } catch (Exception e) {
+            throw new ErrorHandler(ErrorStatus.PAYMENT_GRANT_FAILED);
+        }
+    }
+
+    private String manualRefundEventId(Long paymentId) {
+        return MANUAL_REFUND_EVENT_TYPE + ":" + paymentId;
+    }
+
+    private LocalDateTime firstNonNull(LocalDateTime first, LocalDateTime second, LocalDateTime fallback) {
+        if (first != null) {
+            return first;
+        }
+        return second == null ? fallback : second;
+    }
+
+    private PaymentResponseDTO.AdminManualRefundResponse toResponse(
+            Payment payment,
+            Entitlement entitlement,
+            boolean alreadyProcessed,
+            LocalDateTime processedAt
+    ) {
+        return PaymentResponseDTO.AdminManualRefundResponse.builder()
+                .paymentId(payment.getId())
+                .userId(payment.getUser().getId())
+                .platform(payment.getPlatform().name())
+                .productId(payment.getProduct().getProductId())
+                .status(payment.getStatus().name())
+                .entitlementType(entitlement == null ? null : entitlement.getEntitlementType().name())
+                .entitlementRevoked(entitlement != null && !Boolean.TRUE.equals(entitlement.getActive()))
+                .entitlementActive(entitlement == null ? null : Boolean.TRUE.equals(entitlement.getActive()))
+                .alreadyProcessed(alreadyProcessed)
+                .refundedAt(payment.getRefundedAt())
+                .processedAt(processedAt)
+                .build();
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null || value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
+    }
+}

--- a/src/main/java/com/melissa/diary/web/controller/PaymentAdminController.java
+++ b/src/main/java/com/melissa/diary/web/controller/PaymentAdminController.java
@@ -1,0 +1,47 @@
+package com.melissa.diary.web.controller;
+
+import com.melissa.diary.apiPayload.ApiResponse;
+import com.melissa.diary.service.payment.PaymentAdminRefundService;
+import com.melissa.diary.web.dto.PaymentRequestDTO;
+import com.melissa.diary.web.dto.PaymentResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@Tag(name = "PaymentAdminAPI", description = "결제 관리자 fallback API")
+@RequestMapping("/api/v1/admin/payments")
+@RequiredArgsConstructor
+public class PaymentAdminController {
+
+    private final PaymentAdminRefundService paymentAdminRefundService;
+
+    @Operation(
+            summary = "관리자 수동 환불 반영",
+            description = """
+                스토어 콘솔에서 이미 환불 처리된 결제를 백엔드 DB에 수동 반영하고 광고 제거 권한을 회수합니다.
+                - 관리자 인증 필요 (Bearer JWT, ADMIN 계정)
+                - Google/Apple 스토어에 환불을 요청하는 API가 아니라 내부 fallback 처리 API
+                - paymentId 기준으로 결제 상태를 `REFUNDED`로 변경
+                - 해당 결제가 부여한 `REMOVE_ADS` 권한을 비활성화
+                - 이미 환불 처리된 결제는 `alreadyProcessed=true`로 멱등 응답
+                """
+    )
+    @PostMapping("/{paymentId}/refund")
+    public ApiResponse<PaymentResponseDTO.AdminManualRefundResponse> refundManually(
+            Principal principal,
+            @PathVariable Long paymentId,
+            @Valid @RequestBody PaymentRequestDTO.AdminManualRefundRequest request
+    ) {
+        Long adminUserId = Long.parseLong(principal.getName());
+        return ApiResponse.onSuccess(paymentAdminRefundService.refundManually(adminUserId, paymentId, request));
+    }
+}

--- a/src/main/java/com/melissa/diary/web/controller/PaymentController.java
+++ b/src/main/java/com/melissa/diary/web/controller/PaymentController.java
@@ -16,14 +16,24 @@ import org.springframework.web.bind.annotation.RestController;
 import java.security.Principal;
 
 @RestController
-@Tag(name = "PaymentAPI", description = "In-app purchase verification API")
+@Tag(name = "PaymentAPI", description = "인앱결제 검증 및 구매 복원 API")
 @RequestMapping("/api/v1/payments")
 @RequiredArgsConstructor
 public class PaymentController {
 
     private final PaymentVerificationService paymentVerificationService;
 
-    @Operation(summary = "Verify Google Play remove_ads purchase")
+    @Operation(
+            summary = "Google Play 광고 제거 구매 검증",
+            description = """
+                Google Play Billing에서 받은 비소모성 상품 구매 정보를 서버에서 검증하고 광고 제거 권한을 부여합니다.
+                - 인증 필요 (Bearer JWT)
+                - userId는 토큰(subject) 기반으로 서버에서 결정
+                - 요청 productId는 Google Play 상품 ID인 `premium`
+                - 검증 성공 시 응답의 `entitlement.active=true`로 광고 제거 적용 가능
+                - 같은 구매를 같은 사용자가 다시 검증하면 `alreadyProcessed=true`로 응답
+                """
+    )
     @PostMapping("/google/verify")
     public ApiResponse<PaymentResponseDTO.VerifyResponse> verifyGoogle(
             Principal principal,
@@ -33,7 +43,16 @@ public class PaymentController {
         return ApiResponse.onSuccess(paymentVerificationService.verifyGoogle(userId, request));
     }
 
-    @Operation(summary = "Restore Google Play remove_ads purchases")
+    @Operation(
+            summary = "Google Play 광고 제거 구매 복원",
+            description = """
+                Google Play Billing에서 조회한 보유 구매 목록을 서버에 다시 검증하여 광고 제거 권한을 복원합니다.
+                - 인증 필요 (Bearer JWT)
+                - userId는 토큰(subject) 기반으로 서버에서 결정
+                - 일부 구매 검증 실패가 있어도 API 자체는 성공할 수 있으며 실패 항목은 `failed`에 포함
+                - 최종 광고 제거 여부는 `features.adRemoved` 값으로 판단
+                """
+    )
     @PostMapping("/google/restore")
     public ApiResponse<PaymentResponseDTO.RestoreResponse> restoreGoogle(
             Principal principal,
@@ -43,7 +62,17 @@ public class PaymentController {
         return ApiResponse.onSuccess(paymentVerificationService.restoreGoogle(userId, request));
     }
 
-    @Operation(summary = "Verify Apple App Store remove_ads transaction")
+    @Operation(
+            summary = "Apple App Store 광고 제거 구매 검증",
+            description = """
+                App Store에서 받은 비소모성 상품 transactionId를 서버에서 검증하고 광고 제거 권한을 부여합니다.
+                - 인증 필요 (Bearer JWT)
+                - userId는 토큰(subject) 기반으로 서버에서 결정
+                - 요청 productId는 Apple 상품 ID인 `com.melissa.melissaFE.premium`
+                - environment는 테스트 결제 `SANDBOX`, 상용 결제 `PRODUCTION`
+                - 검증 성공 시 응답의 `entitlement.active=true`로 광고 제거 적용 가능
+                """
+    )
     @PostMapping("/apple/verify")
     public ApiResponse<PaymentResponseDTO.VerifyResponse> verifyApple(
             Principal principal,
@@ -53,7 +82,16 @@ public class PaymentController {
         return ApiResponse.onSuccess(paymentVerificationService.verifyApple(userId, request));
     }
 
-    @Operation(summary = "Restore Apple App Store remove_ads transactions")
+    @Operation(
+            summary = "Apple App Store 광고 제거 구매 복원",
+            description = """
+                App Store에서 조회한 보유 거래 목록을 서버에 다시 검증하여 광고 제거 권한을 복원합니다.
+                - 인증 필요 (Bearer JWT)
+                - userId는 토큰(subject) 기반으로 서버에서 결정
+                - 일부 거래 검증 실패가 있어도 API 자체는 성공할 수 있으며 실패 항목은 `failed`에 포함
+                - 최종 광고 제거 여부는 `features.adRemoved` 값으로 판단
+                """
+    )
     @PostMapping("/apple/restore")
     public ApiResponse<PaymentResponseDTO.RestoreResponse> restoreApple(
             Principal principal,

--- a/src/main/java/com/melissa/diary/web/controller/UserController.java
+++ b/src/main/java/com/melissa/diary/web/controller/UserController.java
@@ -58,13 +58,18 @@ public class UserController {
     }
 
     @Operation(
-            summary = "Get current user's payment entitlements",
-            description = "Returns active payment entitlements and derived feature flags for the authenticated user."
+            summary = "내 결제 권한 조회",
+            description = """
+                현재 로그인한 사용자의 활성 결제 권한과 프론트 기능 플래그를 반환합니다.
+                - 인증 필요 (Bearer JWT)
+                - userId는 토큰(subject) 기반으로 서버에서 결정
+                - 광고 제거 적용 여부는 `features.adRemoved` 값으로 판단
+                """
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Success"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "Authentication failed"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: User not found")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패(토큰 누락/만료/위조)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "AUTH4006: 사용자를 찾을 수 없음")
     })
     @GetMapping("/me/entitlements")
     public ApiResponse<EntitlementResponseDTO.EntitlementsResponse> getMyEntitlements(Principal principal) {

--- a/src/main/java/com/melissa/diary/web/dto/EntitlementResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/EntitlementResponseDTO.java
@@ -11,43 +11,43 @@ public class EntitlementResponseDTO {
 
     @Getter
     @Builder
-    @Schema(description = "Current user's active entitlement response")
+    @Schema(description = "현재 사용자의 활성 권한 응답")
     public static class EntitlementsResponse {
 
-        @Schema(description = "Active entitlement list")
+        @Schema(description = "활성 권한 목록")
         private List<EntitlementSummary> entitlements;
 
-        @Schema(description = "Feature flags derived from active entitlements")
+        @Schema(description = "활성 권한 기반 프론트 기능 플래그")
         private FeatureSummary features;
     }
 
     @Getter
     @Builder
-    @Schema(description = "Active entitlement summary")
+    @Schema(description = "활성 권한 요약")
     public static class EntitlementSummary {
 
-        @Schema(description = "Entitlement type", example = "REMOVE_ADS")
+        @Schema(description = "권한 타입", example = "REMOVE_ADS")
         private String type;
 
-        @Schema(description = "Whether the entitlement is active", example = "true")
+        @Schema(description = "권한 활성 여부", example = "true")
         private Boolean active;
 
-        @Schema(description = "Source platform", example = "GOOGLE", nullable = true)
+        @Schema(description = "권한이 부여된 결제 플랫폼", example = "GOOGLE", nullable = true)
         private String sourcePlatform;
 
-        @Schema(description = "Granted time")
+        @Schema(description = "권한 부여 시각")
         private LocalDateTime grantedAt;
 
-        @Schema(description = "Revoked time", nullable = true)
+        @Schema(description = "권한 회수 시각", nullable = true)
         private LocalDateTime revokedAt;
     }
 
     @Getter
     @Builder
-    @Schema(description = "Feature flags")
+    @Schema(description = "프론트 기능 플래그")
     public static class FeatureSummary {
 
-        @Schema(description = "Whether ads should be removed", example = "true")
+        @Schema(description = "광고 제거 적용 여부. 프론트는 이 값을 기준으로 광고 표시 여부를 판단", example = "true")
         private Boolean adRemoved;
     }
 }

--- a/src/main/java/com/melissa/diary/web/dto/PaymentRequestDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/PaymentRequestDTO.java
@@ -20,22 +20,22 @@ public class PaymentRequestDTO {
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "Google Play one-time product verify request")
+    @Schema(description = "Google Play 비소모성 상품 구매 검증 요청")
     public static class GoogleVerifyRequest {
 
         @NotBlank
-        @Schema(description = "Google Play product id", example = "premium", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "Google Play 상품 ID", example = "premium", requiredMode = Schema.RequiredMode.REQUIRED)
         private String productId;
 
         @NotBlank
-        @Schema(description = "Android package name", example = "com.melissa.melissaFE", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "Android 앱 패키지명", example = "com.melissa.melissaFE", requiredMode = Schema.RequiredMode.REQUIRED)
         private String packageName;
 
         @NotBlank
-        @Schema(description = "Google Play Billing purchase token", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "Google Play Billing purchaseToken", requiredMode = Schema.RequiredMode.REQUIRED)
         private String purchaseToken;
 
-        @Schema(description = "Google order id", example = "GPA.1234-5678-9012-34567", nullable = true)
+        @Schema(description = "Google 주문 ID. 없으면 생략 가능", example = "GPA.1234-5678-9012-34567", nullable = true)
         private String orderId;
     }
 
@@ -43,11 +43,12 @@ public class PaymentRequestDTO {
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "Google Play restore request")
+    @Schema(description = "Google Play 구매 복원 요청")
     public static class GoogleRestoreRequest {
 
         @Valid
         @NotEmpty
+        @Schema(description = "Google Play Billing에서 조회한 보유 구매 목록", requiredMode = Schema.RequiredMode.REQUIRED)
         private List<GoogleVerifyRequest> purchases;
     }
 
@@ -56,26 +57,26 @@ public class PaymentRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
-    @Schema(description = "Apple App Store transaction verify request")
+    @Schema(description = "Apple App Store 거래 검증 요청")
     public static class AppleVerifyRequest {
 
         @NotBlank
-        @Schema(description = "Apple product id", example = "com.melissa.melissaFE.premium", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "Apple 인앱결제 상품 ID", example = "com.melissa.melissaFE.premium", requiredMode = Schema.RequiredMode.REQUIRED)
         private String productId;
 
         @NotBlank
-        @Schema(description = "Apple transaction id", example = "2000000123456789", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "Apple transactionId", example = "2000000123456789", requiredMode = Schema.RequiredMode.REQUIRED)
         private String transactionId;
 
-        @Schema(description = "Apple original transaction id", example = "2000000123456789", nullable = true)
+        @Schema(description = "Apple originalTransactionId. 없으면 생략 가능", example = "2000000123456789", nullable = true)
         private String originalTransactionId;
 
         @NotBlank
-        @Schema(description = "Apple transaction environment", example = "SANDBOX", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "Apple 거래 환경. 테스트 결제는 SANDBOX, 상용 결제는 PRODUCTION", example = "SANDBOX", requiredMode = Schema.RequiredMode.REQUIRED)
         private String environment;
 
         @NotBlank
-        @Schema(description = "iOS bundle id", example = "com.melissa.melissaFE", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "iOS 앱 bundleId", example = "com.melissa.melissaFE", requiredMode = Schema.RequiredMode.REQUIRED)
         private String bundleId;
     }
 
@@ -83,11 +84,12 @@ public class PaymentRequestDTO {
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "Apple App Store restore request")
+    @Schema(description = "Apple App Store 구매 복원 요청")
     public static class AppleRestoreRequest {
 
         @Valid
         @NotEmpty
+        @Schema(description = "App Store에서 조회한 보유 거래 목록", requiredMode = Schema.RequiredMode.REQUIRED)
         private List<AppleVerifyRequest> transactions;
     }
 

--- a/src/main/java/com/melissa/diary/web/dto/PaymentRequestDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/PaymentRequestDTO.java
@@ -5,11 +5,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class PaymentRequestDTO {
@@ -87,5 +89,21 @@ public class PaymentRequestDTO {
         @Valid
         @NotEmpty
         private List<AppleVerifyRequest> transactions;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "관리자 수동 환불 반영 요청")
+    public static class AdminManualRefundRequest {
+
+        @NotBlank
+        @Size(max = 100)
+        @Schema(description = "수동 환불 반영 사유", example = "Google Play Console 환불 처리 확인", requiredMode = Schema.RequiredMode.REQUIRED)
+        private String reason;
+
+        @Schema(description = "스토어 환불 처리 시각. 생략하면 서버 처리 시각 사용", nullable = true)
+        private LocalDateTime refundedAt;
     }
 }

--- a/src/main/java/com/melissa/diary/web/dto/PaymentResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/PaymentResponseDTO.java
@@ -15,17 +15,36 @@ public class PaymentResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "Store purchase verify response")
+    @Schema(description = "스토어 구매 검증 응답")
     public static class VerifyResponse {
+        @Schema(description = "백엔드 결제 내역 ID", example = "1")
         private Long paymentId;
+
+        @Schema(description = "결제 플랫폼", example = "GOOGLE")
         private String platform;
+
+        @Schema(description = "백엔드 내부 상품 ID. 스토어 상품 ID가 아니라 `remove_ads`로 반환", example = "remove_ads")
         private String productId;
+
+        @Schema(description = "결제 상태", example = "PURCHASED")
         private String status;
+
+        @Schema(description = "검증 성공으로 부여된 권한 요약")
         private EntitlementSummary entitlement;
+
+        @Schema(description = "Google 구매 acknowledge 완료 여부. Apple은 null", example = "true", nullable = true)
         private Boolean acknowledged;
+
+        @Schema(description = "프론트의 구매 완료 처리 필요 여부. Apple 검증 성공 시 true", example = "true", nullable = true)
         private Boolean finishRequired;
+
+        @Schema(description = "이미 처리된 같은 구매를 다시 검증했는지 여부", example = "false")
         private Boolean alreadyProcessed;
+
+        @Schema(description = "스토어 구매 시각")
         private LocalDateTime purchasedAt;
+
+        @Schema(description = "백엔드 검증 시각")
         private LocalDateTime verifiedAt;
     }
 
@@ -33,9 +52,12 @@ public class PaymentResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "Payment entitlement summary")
+    @Schema(description = "결제 권한 요약")
     public static class EntitlementSummary {
+        @Schema(description = "권한 타입", example = "REMOVE_ADS")
         private String type;
+
+        @Schema(description = "권한 활성 여부. true면 광고 제거 적용 가능", example = "true")
         private Boolean active;
     }
 
@@ -43,10 +65,15 @@ public class PaymentResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "Store restore response")
+    @Schema(description = "스토어 구매 복원 응답")
     public static class RestoreResponse {
+        @Schema(description = "복원에 성공한 구매 목록")
         private List<RestoredPurchase> restored;
+
+        @Schema(description = "검증에 실패한 구매 목록. 일부 실패가 있어도 API 자체는 성공할 수 있음")
         private List<FailedPurchase> failed;
+
+        @Schema(description = "현재 사용자의 기능 플래그. 광고 제거 여부는 `adRemoved`로 판단")
         private EntitlementResponseDTO.FeatureSummary features;
     }
 
@@ -54,12 +81,21 @@ public class PaymentResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "Restored purchase summary")
+    @Schema(description = "복원 성공 구매 요약")
     public static class RestoredPurchase {
+        @Schema(description = "백엔드 결제 내역 ID", example = "1")
         private Long paymentId;
+
+        @Schema(description = "결제 플랫폼", example = "APPLE")
         private String platform;
+
+        @Schema(description = "백엔드 내부 상품 ID", example = "remove_ads")
         private String productId;
+
+        @Schema(description = "결제 상태", example = "PURCHASED")
         private String status;
+
+        @Schema(description = "복원된 권한 타입", example = "REMOVE_ADS")
         private String entitlementType;
     }
 
@@ -67,12 +103,21 @@ public class PaymentResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "Failed restore item summary")
+    @Schema(description = "복원 실패 구매 요약")
     public static class FailedPurchase {
+        @Schema(description = "결제 플랫폼", example = "GOOGLE")
         private String platform;
+
+        @Schema(description = "요청으로 전달된 스토어 상품 ID", example = "premium")
         private String productId;
+
+        @Schema(description = "실패 항목 식별자. Google은 orderId 또는 purchaseToken, Apple은 transactionId", example = "GPA.1234-5678-9012-34567")
         private String identifier;
+
+        @Schema(description = "실패 코드", example = "PAYMENT4004")
         private String code;
+
+        @Schema(description = "실패 메시지", example = "스토어 구매 검증에 실패했습니다.")
         private String message;
     }
 

--- a/src/main/java/com/melissa/diary/web/dto/PaymentResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/PaymentResponseDTO.java
@@ -75,4 +75,44 @@ public class PaymentResponseDTO {
         private String code;
         private String message;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "관리자 수동 환불 반영 응답")
+    public static class AdminManualRefundResponse {
+        @Schema(description = "백엔드 결제 내역 ID", example = "1")
+        private Long paymentId;
+
+        @Schema(description = "환불 처리 대상 사용자 ID", example = "10")
+        private Long userId;
+
+        @Schema(description = "결제 플랫폼", example = "GOOGLE")
+        private String platform;
+
+        @Schema(description = "백엔드 내부 상품 ID", example = "remove_ads")
+        private String productId;
+
+        @Schema(description = "결제 상태", example = "REFUNDED")
+        private String status;
+
+        @Schema(description = "회수 대상 권한 타입", example = "REMOVE_ADS", nullable = true)
+        private String entitlementType;
+
+        @Schema(description = "권한 회수 완료 여부", example = "true")
+        private Boolean entitlementRevoked;
+
+        @Schema(description = "권한 활성 여부", example = "false", nullable = true)
+        private Boolean entitlementActive;
+
+        @Schema(description = "이미 환불 처리된 결제였는지 여부", example = "false")
+        private Boolean alreadyProcessed;
+
+        @Schema(description = "환불 반영 시각")
+        private LocalDateTime refundedAt;
+
+        @Schema(description = "관리자 fallback 처리 시각")
+        private LocalDateTime processedAt;
+    }
 }

--- a/src/test/java/com/melissa/diary/service/payment/PaymentAdminRefundServiceTest.java
+++ b/src/test/java/com/melissa/diary/service/payment/PaymentAdminRefundServiceTest.java
@@ -1,0 +1,263 @@
+package com.melissa.diary.service.payment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.Entitlement;
+import com.melissa.diary.domain.Payment;
+import com.melissa.diary.domain.PaymentEvent;
+import com.melissa.diary.domain.PaymentProduct;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.enums.EntitlementSourceType;
+import com.melissa.diary.domain.enums.EntitlementType;
+import com.melissa.diary.domain.enums.PaymentPlatform;
+import com.melissa.diary.domain.enums.PaymentStatus;
+import com.melissa.diary.domain.enums.ProductType;
+import com.melissa.diary.repository.EntitlementRepository;
+import com.melissa.diary.repository.PaymentEventRepository;
+import com.melissa.diary.repository.PaymentRepository;
+import com.melissa.diary.repository.UserRepository;
+import com.melissa.diary.service.AdminAuthorizationService;
+import com.melissa.diary.web.dto.PaymentRequestDTO;
+import com.melissa.diary.web.dto.PaymentResponseDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentAdminRefundServiceTest {
+
+    @Mock
+    private AdminAuthorizationService adminAuthorizationService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private EntitlementRepository entitlementRepository;
+
+    @Mock
+    private PaymentEventRepository paymentEventRepository;
+
+    private PaymentAdminRefundService paymentAdminRefundService;
+
+    @BeforeEach
+    void setUp() {
+        paymentAdminRefundService = new PaymentAdminRefundService(
+                adminAuthorizationService,
+                userRepository,
+                paymentRepository,
+                entitlementRepository,
+                paymentEventRepository,
+                new ObjectMapper()
+        );
+    }
+
+    @Test
+    void refundManuallyMarksPaymentRefundedAndRevokesEntitlement() {
+        Long adminUserId = 1L;
+        Long paymentId = 100L;
+        LocalDateTime refundedAt = LocalDateTime.of(2026, 6, 16, 1, 0);
+        User admin = user(adminUserId);
+        User buyer = user(2L);
+        Payment payment = purchasedPayment(paymentId, buyer);
+        Entitlement entitlement = activeEntitlement(buyer, payment);
+        PaymentRequestDTO.AdminManualRefundRequest request =
+                new PaymentRequestDTO.AdminManualRefundRequest("Google Play Console refund confirmed", refundedAt);
+
+        when(userRepository.findById(adminUserId)).thenReturn(Optional.of(admin));
+        when(paymentRepository.findByIdForUpdate(paymentId)).thenReturn(Optional.of(payment));
+        when(entitlementRepository.findBySourcePaymentIdForUpdate(paymentId)).thenReturn(Optional.of(entitlement));
+        when(paymentEventRepository.findByPlatformAndEventId(PaymentPlatform.GOOGLE, "MANUAL_REFUND:" + paymentId))
+                .thenReturn(Optional.empty());
+
+        PaymentResponseDTO.AdminManualRefundResponse response =
+                paymentAdminRefundService.refundManually(adminUserId, paymentId, request);
+
+        assertThat(payment.getStatus()).isEqualTo(PaymentStatus.REFUNDED);
+        assertThat(payment.getRefundedAt()).isEqualTo(refundedAt);
+        assertThat(entitlement.getActive()).isFalse();
+        assertThat(entitlement.getRevokedAt()).isEqualTo(refundedAt);
+        assertThat(entitlement.getRevocationReason()).isEqualTo("Google Play Console refund confirmed");
+        assertThat(response.getPaymentId()).isEqualTo(paymentId);
+        assertThat(response.getUserId()).isEqualTo(buyer.getId());
+        assertThat(response.getStatus()).isEqualTo("REFUNDED");
+        assertThat(response.getEntitlementRevoked()).isTrue();
+        assertThat(response.getAlreadyProcessed()).isFalse();
+
+        ArgumentCaptor<PaymentEvent> eventCaptor = ArgumentCaptor.forClass(PaymentEvent.class);
+        verify(paymentEventRepository).save(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().getEventId()).isEqualTo("MANUAL_REFUND:" + paymentId);
+        assertThat(eventCaptor.getValue().getActorUser()).isEqualTo(admin);
+    }
+
+    @Test
+    void refundManuallyReturnsAlreadyProcessedWhenPaymentWasRefunded() {
+        Long adminUserId = 1L;
+        Long paymentId = 100L;
+        LocalDateTime previousRefundedAt = LocalDateTime.of(2026, 6, 15, 1, 0);
+        User admin = user(adminUserId);
+        User buyer = user(2L);
+        Payment payment = purchasedPayment(paymentId, buyer);
+        payment.setStatus(PaymentStatus.REFUNDED);
+        payment.setRefundedAt(previousRefundedAt);
+        Entitlement entitlement = activeEntitlement(buyer, payment);
+        entitlement.setActive(false);
+        entitlement.setRevokedAt(previousRefundedAt);
+
+        when(userRepository.findById(adminUserId)).thenReturn(Optional.of(admin));
+        when(paymentRepository.findByIdForUpdate(paymentId)).thenReturn(Optional.of(payment));
+        when(entitlementRepository.findBySourcePaymentIdForUpdate(paymentId)).thenReturn(Optional.of(entitlement));
+
+        PaymentResponseDTO.AdminManualRefundResponse response =
+                paymentAdminRefundService.refundManually(
+                        adminUserId,
+                        paymentId,
+                        new PaymentRequestDTO.AdminManualRefundRequest("duplicate request", null)
+                );
+
+        assertThat(response.getAlreadyProcessed()).isTrue();
+        assertThat(response.getRefundedAt()).isEqualTo(previousRefundedAt);
+        assertThat(response.getEntitlementRevoked()).isTrue();
+        verify(paymentEventRepository, never()).save(any(PaymentEvent.class));
+    }
+
+    @Test
+    void refundManuallyRevokesActiveEntitlementEvenWhenPaymentWasAlreadyRefunded() {
+        Long adminUserId = 1L;
+        Long paymentId = 100L;
+        LocalDateTime previousRefundedAt = LocalDateTime.of(2026, 6, 15, 1, 0);
+        User admin = user(adminUserId);
+        User buyer = user(2L);
+        Payment payment = purchasedPayment(paymentId, buyer);
+        payment.setStatus(PaymentStatus.REFUNDED);
+        payment.setRefundedAt(previousRefundedAt);
+        Entitlement entitlement = activeEntitlement(buyer, payment);
+
+        when(userRepository.findById(adminUserId)).thenReturn(Optional.of(admin));
+        when(paymentRepository.findByIdForUpdate(paymentId)).thenReturn(Optional.of(payment));
+        when(entitlementRepository.findBySourcePaymentIdForUpdate(paymentId)).thenReturn(Optional.of(entitlement));
+        when(paymentEventRepository.findByPlatformAndEventId(PaymentPlatform.GOOGLE, "MANUAL_REFUND:" + paymentId))
+                .thenReturn(Optional.empty());
+
+        PaymentResponseDTO.AdminManualRefundResponse response =
+                paymentAdminRefundService.refundManually(
+                        adminUserId,
+                        paymentId,
+                        new PaymentRequestDTO.AdminManualRefundRequest("fix active entitlement", null)
+                );
+
+        assertThat(response.getAlreadyProcessed()).isTrue();
+        assertThat(response.getEntitlementRevoked()).isTrue();
+        assertThat(entitlement.getActive()).isFalse();
+        assertThat(entitlement.getRevokedAt()).isEqualTo(previousRefundedAt);
+        verify(paymentEventRepository).save(any(PaymentEvent.class));
+    }
+
+    @Test
+    void refundManuallyRejectsInvalidPaymentStatus() {
+        Long adminUserId = 1L;
+        Long paymentId = 100L;
+        User admin = user(adminUserId);
+        Payment payment = purchasedPayment(paymentId, user(2L));
+        payment.setStatus(PaymentStatus.FAILED);
+
+        when(userRepository.findById(adminUserId)).thenReturn(Optional.of(admin));
+        when(paymentRepository.findByIdForUpdate(paymentId)).thenReturn(Optional.of(payment));
+        when(entitlementRepository.findBySourcePaymentIdForUpdate(paymentId)).thenReturn(Optional.empty());
+
+        ErrorHandler error = assertThrows(
+                ErrorHandler.class,
+                () -> paymentAdminRefundService.refundManually(
+                        adminUserId,
+                        paymentId,
+                        new PaymentRequestDTO.AdminManualRefundRequest("manual refund", null)
+                )
+        );
+
+        assertThat(error.getErrorCode()).isEqualTo(ErrorStatus.PAYMENT_REFUND_INVALID_STATUS);
+        verify(paymentEventRepository, never()).save(any(PaymentEvent.class));
+    }
+
+    @Test
+    void refundManuallyRejectsNonAdminUser() {
+        Long userId = 1L;
+        doThrow(new ErrorHandler(ErrorStatus.PAYMENT_ADMIN_REQUIRED))
+                .when(adminAuthorizationService)
+                .assertAdmin(userId);
+
+        ErrorHandler error = assertThrows(
+                ErrorHandler.class,
+                () -> paymentAdminRefundService.refundManually(
+                        userId,
+                        100L,
+                        new PaymentRequestDTO.AdminManualRefundRequest("manual refund", null)
+                )
+        );
+
+        assertThat(error.getErrorCode()).isEqualTo(ErrorStatus.PAYMENT_ADMIN_REQUIRED);
+        verify(paymentRepository, never()).findByIdForUpdate(any());
+    }
+
+    private Payment purchasedPayment(Long id, User user) {
+        PaymentProduct product = PaymentProduct.builder()
+                .id(10L)
+                .productId("remove_ads")
+                .platform(PaymentPlatform.GOOGLE)
+                .storeProductId("premium")
+                .productType(ProductType.NON_CONSUMABLE)
+                .entitlementType(EntitlementType.REMOVE_ADS)
+                .active(true)
+                .displayName("광고 제거")
+                .build();
+
+        return Payment.builder()
+                .id(id)
+                .user(user)
+                .platform(PaymentPlatform.GOOGLE)
+                .product(product)
+                .storeProductId("premium")
+                .productType(ProductType.NON_CONSUMABLE)
+                .status(PaymentStatus.PURCHASED)
+                .googlePurchaseTokenHash("hash")
+                .build();
+    }
+
+    private Entitlement activeEntitlement(User user, Payment payment) {
+        return Entitlement.builder()
+                .id(20L)
+                .user(user)
+                .entitlementType(EntitlementType.REMOVE_ADS)
+                .active(true)
+                .sourceType(EntitlementSourceType.PAYMENT)
+                .sourcePlatform(PaymentPlatform.GOOGLE)
+                .sourcePayment(payment)
+                .grantedAt(LocalDateTime.of(2026, 6, 15, 10, 0))
+                .build();
+    }
+
+    private User user(Long id) {
+        return User.builder()
+                .id(id)
+                .provider("GOOGLE")
+                .nickname("user")
+                .build();
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
관리자가 스토어 콘솔에서 환불 완료된 결제를 백엔드에 수동 반영하고, 해당 결제로 부여된 광고 제거 권한을 회수할 수 있는 fallback API를 구현했습니다.

Closes #285

## 📋 변경 사항
- 관리자 수동 환불 반영 API 추가
  - `POST /api/v1/admin/payments/{paymentId}/refund`
- 관리자 권한 검증 후 수동 환불 처리
  - `ADMIN` 계정만 처리 가능
  - 대상 결제 상태를 `REFUNDED`로 변경
  - 해당 결제가 부여한 `REMOVE_ADS` entitlement를 비활성화
- 이미 환불 처리된 결제에 대한 멱등 응답 처리
  - `alreadyProcessed=true`
  - 환불 상태인데 entitlement가 남아 있는 비정상 상태도 회수 가능
- 수동 환불 처리 내역을 `payment_event`에 기록
  - eventType: `MANUAL_REFUND`
  - eventId: `MANUAL_REFUND:{paymentId}`
- 결제 관련 Swagger 문서 한글화 및 설명 보강
  - Google/Apple 구매 검증/복원 API 설명
  - 관리자 환불 fallback API 설명
  - 내 결제 권한 조회 API 설명
  - 결제 요청/응답 DTO schema 설명

## 🔍 Code Review
- 이 API는 Google/Apple 스토어에 환불을 요청하는 API가 아닙니다.
- 스토어 콘솔에서 이미 환불 완료된 결제를 백엔드 DB에 수동 반영하는 fallback API입니다.
- `PURCHASED` 상태의 결제만 신규 환불 처리할 수 있습니다.
- 이미 `REFUNDED` 또는 `REVOKED` 상태인 결제는 멱등 처리됩니다.
- 권한 회수는 해당 payment를 source로 가진 entitlement 기준으로 처리합니다.
- DB 스키마 변경은 없습니다. 기존 PAY-001 테이블 구조를 사용합니다.

검증:
- `./gradlew test --tests "com.melissa.diary.service.payment.*" --tests "com.melissa.diary.service.payment.store.*"`
- `./gradlew bootJar -x test`

## 📸 ScreenShot
백엔드 API 및 Swagger 문서 작업으로 별도 스크린샷은 없음.