### PR TITLE
Feat: 약관 버전 관리 및 사용자 동의 API 구현

### DIFF
--- a/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/melissa/diary/apiPayload/code/status/ErrorStatus.java
@@ -95,7 +95,15 @@ public enum ErrorStatus implements BaseErrorCode {
     PAYMENT_DISABLED(HttpStatus.SERVICE_UNAVAILABLE, "PAYMENT5031", "인앱결제 검증 기능이 비활성화되어 있습니다."),
     PAYMENT_STORE_API_FAILED(HttpStatus.BAD_GATEWAY, "PAYMENT5001", "스토어 API 호출에 실패했습니다."),
     PAYMENT_GRANT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PAYMENT5002", "결제 권한 부여에 실패했습니다."),
-    PAYMENT_ACKNOWLEDGE_FAILED(HttpStatus.BAD_GATEWAY, "PAYMENT5003", "Google 구매 acknowledge 처리에 실패했습니다.");
+    PAYMENT_ACKNOWLEDGE_FAILED(HttpStatus.BAD_GATEWAY, "PAYMENT5003", "Google 구매 acknowledge 처리에 실패했습니다."),
+
+    // Terms
+    TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM4001", "약관을 찾을 수 없습니다."),
+    TERM_VERSION_NOT_FOUND(HttpStatus.NOT_FOUND, "TERM4002", "약관 버전을 찾을 수 없습니다."),
+    TERM_VERSION_NOT_PUBLISHED(HttpStatus.BAD_REQUEST, "TERM4003", "동의할 수 없는 약관 버전입니다."),
+    TERM_VERSION_NOT_CURRENT(HttpStatus.BAD_REQUEST, "TERM4004", "현재 최신 약관 버전에만 동의할 수 있습니다."),
+    TERM_REQUIRED_AGREEMENT_MISSING(HttpStatus.BAD_REQUEST, "TERM4005", "필수 약관 동의가 누락되었습니다."),
+    TERM_REQUIRED_AGREEMENT_REJECTED(HttpStatus.BAD_REQUEST, "TERM4006", "필수 약관은 동의가 필요합니다.");
 
 
 

--- a/src/main/java/com/melissa/diary/converter/TermConverter.java
+++ b/src/main/java/com/melissa/diary/converter/TermConverter.java
@@ -1,0 +1,80 @@
+package com.melissa.diary.converter;
+
+import com.melissa.diary.domain.Term;
+import com.melissa.diary.domain.TermVersion;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.UserTermAgreement;
+import com.melissa.diary.domain.enums.AgreementContext;
+import com.melissa.diary.domain.enums.TermAgreementAction;
+import com.melissa.diary.web.dto.TermResponseDTO;
+
+import java.time.LocalDateTime;
+
+public class TermConverter {
+
+    public static TermResponseDTO.TermItemResponse toTermItemResponse(
+            TermVersion currentVersion,
+            UserTermAgreement latestAgreement,
+            Boolean agreed,
+            Boolean needsAgreement,
+            Boolean updated,
+            Boolean blocking,
+            TermAgreementAction action,
+            boolean includeContent
+    ) {
+        Term term = currentVersion.getTerm();
+
+        return TermResponseDTO.TermItemResponse.builder()
+                .termCode(term.getTermCode())
+                .title(currentVersion.getTitle())
+                .required(currentVersion.getRequired())
+                .currentTermVersionId(currentVersion.getId())
+                .currentVersion(currentVersion.getVersionLabel())
+                .previousVersion(latestAgreement == null ? null : latestAgreement.getVersionLabelSnapshot())
+                .agreed(agreed)
+                .needsAgreement(needsAgreement)
+                .updated(updated)
+                .requiresReconsent(currentVersion.getRequiresReconsent())
+                .blocking(blocking)
+                .action(action.name())
+                .contentUrl(includeContent ? null : "/api/v1/terms/versions/" + currentVersion.getId())
+                .content(includeContent ? currentVersion.getContent() : null)
+                .build();
+    }
+
+    public static TermResponseDTO.TermVersionDetailResponse toTermVersionDetailResponse(TermVersion termVersion) {
+        return TermResponseDTO.TermVersionDetailResponse.builder()
+                .termCode(termVersion.getTerm().getTermCode())
+                .title(termVersion.getTitle())
+                .required(termVersion.getRequired())
+                .termVersionId(termVersion.getId())
+                .version(termVersion.getVersionLabel())
+                .effectiveFrom(termVersion.getEffectiveFrom())
+                .contentFormat(termVersion.getContentFormat().name())
+                .content(termVersion.getContent())
+                .build();
+    }
+
+    public static UserTermAgreement toUserTermAgreement(
+            User user,
+            TermVersion termVersion,
+            Boolean agreed,
+            AgreementContext context,
+            LocalDateTime decidedAt
+    ) {
+        Term term = termVersion.getTerm();
+
+        return UserTermAgreement.builder()
+                .user(user)
+                .term(term)
+                .termVersion(termVersion)
+                .termCodeSnapshot(term.getTermCode())
+                .versionLabelSnapshot(termVersion.getVersionLabel())
+                .titleSnapshot(termVersion.getTitle())
+                .requiredSnapshot(termVersion.getRequired())
+                .agreed(agreed)
+                .agreementContext(context)
+                .decidedAt(decidedAt)
+                .build();
+    }
+}

--- a/src/main/java/com/melissa/diary/domain/Term.java
+++ b/src/main/java/com/melissa/diary/domain/Term.java
@@ -1,0 +1,47 @@
+package com.melissa.diary.domain;
+
+import com.melissa.diary.domain.common.BaseEntity;
+import com.melissa.diary.domain.enums.TermCategory;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "term",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_term_code", columnNames = "term_code")
+        },
+        indexes = {
+                @Index(name = "idx_term_active_order", columnList = "active,display_order")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Term extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "term_code", nullable = false, length = 50)
+    private String termCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private TermCategory category;
+
+    @Column(name = "display_order", nullable = false)
+    private Integer displayOrder;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean active = true;
+
+    @Version
+    @Column(nullable = false)
+    @Builder.Default
+    private Long version = 0L;
+}

--- a/src/main/java/com/melissa/diary/domain/TermVersion.java
+++ b/src/main/java/com/melissa/diary/domain/TermVersion.java
@@ -1,0 +1,72 @@
+package com.melissa.diary.domain;
+
+import com.melissa.diary.domain.common.BaseEntity;
+import com.melissa.diary.domain.enums.TermContentFormat;
+import com.melissa.diary.domain.enums.TermVersionStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "term_version",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_term_version_term_version", columnNames = {"term_id", "version_label"})
+        },
+        indexes = {
+                @Index(name = "idx_term_version_current", columnList = "term_id,status,effective_from")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TermVersion extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "term_id", nullable = false)
+    private Term term;
+
+    @Column(name = "version_label", nullable = false, length = 20)
+    private String versionLabel;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false)
+    private Boolean required;
+
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    @Column(name = "content_format", nullable = false, length = 20)
+    private TermContentFormat contentFormat = TermContentFormat.TEXT;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    @Column(nullable = false, length = 20)
+    private TermVersionStatus status = TermVersionStatus.DRAFT;
+
+    @Builder.Default
+    @Column(name = "requires_reconsent", nullable = false)
+    private Boolean requiresReconsent = true;
+
+    @Column(name = "effective_from", nullable = false)
+    private LocalDateTime effectiveFrom;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    @Version
+    @Column(nullable = false)
+    @Builder.Default
+    private Long version = 0L;
+}

--- a/src/main/java/com/melissa/diary/domain/UserTermAgreement.java
+++ b/src/main/java/com/melissa/diary/domain/UserTermAgreement.java
@@ -1,0 +1,63 @@
+package com.melissa.diary.domain;
+
+import com.melissa.diary.domain.common.BaseEntity;
+import com.melissa.diary.domain.enums.AgreementContext;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+        name = "user_term_agreement",
+        indexes = {
+                @Index(name = "idx_user_term_agreement_user_term_decided", columnList = "user_id,term_id,decided_at,id"),
+                @Index(name = "idx_user_term_agreement_user_version", columnList = "user_id,term_version_id"),
+                @Index(name = "idx_user_term_agreement_version", columnList = "term_version_id")
+        }
+)
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserTermAgreement extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "term_id", nullable = false)
+    private Term term;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "term_version_id", nullable = false)
+    private TermVersion termVersion;
+
+    @Column(name = "term_code_snapshot", nullable = false, length = 50)
+    private String termCodeSnapshot;
+
+    @Column(name = "version_label_snapshot", nullable = false, length = 20)
+    private String versionLabelSnapshot;
+
+    @Column(name = "title_snapshot", nullable = false, length = 100)
+    private String titleSnapshot;
+
+    @Column(name = "required_snapshot", nullable = false)
+    private Boolean requiredSnapshot;
+
+    @Column(nullable = false)
+    private Boolean agreed;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "agreement_context", nullable = false, length = 30)
+    private AgreementContext agreementContext;
+
+    @Column(name = "decided_at", nullable = false)
+    private LocalDateTime decidedAt;
+}

--- a/src/main/java/com/melissa/diary/domain/enums/AgreementContext.java
+++ b/src/main/java/com/melissa/diary/domain/enums/AgreementContext.java
@@ -1,0 +1,9 @@
+package com.melissa.diary.domain.enums;
+
+public enum AgreementContext {
+    NONE,
+    SIGNUP,
+    RECONSENT,
+    OPTIONAL_UPDATE,
+    WITHDRAWAL
+}

--- a/src/main/java/com/melissa/diary/domain/enums/AgreementStatusReason.java
+++ b/src/main/java/com/melissa/diary/domain/enums/AgreementStatusReason.java
@@ -1,0 +1,8 @@
+package com.melissa.diary.domain.enums;
+
+public enum AgreementStatusReason {
+    NONE,
+    INITIAL_REQUIRED_TERMS,
+    UPDATED_REQUIRED_TERMS,
+    OPTIONAL_TERMS_AVAILABLE
+}

--- a/src/main/java/com/melissa/diary/domain/enums/TermAgreementAction.java
+++ b/src/main/java/com/melissa/diary/domain/enums/TermAgreementAction.java
@@ -1,0 +1,9 @@
+package com.melissa.diary.domain.enums;
+
+public enum TermAgreementAction {
+    NONE,
+    INITIAL_AGREEMENT_REQUIRED,
+    RECONSENT_REQUIRED,
+    OPTIONAL_CONSENT_AVAILABLE,
+    OPTIONAL_RECONSENT_AVAILABLE
+}

--- a/src/main/java/com/melissa/diary/domain/enums/TermCategory.java
+++ b/src/main/java/com/melissa/diary/domain/enums/TermCategory.java
@@ -1,0 +1,7 @@
+package com.melissa.diary.domain.enums;
+
+public enum TermCategory {
+    SERVICE,
+    PRIVACY,
+    MARKETING
+}

--- a/src/main/java/com/melissa/diary/domain/enums/TermContentFormat.java
+++ b/src/main/java/com/melissa/diary/domain/enums/TermContentFormat.java
@@ -1,0 +1,7 @@
+package com.melissa.diary.domain.enums;
+
+public enum TermContentFormat {
+    TEXT,
+    HTML,
+    MARKDOWN
+}

--- a/src/main/java/com/melissa/diary/domain/enums/TermVersionStatus.java
+++ b/src/main/java/com/melissa/diary/domain/enums/TermVersionStatus.java
@@ -1,0 +1,7 @@
+package com.melissa.diary.domain.enums;
+
+public enum TermVersionStatus {
+    DRAFT,
+    PUBLISHED,
+    ARCHIVED
+}

--- a/src/main/java/com/melissa/diary/repository/TermRepository.java
+++ b/src/main/java/com/melissa/diary/repository/TermRepository.java
@@ -1,0 +1,14 @@
+package com.melissa.diary.repository;
+
+import com.melissa.diary.domain.Term;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface TermRepository extends JpaRepository<Term, Long> {
+
+    List<Term> findByActiveTrueOrderByDisplayOrderAsc();
+
+    Optional<Term> findByTermCode(String termCode);
+}

--- a/src/main/java/com/melissa/diary/repository/TermVersionRepository.java
+++ b/src/main/java/com/melissa/diary/repository/TermVersionRepository.java
@@ -1,0 +1,30 @@
+package com.melissa.diary.repository;
+
+import com.melissa.diary.domain.TermVersion;
+import com.melissa.diary.domain.enums.TermVersionStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface TermVersionRepository extends JpaRepository<TermVersion, Long> {
+
+    @EntityGraph(attributePaths = "term")
+    List<TermVersion> findByTermIdInAndStatusAndEffectiveFromLessThanEqual(
+            List<Long> termIds,
+            TermVersionStatus status,
+            LocalDateTime effectiveFrom
+    );
+
+    @Query("""
+            SELECT tv
+            FROM TermVersion tv
+            JOIN FETCH tv.term
+            WHERE tv.id = :termVersionId
+            """)
+    Optional<TermVersion> findByIdWithTerm(@Param("termVersionId") Long termVersionId);
+}

--- a/src/main/java/com/melissa/diary/repository/UserTermAgreementRepository.java
+++ b/src/main/java/com/melissa/diary/repository/UserTermAgreementRepository.java
@@ -1,0 +1,13 @@
+package com.melissa.diary.repository;
+
+import com.melissa.diary.domain.UserTermAgreement;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserTermAgreementRepository extends JpaRepository<UserTermAgreement, Long> {
+
+    @EntityGraph(attributePaths = {"term", "termVersion"})
+    List<UserTermAgreement> findByUserIdAndTermIdIn(Long userId, List<Long> termIds);
+}

--- a/src/main/java/com/melissa/diary/service/TermAgreementService.java
+++ b/src/main/java/com/melissa/diary/service/TermAgreementService.java
@@ -1,0 +1,346 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.converter.TermConverter;
+import com.melissa.diary.domain.Term;
+import com.melissa.diary.domain.TermVersion;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.UserTermAgreement;
+import com.melissa.diary.domain.enums.AgreementContext;
+import com.melissa.diary.domain.enums.AgreementStatusReason;
+import com.melissa.diary.domain.enums.TermAgreementAction;
+import com.melissa.diary.domain.enums.TermVersionStatus;
+import com.melissa.diary.repository.TermRepository;
+import com.melissa.diary.repository.TermVersionRepository;
+import com.melissa.diary.repository.UserRepository;
+import com.melissa.diary.repository.UserTermAgreementRepository;
+import com.melissa.diary.web.dto.TermRequestDTO;
+import com.melissa.diary.web.dto.TermResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TermAgreementService {
+
+    private final UserRepository userRepository;
+    private final TermRepository termRepository;
+    private final TermVersionRepository termVersionRepository;
+    private final UserTermAgreementRepository userTermAgreementRepository;
+
+    @Transactional(readOnly = true)
+    public TermResponseDTO.AgreementStatusResponse getAgreementStatus(Long userId) {
+        findUser(userId);
+        List<ComputedTermStatus> statuses = loadTermStatuses(userId, LocalDateTime.now());
+        return toAgreementStatusResponse(statuses, false);
+    }
+
+    @Transactional(readOnly = true)
+    public TermResponseDTO.AgreementStatusResponse getAgreementScreen(Long userId) {
+        findUser(userId);
+        List<ComputedTermStatus> statuses = loadTermStatuses(userId, LocalDateTime.now());
+        return toAgreementStatusResponse(statuses, true);
+    }
+
+    @Transactional(readOnly = true)
+    public TermResponseDTO.TermVersionDetailResponse getTermVersion(Long termVersionId) {
+        TermVersion termVersion = termVersionRepository.findByIdWithTerm(termVersionId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.TERM_VERSION_NOT_FOUND));
+        validatePublishedAndEffective(termVersion, LocalDateTime.now());
+        return TermConverter.toTermVersionDetailResponse(termVersion);
+    }
+
+    @Transactional
+    public TermResponseDTO.SubmitAgreementsResponse submitAgreements(
+            Long userId,
+            TermRequestDTO.SubmitAgreementsRequest request
+    ) {
+        User user = findUser(userId);
+        LocalDateTime now = LocalDateTime.now();
+        List<ComputedTermStatus> currentStatuses = loadTermStatuses(userId, now);
+
+        validateRequiredAgreements(currentStatuses, request);
+
+        Map<Long, ComputedTermStatus> statusByTermId = currentStatuses.stream()
+                .collect(Collectors.toMap(status -> status.currentVersion().getTerm().getId(), Function.identity()));
+
+        for (TermRequestDTO.AgreementDecisionRequest decision : request.getAgreements()) {
+            TermVersion requestedVersion = termVersionRepository.findByIdWithTerm(decision.getTermVersionId())
+                    .orElseThrow(() -> new ErrorHandler(ErrorStatus.TERM_VERSION_NOT_FOUND));
+            validatePublishedAndEffective(requestedVersion, now);
+
+            ComputedTermStatus termStatus = statusByTermId.get(requestedVersion.getTerm().getId());
+            if (termStatus == null || !sameId(termStatus.currentVersion().getId(), requestedVersion.getId())) {
+                throw new ErrorHandler(ErrorStatus.TERM_VERSION_NOT_CURRENT);
+            }
+
+            if (Boolean.TRUE.equals(requestedVersion.getRequired()) && !Boolean.TRUE.equals(decision.getAgreed())) {
+                throw new ErrorHandler(ErrorStatus.TERM_REQUIRED_AGREEMENT_REJECTED);
+            }
+
+            if (isNoop(termStatus.latestAgreement(), requestedVersion, decision.getAgreed())) {
+                continue;
+            }
+
+            UserTermAgreement agreement = TermConverter.toUserTermAgreement(
+                    user,
+                    requestedVersion,
+                    decision.getAgreed(),
+                    request.getContext(),
+                    now
+            );
+            userTermAgreementRepository.save(agreement);
+        }
+
+        List<ComputedTermStatus> updatedStatuses = loadTermStatuses(userId, LocalDateTime.now());
+        AgreementStatusReason reason = calculateReason(updatedStatuses);
+        return TermResponseDTO.SubmitAgreementsResponse.builder()
+                .agreementRequired(hasBlockingTerm(updatedStatuses))
+                .reason(reason.name())
+                .build();
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    private List<ComputedTermStatus> loadTermStatuses(Long userId, LocalDateTime now) {
+        List<Term> terms = termRepository.findByActiveTrueOrderByDisplayOrderAsc();
+        if (terms.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> termIds = terms.stream()
+                .map(Term::getId)
+                .toList();
+
+        Map<Long, TermVersion> currentVersionByTermId = termVersionRepository
+                .findByTermIdInAndStatusAndEffectiveFromLessThanEqual(termIds, TermVersionStatus.PUBLISHED, now)
+                .stream()
+                .collect(Collectors.toMap(
+                        termVersion -> termVersion.getTerm().getId(),
+                        Function.identity(),
+                        this::latestTermVersion
+                ));
+
+        Map<Long, UserTermAgreement> latestAgreementByTermId = userTermAgreementRepository
+                .findByUserIdAndTermIdIn(userId, termIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        agreement -> agreement.getTerm().getId(),
+                        Function.identity(),
+                        this::latestAgreement
+                ));
+
+        return terms.stream()
+                .map(term -> {
+                    TermVersion currentVersion = currentVersionByTermId.get(term.getId());
+                    if (currentVersion == null) {
+                        throw new ErrorHandler(ErrorStatus.TERM_VERSION_NOT_FOUND);
+                    }
+                    return computeStatus(currentVersion, latestAgreementByTermId.get(term.getId()));
+                })
+                .toList();
+    }
+
+    private ComputedTermStatus computeStatus(TermVersion currentVersion, UserTermAgreement latestAgreement) {
+        boolean required = Boolean.TRUE.equals(currentVersion.getRequired());
+        boolean requiresReconsent = Boolean.TRUE.equals(currentVersion.getRequiresReconsent());
+        boolean latestAgreed = latestAgreement != null && Boolean.TRUE.equals(latestAgreement.getAgreed());
+        boolean agreed = latestAgreement != null
+                && sameId(latestAgreement.getTermVersion().getId(), currentVersion.getId())
+                && latestAgreed;
+        boolean updated = latestAgreement != null
+                && !sameId(latestAgreement.getTermVersion().getId(), currentVersion.getId());
+        boolean blocking = required
+                && !agreed
+                && (latestAgreement == null || !latestAgreed || requiresReconsent);
+
+        TermAgreementAction action = calculateAction(
+                required,
+                requiresReconsent,
+                latestAgreement,
+                latestAgreed,
+                agreed,
+                updated
+        );
+        boolean needsAgreement = blocking || action != TermAgreementAction.NONE;
+
+        return new ComputedTermStatus(
+                currentVersion,
+                latestAgreement,
+                agreed,
+                needsAgreement,
+                updated,
+                blocking,
+                action
+        );
+    }
+
+    private TermAgreementAction calculateAction(
+            boolean required,
+            boolean requiresReconsent,
+            UserTermAgreement latestAgreement,
+            boolean latestAgreed,
+            boolean agreed,
+            boolean updated
+    ) {
+        if (agreed) {
+            return TermAgreementAction.NONE;
+        }
+        if (latestAgreement == null) {
+            return required
+                    ? TermAgreementAction.INITIAL_AGREEMENT_REQUIRED
+                    : TermAgreementAction.OPTIONAL_CONSENT_AVAILABLE;
+        }
+        if (updated && required && requiresReconsent) {
+            return TermAgreementAction.RECONSENT_REQUIRED;
+        }
+        if (updated && !required && requiresReconsent) {
+            return latestAgreed
+                    ? TermAgreementAction.OPTIONAL_RECONSENT_AVAILABLE
+                    : TermAgreementAction.OPTIONAL_CONSENT_AVAILABLE;
+        }
+        if (required && !latestAgreed) {
+            return TermAgreementAction.INITIAL_AGREEMENT_REQUIRED;
+        }
+        return TermAgreementAction.NONE;
+    }
+
+    private TermResponseDTO.AgreementStatusResponse toAgreementStatusResponse(
+            List<ComputedTermStatus> statuses,
+            boolean includeContent
+    ) {
+        AgreementStatusReason reason = calculateReason(statuses);
+        AgreementContext submitContext = calculateSubmitContext(reason);
+
+        return TermResponseDTO.AgreementStatusResponse.builder()
+                .agreementRequired(hasBlockingTerm(statuses))
+                .reason(reason.name())
+                .submitContext(submitContext.name())
+                .terms(statuses.stream()
+                        .map(status -> TermConverter.toTermItemResponse(
+                                status.currentVersion(),
+                                status.latestAgreement(),
+                                status.agreed(),
+                                status.needsAgreement(),
+                                status.updated(),
+                                status.blocking(),
+                                status.action(),
+                                includeContent
+                        ))
+                        .toList())
+                .build();
+    }
+
+    private void validateRequiredAgreements(
+            List<ComputedTermStatus> statuses,
+            TermRequestDTO.SubmitAgreementsRequest request
+    ) {
+        Set<Long> agreedVersionIds = request.getAgreements().stream()
+                .filter(decision -> Boolean.TRUE.equals(decision.getAgreed()))
+                .map(TermRequestDTO.AgreementDecisionRequest::getTermVersionId)
+                .collect(Collectors.toSet());
+
+        boolean missingRequiredAgreement = statuses.stream()
+                .filter(ComputedTermStatus::blocking)
+                .map(status -> status.currentVersion().getId())
+                .anyMatch(versionId -> !agreedVersionIds.contains(versionId));
+
+        if (missingRequiredAgreement) {
+            throw new ErrorHandler(ErrorStatus.TERM_REQUIRED_AGREEMENT_MISSING);
+        }
+    }
+
+    private void validatePublishedAndEffective(TermVersion termVersion, LocalDateTime now) {
+        if (termVersion.getStatus() != TermVersionStatus.PUBLISHED
+                || termVersion.getEffectiveFrom() == null
+                || termVersion.getEffectiveFrom().isAfter(now)) {
+            throw new ErrorHandler(ErrorStatus.TERM_VERSION_NOT_PUBLISHED);
+        }
+    }
+
+    private boolean isNoop(UserTermAgreement latestAgreement, TermVersion requestedVersion, Boolean agreed) {
+        return latestAgreement != null
+                && sameId(latestAgreement.getTermVersion().getId(), requestedVersion.getId())
+                && Objects.equals(latestAgreement.getAgreed(), agreed);
+    }
+
+    private boolean hasBlockingTerm(List<ComputedTermStatus> statuses) {
+        return statuses.stream().anyMatch(ComputedTermStatus::blocking);
+    }
+
+    private AgreementStatusReason calculateReason(List<ComputedTermStatus> statuses) {
+        if (hasBlockingTerm(statuses)) {
+            boolean initialRequired = statuses.stream()
+                    .filter(ComputedTermStatus::blocking)
+                    .anyMatch(status -> status.action() == TermAgreementAction.INITIAL_AGREEMENT_REQUIRED);
+            return initialRequired
+                    ? AgreementStatusReason.INITIAL_REQUIRED_TERMS
+                    : AgreementStatusReason.UPDATED_REQUIRED_TERMS;
+        }
+
+        boolean optionalAvailable = statuses.stream()
+                .anyMatch(status -> status.action() == TermAgreementAction.OPTIONAL_CONSENT_AVAILABLE
+                        || status.action() == TermAgreementAction.OPTIONAL_RECONSENT_AVAILABLE);
+        return optionalAvailable
+                ? AgreementStatusReason.OPTIONAL_TERMS_AVAILABLE
+                : AgreementStatusReason.NONE;
+    }
+
+    private AgreementContext calculateSubmitContext(AgreementStatusReason reason) {
+        return switch (reason) {
+            case INITIAL_REQUIRED_TERMS -> AgreementContext.SIGNUP;
+            case UPDATED_REQUIRED_TERMS -> AgreementContext.RECONSENT;
+            case OPTIONAL_TERMS_AVAILABLE -> AgreementContext.OPTIONAL_UPDATE;
+            case NONE -> AgreementContext.NONE;
+        };
+    }
+
+    private TermVersion latestTermVersion(TermVersion left, TermVersion right) {
+        return termVersionComparator().compare(left, right) >= 0 ? left : right;
+    }
+
+    private UserTermAgreement latestAgreement(UserTermAgreement left, UserTermAgreement right) {
+        return agreementComparator().compare(left, right) >= 0 ? left : right;
+    }
+
+    private Comparator<TermVersion> termVersionComparator() {
+        return Comparator
+                .comparing(TermVersion::getEffectiveFrom, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(TermVersion::getId, Comparator.nullsLast(Comparator.naturalOrder()));
+    }
+
+    private Comparator<UserTermAgreement> agreementComparator() {
+        return Comparator
+                .comparing(UserTermAgreement::getDecidedAt, Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(UserTermAgreement::getId, Comparator.nullsLast(Comparator.naturalOrder()));
+    }
+
+    private boolean sameId(Long left, Long right) {
+        return Objects.equals(left, right);
+    }
+
+    private record ComputedTermStatus(
+            TermVersion currentVersion,
+            UserTermAgreement latestAgreement,
+            Boolean agreed,
+            Boolean needsAgreement,
+            Boolean updated,
+            Boolean blocking,
+            TermAgreementAction action
+    ) {
+    }
+}

--- a/src/main/java/com/melissa/diary/web/controller/ExpoPushTokenController.java
+++ b/src/main/java/com/melissa/diary/web/controller/ExpoPushTokenController.java
@@ -24,7 +24,7 @@ import java.security.Principal;
 import java.util.List;
 
 @RestController
-@Tag(name = "ExpoPushTokenAPI", description = "Expo Push token management API")
+@Tag(name = "ExpoPushTokenAPI", description = "Expo Push Token 관리 API")
 @RequestMapping("/api/v1/expo-push-tokens")
 @RequiredArgsConstructor
 @Slf4j
@@ -38,8 +38,15 @@ public class ExpoPushTokenController {
     private final IdempotencyService idempotencyService;
 
     @Operation(
-            summary = "Register Expo Push Token",
-            description = "Registers or updates the Expo Push Token for the authenticated user."
+            summary = "Expo Push Token 등록/갱신",
+            description = """
+                    현재 로그인한 사용자의 Expo Push Token을 등록하거나 기존 토큰 정보를 갱신합니다.
+                    - 인증 필요 (Bearer JWT)
+                    - userId는 토큰(subject) 기반으로 서버에서 결정
+                    - `platform` 후보: ANDROID, IOS
+                    - `expoPushToken` 형식: ExponentPushToken[...]
+                    - `Idempotency-Key` 헤더를 전달하면 같은 요청의 중복 처리를 방지합니다.
+                    """
     )
     @PostMapping
     public ApiResponse<ExpoPushTokenResponseDTO.TokenResponse> registerToken(
@@ -76,8 +83,13 @@ public class ExpoPushTokenController {
     }
 
     @Operation(
-            summary = "Get Expo Push Tokens",
-            description = "Returns all Expo Push Tokens registered for the authenticated user."
+            summary = "내 Expo Push Token 목록 조회",
+            description = """
+                    현재 로그인한 사용자에게 연결된 Expo Push Token 목록을 반환합니다.
+                    - 인증 필요 (Bearer JWT)
+                    - `platform` 후보: ANDROID, IOS
+                    - `invalid=true`이면 발송 실패 등으로 무효 처리된 토큰입니다.
+                    """
     )
     @GetMapping
     public ApiResponse<List<ExpoPushTokenResponseDTO.TokenResponse>> getUserTokens(Principal principal) {
@@ -89,12 +101,17 @@ public class ExpoPushTokenController {
     }
 
     @Operation(
-            summary = "Delete Expo Push Token",
-            description = "Deletes a specific Expo Push Token."
+            summary = "Expo Push Token 삭제",
+            description = """
+                    특정 Expo Push Token을 삭제합니다.
+                    - 인증 필요 (Bearer JWT)
+                    - 삭제 대상 토큰은 path variable로 전달합니다.
+                    - `Idempotency-Key` 헤더를 전달하면 같은 삭제 요청의 중복 처리를 방지합니다.
+                    """
     )
     @DeleteMapping("/{expoPushToken}")
     public ApiResponse<ExpoPushTokenResponseDTO.DeleteResponse> deleteToken(
-            @Parameter(description = "Expo Push Token to delete", required = true,
+            @Parameter(description = "삭제할 Expo Push Token. 형식: ExponentPushToken[...]", required = true,
                     example = "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]")
             @PathVariable String expoPushToken,
             @RequestHeader(value = IDEMPOTENCY_HEADER, required = false) String idempotencyKey,

--- a/src/main/java/com/melissa/diary/web/controller/TermController.java
+++ b/src/main/java/com/melissa/diary/web/controller/TermController.java
@@ -1,0 +1,90 @@
+package com.melissa.diary.web.controller;
+
+import com.melissa.diary.apiPayload.ApiResponse;
+import com.melissa.diary.service.TermAgreementService;
+import com.melissa.diary.web.dto.TermRequestDTO;
+import com.melissa.diary.web.dto.TermResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+@RestController
+@Tag(name = "TermAPI", description = "약관 동의 API")
+@RequestMapping("/api/v1/terms")
+@RequiredArgsConstructor
+public class TermController {
+
+    private final TermAgreementService termAgreementService;
+
+    @Operation(
+            summary = "내 약관 동의 상태 조회",
+            description = """
+                    현재 로그인한 사용자의 약관 동의 상태와 서비스 진입 차단 여부를 반환합니다.
+                    - 인증 필요 (Bearer JWT)
+                    - 약관 본문은 포함하지 않습니다.
+                    - 프론트는 `agreementRequired`와 각 약관의 `blocking`, `action`을 기준으로 분기합니다.
+                    """
+    )
+    @GetMapping("/agreement-status")
+    public ApiResponse<TermResponseDTO.AgreementStatusResponse> getAgreementStatus(Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+        return ApiResponse.onSuccess(termAgreementService.getAgreementStatus(userId));
+    }
+
+    @Operation(
+            summary = "약관 동의 화면 조회",
+            description = """
+                    현재 로그인한 사용자의 약관 동의 화면 구성 데이터를 반환합니다.
+                    - 인증 필요 (Bearer JWT)
+                    - 약관 본문을 포함합니다.
+                    - 프론트 약관 동의 화면 렌더링용 API입니다.
+                    """
+    )
+    @GetMapping("/agreement-screen")
+    public ApiResponse<TermResponseDTO.AgreementStatusResponse> getAgreementScreen(Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+        return ApiResponse.onSuccess(termAgreementService.getAgreementScreen(userId));
+    }
+
+    @Operation(
+            summary = "약관 버전 본문 조회",
+            description = """
+                    특정 약관 버전의 상세 본문을 반환합니다.
+                    - 인증 필요 (Bearer JWT)
+                    - 발행되지 않았거나 아직 효력이 발생하지 않은 버전은 조회할 수 없습니다.
+                    """
+    )
+    @GetMapping("/versions/{termVersionId}")
+    public ApiResponse<TermResponseDTO.TermVersionDetailResponse> getTermVersion(
+            @PathVariable Long termVersionId
+    ) {
+        return ApiResponse.onSuccess(termAgreementService.getTermVersion(termVersionId));
+    }
+
+    @Operation(
+            summary = "약관 동의 제출",
+            description = """
+                    현재 로그인한 사용자의 약관 동의/거절 결정을 저장합니다.
+                    - 인증 필요 (Bearer JWT)
+                    - 필수 약관은 반드시 true로 제출해야 합니다.
+                    - 선택 약관은 false 제출이 가능하며 이력으로 저장됩니다.
+                    """
+    )
+    @PostMapping("/agreements")
+    public ApiResponse<TermResponseDTO.SubmitAgreementsResponse> submitAgreements(
+            Principal principal,
+            @Valid @RequestBody TermRequestDTO.SubmitAgreementsRequest request
+    ) {
+        Long userId = Long.parseLong(principal.getName());
+        return ApiResponse.onSuccess(termAgreementService.submitAgreements(userId, request));
+    }
+}

--- a/src/main/java/com/melissa/diary/web/controller/TermController.java
+++ b/src/main/java/com/melissa/diary/web/controller/TermController.java
@@ -32,6 +32,10 @@ public class TermController {
                     - 인증 필요 (Bearer JWT)
                     - 약관 본문은 포함하지 않습니다.
                     - 프론트는 `agreementRequired`와 각 약관의 `blocking`, `action`을 기준으로 분기합니다.
+                    - `reason` 후보: NONE, INITIAL_REQUIRED_TERMS, UPDATED_REQUIRED_TERMS, OPTIONAL_TERMS_AVAILABLE
+                    - `submitContext` 후보: NONE, SIGNUP, RECONSENT, OPTIONAL_UPDATE
+                    - `terms[].termCode` 초기 후보: SERVICE_TERMS, PRIVACY_POLICY, MARKETING
+                    - `terms[].action` 후보: NONE, INITIAL_AGREEMENT_REQUIRED, RECONSENT_REQUIRED, OPTIONAL_CONSENT_AVAILABLE, OPTIONAL_RECONSENT_AVAILABLE
                     """
     )
     @GetMapping("/agreement-status")
@@ -47,6 +51,11 @@ public class TermController {
                     - 인증 필요 (Bearer JWT)
                     - 약관 본문을 포함합니다.
                     - 프론트 약관 동의 화면 렌더링용 API입니다.
+                    - 응답 구조는 agreement-status와 같고 `terms[].content`가 포함됩니다.
+                    - `reason` 후보: NONE, INITIAL_REQUIRED_TERMS, UPDATED_REQUIRED_TERMS, OPTIONAL_TERMS_AVAILABLE
+                    - `submitContext` 후보: NONE, SIGNUP, RECONSENT, OPTIONAL_UPDATE
+                    - `terms[].termCode` 초기 후보: SERVICE_TERMS, PRIVACY_POLICY, MARKETING
+                    - `terms[].action` 후보: NONE, INITIAL_AGREEMENT_REQUIRED, RECONSENT_REQUIRED, OPTIONAL_CONSENT_AVAILABLE, OPTIONAL_RECONSENT_AVAILABLE
                     """
     )
     @GetMapping("/agreement-screen")
@@ -61,6 +70,8 @@ public class TermController {
                     특정 약관 버전의 상세 본문을 반환합니다.
                     - 인증 필요 (Bearer JWT)
                     - 발행되지 않았거나 아직 효력이 발생하지 않은 버전은 조회할 수 없습니다.
+                    - `termCode` 초기 후보: SERVICE_TERMS, PRIVACY_POLICY, MARKETING
+                    - `contentFormat` 후보: TEXT, HTML, MARKDOWN
                     """
     )
     @GetMapping("/versions/{termVersionId}")
@@ -77,6 +88,9 @@ public class TermController {
                     - 인증 필요 (Bearer JWT)
                     - 필수 약관은 반드시 true로 제출해야 합니다.
                     - 선택 약관은 false 제출이 가능하며 이력으로 저장됩니다.
+                    - `context` 후보: SIGNUP, RECONSENT, OPTIONAL_UPDATE, WITHDRAWAL
+                    - `termVersionId`는 agreement-status 또는 agreement-screen의 `terms[].currentTermVersionId` 값을 사용합니다.
+                    - 필수 약관 누락 또는 필수 약관 `agreed=false` 제출 시 400으로 응답합니다.
                     """
     )
     @PostMapping("/agreements")

--- a/src/main/java/com/melissa/diary/web/dto/EntitlementResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/EntitlementResponseDTO.java
@@ -26,13 +26,22 @@ public class EntitlementResponseDTO {
     @Schema(description = "활성 권한 요약")
     public static class EntitlementSummary {
 
-        @Schema(description = "권한 타입", example = "REMOVE_ADS")
+        @Schema(
+                description = "권한 타입. enum 후보: REMOVE_ADS(광고 제거), PREMIUM, EXTRA_STORAGE, AI_CREDIT. 현재 결제 상품은 REMOVE_ADS만 사용",
+                example = "REMOVE_ADS",
+                allowableValues = {"REMOVE_ADS", "PREMIUM", "EXTRA_STORAGE", "AI_CREDIT"}
+        )
         private String type;
 
         @Schema(description = "권한 활성 여부", example = "true")
         private Boolean active;
 
-        @Schema(description = "권한이 부여된 결제 플랫폼", example = "GOOGLE", nullable = true)
+        @Schema(
+                description = "권한이 부여된 결제 플랫폼. 후보: GOOGLE, APPLE. 결제 외 수동 부여 등 플랫폼이 없으면 null",
+                example = "GOOGLE",
+                allowableValues = {"GOOGLE", "APPLE"},
+                nullable = true
+        )
         private String sourcePlatform;
 
         @Schema(description = "권한 부여 시각")

--- a/src/main/java/com/melissa/diary/web/dto/ExpoPushTokenRequestDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/ExpoPushTokenRequestDTO.java
@@ -21,20 +21,22 @@ public class ExpoPushTokenRequestDTO {
         @NotBlank(message = "Expo Push Token은 필수입니다.")
         @Pattern(regexp = "^ExponentPushToken\\[.+\\]$", 
                  message = "유효한 Expo Push Token 형식이 아닙니다. (ExponentPushToken[...])")
-        @Schema(description = "Expo Push Token", 
+        @Schema(description = "Expo Push Token. 형식: ExponentPushToken[...]",
                 example = "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]",
-                required = true)
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private String expoPushToken;
         
         @NotNull(message = "플랫폼 정보는 필수입니다.")
-        @Schema(description = "플랫폼 (ANDROID 또는 IOS)", 
+        @Schema(description = "클라이언트 플랫폼. 후보: ANDROID, IOS",
                 example = "ANDROID",
                 allowableValues = {"ANDROID", "IOS"},
-                required = true)
+                requiredMode = Schema.RequiredMode.REQUIRED)
         private Platform platform;
         
-        @Schema(description = "기기 ID (선택사항) nullable", 
-                example = "device-uuid-1234")
+        @Schema(description = "기기 ID. 앱에서 관리하는 디바이스 식별자가 있으면 전달하며, 없으면 생략 가능",
+                example = "device-uuid-1234",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+                nullable = true)
         private String deviceId;
     }
 }

--- a/src/main/java/com/melissa/diary/web/dto/ExpoPushTokenResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/ExpoPushTokenResponseDTO.java
@@ -21,10 +21,10 @@ public class ExpoPushTokenResponseDTO {
         @Schema(description = "토큰 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long id;
         
-        @Schema(description = "Expo Push Token", example = "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "Expo Push Token. 형식: ExponentPushToken[...]", example = "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]", requiredMode = Schema.RequiredMode.REQUIRED)
         private String expoPushToken;
         
-        @Schema(description = "플랫폼", example = "ANDROID", 
+        @Schema(description = "클라이언트 플랫폼. 후보: ANDROID, IOS", example = "ANDROID",
                 allowableValues = {"ANDROID", "IOS"},
                 requiredMode = Schema.RequiredMode.REQUIRED)
         private Platform platform;
@@ -32,7 +32,7 @@ public class ExpoPushTokenResponseDTO {
         @Schema(description = "기기 ID", example = "device-uuid-1234", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String deviceId;
         
-        @Schema(description = "유효하지 않은 토큰 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "유효하지 않은 토큰 여부. true이면 발송 실패 등으로 무효 처리된 토큰", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean invalid;
         
         @Schema(description = "생성일시", example = "2025-01-01T12:00:00", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/com/melissa/diary/web/dto/PaymentRequestDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/PaymentRequestDTO.java
@@ -24,7 +24,7 @@ public class PaymentRequestDTO {
     public static class GoogleVerifyRequest {
 
         @NotBlank
-        @Schema(description = "Google Play 상품 ID", example = "premium", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "Google Play 상품 ID. 현재 후보: premium(광고 제거)", example = "premium", allowableValues = {"premium"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String productId;
 
         @NotBlank
@@ -61,7 +61,7 @@ public class PaymentRequestDTO {
     public static class AppleVerifyRequest {
 
         @NotBlank
-        @Schema(description = "Apple 인앱결제 상품 ID", example = "com.melissa.melissaFE.premium", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "Apple 인앱결제 상품 ID. 현재 후보: com.melissa.melissaFE.premium(광고 제거)", example = "com.melissa.melissaFE.premium", allowableValues = {"com.melissa.melissaFE.premium"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String productId;
 
         @NotBlank
@@ -72,7 +72,7 @@ public class PaymentRequestDTO {
         private String originalTransactionId;
 
         @NotBlank
-        @Schema(description = "Apple 거래 환경. 테스트 결제는 SANDBOX, 상용 결제는 PRODUCTION", example = "SANDBOX", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "Apple 거래 환경. 후보: SANDBOX(테스트 결제), PRODUCTION(상용 결제)", example = "SANDBOX", allowableValues = {"SANDBOX", "PRODUCTION"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String environment;
 
         @NotBlank

--- a/src/main/java/com/melissa/diary/web/dto/PaymentResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/PaymentResponseDTO.java
@@ -20,13 +20,13 @@ public class PaymentResponseDTO {
         @Schema(description = "백엔드 결제 내역 ID", example = "1")
         private Long paymentId;
 
-        @Schema(description = "결제 플랫폼", example = "GOOGLE")
+        @Schema(description = "결제 플랫폼. 후보: GOOGLE, APPLE", example = "GOOGLE", allowableValues = {"GOOGLE", "APPLE"})
         private String platform;
 
-        @Schema(description = "백엔드 내부 상품 ID. 스토어 상품 ID가 아니라 `remove_ads`로 반환", example = "remove_ads")
+        @Schema(description = "백엔드 내부 상품 ID. 현재 후보: remove_ads(광고 제거). 스토어 상품 ID가 아니라 내부 상품 ID로 반환", example = "remove_ads", allowableValues = {"remove_ads"})
         private String productId;
 
-        @Schema(description = "결제 상태", example = "PURCHASED")
+        @Schema(description = "결제 상태. 후보: PENDING, PURCHASED, FAILED, REFUNDED, REVOKED", example = "PURCHASED", allowableValues = {"PENDING", "PURCHASED", "FAILED", "REFUNDED", "REVOKED"})
         private String status;
 
         @Schema(description = "검증 성공으로 부여된 권한 요약")
@@ -54,7 +54,7 @@ public class PaymentResponseDTO {
     @AllArgsConstructor
     @Schema(description = "결제 권한 요약")
     public static class EntitlementSummary {
-        @Schema(description = "권한 타입", example = "REMOVE_ADS")
+        @Schema(description = "권한 타입. enum 후보: REMOVE_ADS(광고 제거), PREMIUM, EXTRA_STORAGE, AI_CREDIT. 현재 결제 상품은 REMOVE_ADS만 사용", example = "REMOVE_ADS", allowableValues = {"REMOVE_ADS", "PREMIUM", "EXTRA_STORAGE", "AI_CREDIT"})
         private String type;
 
         @Schema(description = "권한 활성 여부. true면 광고 제거 적용 가능", example = "true")
@@ -86,16 +86,16 @@ public class PaymentResponseDTO {
         @Schema(description = "백엔드 결제 내역 ID", example = "1")
         private Long paymentId;
 
-        @Schema(description = "결제 플랫폼", example = "APPLE")
+        @Schema(description = "결제 플랫폼. 후보: GOOGLE, APPLE", example = "APPLE", allowableValues = {"GOOGLE", "APPLE"})
         private String platform;
 
-        @Schema(description = "백엔드 내부 상품 ID", example = "remove_ads")
+        @Schema(description = "백엔드 내부 상품 ID. 현재 후보: remove_ads(광고 제거)", example = "remove_ads", allowableValues = {"remove_ads"})
         private String productId;
 
-        @Schema(description = "결제 상태", example = "PURCHASED")
+        @Schema(description = "결제 상태. 후보: PENDING, PURCHASED, FAILED, REFUNDED, REVOKED", example = "PURCHASED", allowableValues = {"PENDING", "PURCHASED", "FAILED", "REFUNDED", "REVOKED"})
         private String status;
 
-        @Schema(description = "복원된 권한 타입", example = "REMOVE_ADS")
+        @Schema(description = "복원된 권한 타입. enum 후보: REMOVE_ADS(광고 제거), PREMIUM, EXTRA_STORAGE, AI_CREDIT. 현재 결제 상품은 REMOVE_ADS만 사용", example = "REMOVE_ADS", allowableValues = {"REMOVE_ADS", "PREMIUM", "EXTRA_STORAGE", "AI_CREDIT"})
         private String entitlementType;
     }
 
@@ -105,7 +105,7 @@ public class PaymentResponseDTO {
     @AllArgsConstructor
     @Schema(description = "복원 실패 구매 요약")
     public static class FailedPurchase {
-        @Schema(description = "결제 플랫폼", example = "GOOGLE")
+        @Schema(description = "결제 플랫폼. 후보: GOOGLE, APPLE", example = "GOOGLE", allowableValues = {"GOOGLE", "APPLE"})
         private String platform;
 
         @Schema(description = "요청으로 전달된 스토어 상품 ID", example = "premium")
@@ -133,16 +133,16 @@ public class PaymentResponseDTO {
         @Schema(description = "환불 처리 대상 사용자 ID", example = "10")
         private Long userId;
 
-        @Schema(description = "결제 플랫폼", example = "GOOGLE")
+        @Schema(description = "결제 플랫폼. 후보: GOOGLE, APPLE", example = "GOOGLE", allowableValues = {"GOOGLE", "APPLE"})
         private String platform;
 
-        @Schema(description = "백엔드 내부 상품 ID", example = "remove_ads")
+        @Schema(description = "백엔드 내부 상품 ID. 현재 후보: remove_ads(광고 제거)", example = "remove_ads", allowableValues = {"remove_ads"})
         private String productId;
 
-        @Schema(description = "결제 상태", example = "REFUNDED")
+        @Schema(description = "결제 상태. 후보: PENDING, PURCHASED, FAILED, REFUNDED, REVOKED", example = "REFUNDED", allowableValues = {"PENDING", "PURCHASED", "FAILED", "REFUNDED", "REVOKED"})
         private String status;
 
-        @Schema(description = "회수 대상 권한 타입", example = "REMOVE_ADS", nullable = true)
+        @Schema(description = "회수 대상 권한 타입. enum 후보: REMOVE_ADS(광고 제거), PREMIUM, EXTRA_STORAGE, AI_CREDIT. 회수 대상 권한이 없으면 null", example = "REMOVE_ADS", allowableValues = {"REMOVE_ADS", "PREMIUM", "EXTRA_STORAGE", "AI_CREDIT"}, nullable = true)
         private String entitlementType;
 
         @Schema(description = "권한 회수 완료 여부", example = "true")

--- a/src/main/java/com/melissa/diary/web/dto/TermRequestDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/TermRequestDTO.java
@@ -22,12 +22,20 @@ public class TermRequestDTO {
     public static class SubmitAgreementsRequest {
 
         @NotNull
-        @Schema(description = "약관 동의 제출 맥락", example = "SIGNUP", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(
+                description = "약관 동의 제출 맥락. 후보: SIGNUP(최초 동의), RECONSENT(필수 약관 재동의), OPTIONAL_UPDATE(선택 약관 변경/동의), WITHDRAWAL(선택 약관 철회)",
+                example = "SIGNUP",
+                allowableValues = {"SIGNUP", "RECONSENT", "OPTIONAL_UPDATE", "WITHDRAWAL"},
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
         private AgreementContext context;
 
         @Valid
         @NotEmpty
-        @Schema(description = "약관 버전별 동의/거절 결정 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(
+                description = "약관 버전별 동의/거절 결정 목록. 필수 약관은 반드시 agreed=true로 포함해야 하며, 선택 약관은 agreed=false 제출 가능",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
         private List<AgreementDecisionRequest> agreements;
     }
 
@@ -39,11 +47,19 @@ public class TermRequestDTO {
     public static class AgreementDecisionRequest {
 
         @NotNull
-        @Schema(description = "동의 대상 약관 버전 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(
+                description = "동의 대상 약관 버전 ID. agreement-status 또는 agreement-screen 응답의 terms[].currentTermVersionId 값을 전달",
+                example = "1",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
         private Long termVersionId;
 
         @NotNull
-        @Schema(description = "동의 여부. 선택 약관은 false 제출 가능", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(
+                description = "동의 여부. 필수 약관은 true만 가능하며, 선택 약관은 false 제출 가능",
+                example = "true",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
         private Boolean agreed;
     }
 }

--- a/src/main/java/com/melissa/diary/web/dto/TermRequestDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/TermRequestDTO.java
@@ -1,0 +1,49 @@
+package com.melissa.diary.web.dto;
+
+import com.melissa.diary.domain.enums.AgreementContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+public class TermRequestDTO {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "약관 동의 제출 요청")
+    public static class SubmitAgreementsRequest {
+
+        @NotNull
+        @Schema(description = "약관 동의 제출 맥락", example = "SIGNUP", requiredMode = Schema.RequiredMode.REQUIRED)
+        private AgreementContext context;
+
+        @Valid
+        @NotEmpty
+        @Schema(description = "약관 버전별 동의/거절 결정 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+        private List<AgreementDecisionRequest> agreements;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "약관 버전별 동의/거절 결정")
+    public static class AgreementDecisionRequest {
+
+        @NotNull
+        @Schema(description = "동의 대상 약관 버전 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        private Long termVersionId;
+
+        @NotNull
+        @Schema(description = "동의 여부. 선택 약관은 false 제출 가능", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+        private Boolean agreed;
+    }
+}

--- a/src/main/java/com/melissa/diary/web/dto/TermResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/TermResponseDTO.java
@@ -18,13 +18,21 @@ public class TermResponseDTO {
     @Schema(description = "약관 동의 상태 응답")
     public static class AgreementStatusResponse {
 
-        @Schema(description = "서비스 진입 전 약관 동의 화면이 필요한지 여부", example = "true")
+        @Schema(description = "서비스 진입 전 약관 동의 화면이 필요한지 여부. true면 서비스 진입 전 약관 동의 화면으로 이동", example = "true")
         private Boolean agreementRequired;
 
-        @Schema(description = "약관 동의 상태 사유", example = "INITIAL_REQUIRED_TERMS")
+        @Schema(
+                description = "약관 동의 상태 사유. 후보: NONE(필요 없음), INITIAL_REQUIRED_TERMS(최초 필수 약관 동의 필요), UPDATED_REQUIRED_TERMS(개정된 필수 약관 재동의 필요), OPTIONAL_TERMS_AVAILABLE(선택 약관 동의/변경 가능)",
+                example = "INITIAL_REQUIRED_TERMS",
+                allowableValues = {"NONE", "INITIAL_REQUIRED_TERMS", "UPDATED_REQUIRED_TERMS", "OPTIONAL_TERMS_AVAILABLE"}
+        )
         private String reason;
 
-        @Schema(description = "프론트가 동의 제출 시 사용할 맥락", example = "SIGNUP")
+        @Schema(
+                description = "프론트가 POST /api/v1/terms/agreements 호출 시 context로 사용할 값. 후보: NONE, SIGNUP, RECONSENT, OPTIONAL_UPDATE",
+                example = "SIGNUP",
+                allowableValues = {"NONE", "SIGNUP", "RECONSENT", "OPTIONAL_UPDATE"}
+        )
         private String submitContext;
 
         @Schema(description = "현재 사용자 기준 약관 항목 목록")
@@ -38,13 +46,17 @@ public class TermResponseDTO {
     @Schema(description = "약관 항목 응답")
     public static class TermItemResponse {
 
-        @Schema(description = "약관 코드", example = "SERVICE_TERMS")
+        @Schema(
+                description = "약관 코드. 초기 후보: SERVICE_TERMS(서비스 이용약관), PRIVACY_POLICY(개인정보 처리방침), MARKETING(마케팅 정보 수신 동의)",
+                example = "SERVICE_TERMS",
+                allowableValues = {"SERVICE_TERMS", "PRIVACY_POLICY", "MARKETING"}
+        )
         private String termCode;
 
         @Schema(description = "약관 제목", example = "서비스 이용약관")
         private String title;
 
-        @Schema(description = "필수 약관 여부", example = "true")
+        @Schema(description = "필수 약관 여부. true면 동의해야 서비스 이용 가능", example = "true")
         private Boolean required;
 
         @Schema(description = "현재 최신 약관 버전 ID", example = "1")
@@ -56,10 +68,10 @@ public class TermResponseDTO {
         @Schema(description = "사용자가 이전에 결정한 약관 버전. 최초 동의 전이면 null", example = "1.0", nullable = true)
         private String previousVersion;
 
-        @Schema(description = "현재 최신 버전에 동의한 상태인지 여부", example = "false")
+        @Schema(description = "현재 최신 버전에 동의한 상태인지 여부. true면 해당 currentTermVersionId에 이미 동의한 상태", example = "false")
         private Boolean agreed;
 
-        @Schema(description = "이번 화면에서 새 결정을 받아야 하는지 여부", example = "true")
+        @Schema(description = "이번 화면에서 사용자에게 새 동의/거절 결정을 받아야 하는지 여부", example = "true")
         private Boolean needsAgreement;
 
         @Schema(description = "사용자 이전 결정 버전과 현재 최신 버전이 다른지 여부", example = "false")
@@ -68,10 +80,14 @@ public class TermResponseDTO {
         @Schema(description = "현재 최신 버전이 재동의를 요구하는지 여부", example = "true")
         private Boolean requiresReconsent;
 
-        @Schema(description = "동의 전 서비스 진입 차단 여부", example = "true")
+        @Schema(description = "동의 전 서비스 진입 차단 여부. true면 해당 약관 동의 전 서비스 진입 차단", example = "true")
         private Boolean blocking;
 
-        @Schema(description = "프론트 화면 분기용 서버 계산 액션", example = "INITIAL_AGREEMENT_REQUIRED")
+        @Schema(
+                description = "프론트 화면 분기용 서버 계산 액션. 후보: NONE(처리 없음), INITIAL_AGREEMENT_REQUIRED(최초 동의 필요), RECONSENT_REQUIRED(필수 약관 재동의 필요), OPTIONAL_CONSENT_AVAILABLE(선택 약관 동의 가능), OPTIONAL_RECONSENT_AVAILABLE(선택 약관 재동의 가능)",
+                example = "INITIAL_AGREEMENT_REQUIRED",
+                allowableValues = {"NONE", "INITIAL_AGREEMENT_REQUIRED", "RECONSENT_REQUIRED", "OPTIONAL_CONSENT_AVAILABLE", "OPTIONAL_RECONSENT_AVAILABLE"}
+        )
         private String action;
 
         @Schema(description = "약관 본문 상세 조회 URL", example = "/api/v1/terms/versions/1", nullable = true)
@@ -88,13 +104,17 @@ public class TermResponseDTO {
     @Schema(description = "약관 버전 상세 응답")
     public static class TermVersionDetailResponse {
 
-        @Schema(description = "약관 코드", example = "SERVICE_TERMS")
+        @Schema(
+                description = "약관 코드. 초기 후보: SERVICE_TERMS(서비스 이용약관), PRIVACY_POLICY(개인정보 처리방침), MARKETING(마케팅 정보 수신 동의)",
+                example = "SERVICE_TERMS",
+                allowableValues = {"SERVICE_TERMS", "PRIVACY_POLICY", "MARKETING"}
+        )
         private String termCode;
 
         @Schema(description = "약관 제목", example = "서비스 이용약관")
         private String title;
 
-        @Schema(description = "필수 약관 여부", example = "true")
+        @Schema(description = "필수 약관 여부. true면 동의해야 서비스 이용 가능", example = "true")
         private Boolean required;
 
         @Schema(description = "약관 버전 ID", example = "1")
@@ -106,7 +126,11 @@ public class TermResponseDTO {
         @Schema(description = "약관 효력 발생 시각")
         private LocalDateTime effectiveFrom;
 
-        @Schema(description = "약관 본문 형식", example = "TEXT")
+        @Schema(
+                description = "약관 본문 형식. 후보: TEXT(일반 텍스트), HTML(HTML), MARKDOWN(마크다운)",
+                example = "TEXT",
+                allowableValues = {"TEXT", "HTML", "MARKDOWN"}
+        )
         private String contentFormat;
 
         @Schema(description = "약관 본문")
@@ -120,10 +144,14 @@ public class TermResponseDTO {
     @Schema(description = "약관 동의 제출 응답")
     public static class SubmitAgreementsResponse {
 
-        @Schema(description = "서비스 진입 전 약관 동의 화면이 필요한지 여부", example = "false")
+        @Schema(description = "서비스 진입 전 약관 동의 화면이 필요한지 여부. false면 필수 약관 기준 서비스 진입 가능", example = "false")
         private Boolean agreementRequired;
 
-        @Schema(description = "약관 동의 상태 사유", example = "NONE")
+        @Schema(
+                description = "약관 동의 상태 사유. 후보: NONE(필요 없음), INITIAL_REQUIRED_TERMS(최초 필수 약관 동의 필요), UPDATED_REQUIRED_TERMS(개정된 필수 약관 재동의 필요), OPTIONAL_TERMS_AVAILABLE(선택 약관 동의/변경 가능)",
+                example = "NONE",
+                allowableValues = {"NONE", "INITIAL_REQUIRED_TERMS", "UPDATED_REQUIRED_TERMS", "OPTIONAL_TERMS_AVAILABLE"}
+        )
         private String reason;
     }
 }

--- a/src/main/java/com/melissa/diary/web/dto/TermResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/TermResponseDTO.java
@@ -1,0 +1,129 @@
+package com.melissa.diary.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class TermResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "약관 동의 상태 응답")
+    public static class AgreementStatusResponse {
+
+        @Schema(description = "서비스 진입 전 약관 동의 화면이 필요한지 여부", example = "true")
+        private Boolean agreementRequired;
+
+        @Schema(description = "약관 동의 상태 사유", example = "INITIAL_REQUIRED_TERMS")
+        private String reason;
+
+        @Schema(description = "프론트가 동의 제출 시 사용할 맥락", example = "SIGNUP")
+        private String submitContext;
+
+        @Schema(description = "현재 사용자 기준 약관 항목 목록")
+        private List<TermItemResponse> terms;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "약관 항목 응답")
+    public static class TermItemResponse {
+
+        @Schema(description = "약관 코드", example = "SERVICE_TERMS")
+        private String termCode;
+
+        @Schema(description = "약관 제목", example = "서비스 이용약관")
+        private String title;
+
+        @Schema(description = "필수 약관 여부", example = "true")
+        private Boolean required;
+
+        @Schema(description = "현재 최신 약관 버전 ID", example = "1")
+        private Long currentTermVersionId;
+
+        @Schema(description = "현재 최신 약관 버전", example = "1.0")
+        private String currentVersion;
+
+        @Schema(description = "사용자가 이전에 결정한 약관 버전. 최초 동의 전이면 null", example = "1.0", nullable = true)
+        private String previousVersion;
+
+        @Schema(description = "현재 최신 버전에 동의한 상태인지 여부", example = "false")
+        private Boolean agreed;
+
+        @Schema(description = "이번 화면에서 새 결정을 받아야 하는지 여부", example = "true")
+        private Boolean needsAgreement;
+
+        @Schema(description = "사용자 이전 결정 버전과 현재 최신 버전이 다른지 여부", example = "false")
+        private Boolean updated;
+
+        @Schema(description = "현재 최신 버전이 재동의를 요구하는지 여부", example = "true")
+        private Boolean requiresReconsent;
+
+        @Schema(description = "동의 전 서비스 진입 차단 여부", example = "true")
+        private Boolean blocking;
+
+        @Schema(description = "프론트 화면 분기용 서버 계산 액션", example = "INITIAL_AGREEMENT_REQUIRED")
+        private String action;
+
+        @Schema(description = "약관 본문 상세 조회 URL", example = "/api/v1/terms/versions/1", nullable = true)
+        private String contentUrl;
+
+        @Schema(description = "약관 본문. agreement-screen 응답에서만 포함", nullable = true)
+        private String content;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "약관 버전 상세 응답")
+    public static class TermVersionDetailResponse {
+
+        @Schema(description = "약관 코드", example = "SERVICE_TERMS")
+        private String termCode;
+
+        @Schema(description = "약관 제목", example = "서비스 이용약관")
+        private String title;
+
+        @Schema(description = "필수 약관 여부", example = "true")
+        private Boolean required;
+
+        @Schema(description = "약관 버전 ID", example = "1")
+        private Long termVersionId;
+
+        @Schema(description = "약관 버전", example = "1.0")
+        private String version;
+
+        @Schema(description = "약관 효력 발생 시각")
+        private LocalDateTime effectiveFrom;
+
+        @Schema(description = "약관 본문 형식", example = "TEXT")
+        private String contentFormat;
+
+        @Schema(description = "약관 본문")
+        private String content;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "약관 동의 제출 응답")
+    public static class SubmitAgreementsResponse {
+
+        @Schema(description = "서비스 진입 전 약관 동의 화면이 필요한지 여부", example = "false")
+        private Boolean agreementRequired;
+
+        @Schema(description = "약관 동의 상태 사유", example = "NONE")
+        private String reason;
+    }
+}

--- a/src/main/java/com/melissa/diary/web/dto/UserResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/UserResponseDTO.java
@@ -14,7 +14,13 @@ public class UserResponseDTO {
         @Schema(description = "사용자 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long userId;
         
-        @Schema(description = "OAuth 제공자", example = "GOOGLE", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        @Schema(
+                description = "OAuth 제공자. 후보: GOOGLE, KAKAO, APPLE",
+                example = "GOOGLE",
+                allowableValues = {"GOOGLE", "KAKAO", "APPLE"},
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+                nullable = true
+        )
         private String oauthProvider;
         
         @Schema(description = "이메일", example = "user@example.com", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
@@ -29,7 +35,7 @@ public class UserResponseDTO {
         @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", requiredMode = Schema.RequiredMode.REQUIRED)
         private String refreshToken;
         
-        @Schema(description = "토큰 타입", example = "Bearer", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "토큰 타입. 현재는 Bearer 고정", example = "Bearer", allowableValues = {"Bearer"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String tokenType;
     }
 
@@ -41,7 +47,7 @@ public class UserResponseDTO {
         @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", requiredMode = Schema.RequiredMode.REQUIRED)
         private String refreshToken;
         
-        @Schema(description = "토큰 타입", example = "Bearer", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "토큰 타입. 현재는 Bearer 고정", example = "Bearer", allowableValues = {"Bearer"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String tokenType;
         
         @Schema(description = "만료 시간 (초)", example = "3600", requiredMode = Schema.RequiredMode.REQUIRED)
@@ -56,7 +62,13 @@ public class UserResponseDTO {
         @Schema(description = "사용자 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long userId;
         
-        @Schema(description = "OAuth 제공자", example = "GOOGLE", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        @Schema(
+                description = "OAuth 제공자. 후보: GOOGLE, KAKAO, APPLE",
+                example = "GOOGLE",
+                allowableValues = {"GOOGLE", "KAKAO", "APPLE"},
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+                nullable = true
+        )
         private String oauthProvider;
         
         @Schema(description = "제공자 ID", example = "1234567890", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
@@ -83,7 +95,13 @@ public class UserResponseDTO {
         @Schema(description = "닉네임", example = "홍길동", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String nickname;
 
-        @Schema(description = "OAuth 제공자", example = "GOOGLE", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
+        @Schema(
+                description = "OAuth 제공자. 후보: GOOGLE, KAKAO, APPLE",
+                example = "GOOGLE",
+                allowableValues = {"GOOGLE", "KAKAO", "APPLE"},
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED,
+                nullable = true
+        )
         private String oauthProvider;
 
         @Schema(description = "사용량(쿼터) 정보", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/resources/db/migration/manual/TERM-001-apply.sql
+++ b/src/main/resources/db/migration/manual/TERM-001-apply.sql
@@ -1,0 +1,249 @@
+-- TERM-001 apply script
+-- Target DB: MySQL 8.x
+-- Purpose: add terms version management and user agreement history
+
+-- =========================
+-- A. term
+-- =========================
+SET @has_term := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'term'
+);
+
+SET @sql := IF(
+    @has_term = 0,
+    'CREATE TABLE term (
+        id BIGINT NOT NULL AUTO_INCREMENT,
+        term_code VARCHAR(50) NOT NULL,
+        category VARCHAR(50) NOT NULL,
+        display_order INT NOT NULL,
+        active BOOLEAN NOT NULL DEFAULT TRUE,
+        created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+        version BIGINT NOT NULL DEFAULT 0,
+        PRIMARY KEY (id),
+        CONSTRAINT uk_term_code UNIQUE (term_code),
+        KEY idx_term_active_order (active, display_order)
+    )',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+INSERT INTO term (
+    term_code,
+    category,
+    display_order,
+    active,
+    created_at,
+    updated_at
+) VALUES
+('SERVICE_TERMS', 'SERVICE', 1, TRUE, NOW(6), NOW(6)),
+('PRIVACY_POLICY', 'PRIVACY', 2, TRUE, NOW(6), NOW(6)),
+('MARKETING', 'MARKETING', 3, TRUE, NOW(6), NOW(6))
+ON DUPLICATE KEY UPDATE
+    category = VALUES(category),
+    display_order = VALUES(display_order),
+    active = VALUES(active),
+    updated_at = NOW(6);
+
+-- =========================
+-- B. term_version
+-- =========================
+SET @has_term_version := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'term_version'
+);
+
+SET @sql := IF(
+    @has_term_version = 0,
+    'CREATE TABLE term_version (
+        id BIGINT NOT NULL AUTO_INCREMENT,
+        term_id BIGINT NOT NULL,
+        version_label VARCHAR(20) NOT NULL,
+        title VARCHAR(100) NOT NULL,
+        required BOOLEAN NOT NULL,
+        content LONGTEXT NOT NULL,
+        content_format VARCHAR(20) NOT NULL DEFAULT ''TEXT'',
+        status VARCHAR(20) NOT NULL DEFAULT ''DRAFT'',
+        requires_reconsent BOOLEAN NOT NULL DEFAULT TRUE,
+        effective_from DATETIME(6) NOT NULL,
+        published_at DATETIME(6) NULL,
+        created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+        version BIGINT NOT NULL DEFAULT 0,
+        PRIMARY KEY (id),
+        CONSTRAINT uk_term_version_term_version UNIQUE (term_id, version_label),
+        KEY idx_term_version_current (term_id, status, effective_from),
+        CONSTRAINT fk_term_version_term
+            FOREIGN KEY (term_id) REFERENCES term(id)
+            ON DELETE RESTRICT
+    )',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @service_terms_v1 := '서비스 이용약관 v1.0 목업 내용입니다.';
+SET @privacy_policy_v1 := '개인정보 처리방침 v1.0 목업 내용입니다.';
+SET @marketing_v1 := '마케팅 정보 수신 동의 v1.0 목업 내용입니다.';
+
+INSERT INTO term_version (
+    term_id,
+    version_label,
+    title,
+    required,
+    content,
+    content_format,
+    status,
+    requires_reconsent,
+    effective_from,
+    published_at,
+    created_at,
+    updated_at
+)
+SELECT
+    t.id,
+    '1.0',
+    '서비스 이용약관',
+    TRUE,
+    @service_terms_v1,
+    'TEXT',
+    'PUBLISHED',
+    TRUE,
+    NOW(6),
+    NOW(6),
+    NOW(6),
+    NOW(6)
+FROM term t
+WHERE t.term_code = 'SERVICE_TERMS'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM term_version tv
+      WHERE tv.term_id = t.id
+        AND tv.version_label = '1.0'
+  );
+
+INSERT INTO term_version (
+    term_id,
+    version_label,
+    title,
+    required,
+    content,
+    content_format,
+    status,
+    requires_reconsent,
+    effective_from,
+    published_at,
+    created_at,
+    updated_at
+)
+SELECT
+    t.id,
+    '1.0',
+    '개인정보 처리방침',
+    TRUE,
+    @privacy_policy_v1,
+    'TEXT',
+    'PUBLISHED',
+    TRUE,
+    NOW(6),
+    NOW(6),
+    NOW(6),
+    NOW(6)
+FROM term t
+WHERE t.term_code = 'PRIVACY_POLICY'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM term_version tv
+      WHERE tv.term_id = t.id
+        AND tv.version_label = '1.0'
+  );
+
+INSERT INTO term_version (
+    term_id,
+    version_label,
+    title,
+    required,
+    content,
+    content_format,
+    status,
+    requires_reconsent,
+    effective_from,
+    published_at,
+    created_at,
+    updated_at
+)
+SELECT
+    t.id,
+    '1.0',
+    '마케팅 정보 수신 동의',
+    FALSE,
+    @marketing_v1,
+    'TEXT',
+    'PUBLISHED',
+    FALSE,
+    NOW(6),
+    NOW(6),
+    NOW(6),
+    NOW(6)
+FROM term t
+WHERE t.term_code = 'MARKETING'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM term_version tv
+      WHERE tv.term_id = t.id
+        AND tv.version_label = '1.0'
+  );
+
+-- =========================
+-- C. user_term_agreement
+-- =========================
+SET @has_user_term_agreement := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'user_term_agreement'
+);
+
+SET @sql := IF(
+    @has_user_term_agreement = 0,
+    'CREATE TABLE user_term_agreement (
+        id BIGINT NOT NULL AUTO_INCREMENT,
+        user_id BIGINT NOT NULL,
+        term_id BIGINT NOT NULL,
+        term_version_id BIGINT NOT NULL,
+        term_code_snapshot VARCHAR(50) NOT NULL,
+        version_label_snapshot VARCHAR(20) NOT NULL,
+        title_snapshot VARCHAR(100) NOT NULL,
+        required_snapshot BOOLEAN NOT NULL,
+        agreed BOOLEAN NOT NULL,
+        agreement_context VARCHAR(30) NOT NULL,
+        decided_at DATETIME(6) NOT NULL,
+        created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+        PRIMARY KEY (id),
+        KEY idx_user_term_agreement_user_term_decided (user_id, term_id, decided_at, id),
+        KEY idx_user_term_agreement_user_version (user_id, term_version_id),
+        KEY idx_user_term_agreement_version (term_version_id),
+        CONSTRAINT fk_user_term_agreement_user
+            FOREIGN KEY (user_id) REFERENCES `user`(id)
+            ON DELETE RESTRICT,
+        CONSTRAINT fk_user_term_agreement_term
+            FOREIGN KEY (term_id) REFERENCES term(id)
+            ON DELETE RESTRICT,
+        CONSTRAINT fk_user_term_agreement_term_version
+            FOREIGN KEY (term_version_id) REFERENCES term_version(id)
+            ON DELETE RESTRICT
+    )',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/main/resources/db/migration/manual/TERM-001-precheck.sql
+++ b/src/main/resources/db/migration/manual/TERM-001-precheck.sql
@@ -1,0 +1,50 @@
+-- TERM-001 pre-check
+-- Target DB: MySQL 8.x
+-- Purpose: inspect terms agreement migration readiness
+
+SELECT table_name, table_rows
+FROM information_schema.tables
+WHERE table_schema = DATABASE()
+  AND table_name IN ('term', 'term_version', 'user_term_agreement')
+ORDER BY table_name;
+
+SELECT table_name, index_name, column_name, seq_in_index, non_unique
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+  AND table_name IN ('term', 'term_version', 'user_term_agreement')
+ORDER BY table_name, index_name, seq_in_index;
+
+SET @has_term := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'term'
+);
+
+SET @sql := IF(
+    @has_term = 1,
+    'SELECT term_code, category, display_order, active FROM term ORDER BY display_order',
+    'SELECT ''term table not found'' AS message'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_term_version := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'term_version'
+);
+
+SET @sql := IF(
+    @has_term_version = 1,
+    'SELECT t.term_code, tv.version_label, tv.title, tv.required, tv.status, tv.requires_reconsent, tv.effective_from
+     FROM term_version tv
+     JOIN term t ON t.id = tv.term_id
+     ORDER BY t.display_order, tv.effective_from, tv.id',
+    'SELECT ''term_version table not found'' AS message'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/main/resources/db/migration/manual/TERM-001-rollback.sql
+++ b/src/main/resources/db/migration/manual/TERM-001-rollback.sql
@@ -1,0 +1,38 @@
+-- TERM-001 rollback script
+-- Target DB: MySQL 8.x
+
+SET @has_user_term_agreement := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'user_term_agreement'
+);
+
+SET @sql := IF(@has_user_term_agreement > 0, 'DROP TABLE user_term_agreement', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_term_version := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'term_version'
+);
+
+SET @sql := IF(@has_term_version > 0, 'DROP TABLE term_version', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @has_term := (
+    SELECT COUNT(*)
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name = 'term'
+);
+
+SET @sql := IF(@has_term > 0, 'DROP TABLE term', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/test/java/com/melissa/diary/service/TermAgreementServiceTest.java
+++ b/src/test/java/com/melissa/diary/service/TermAgreementServiceTest.java
@@ -1,0 +1,236 @@
+package com.melissa.diary.service;
+
+import com.melissa.diary.apiPayload.code.status.ErrorStatus;
+import com.melissa.diary.apiPayload.exception.handler.ErrorHandler;
+import com.melissa.diary.domain.Term;
+import com.melissa.diary.domain.TermVersion;
+import com.melissa.diary.domain.User;
+import com.melissa.diary.domain.UserTermAgreement;
+import com.melissa.diary.domain.enums.AgreementContext;
+import com.melissa.diary.domain.enums.TermCategory;
+import com.melissa.diary.domain.enums.TermContentFormat;
+import com.melissa.diary.domain.enums.TermVersionStatus;
+import com.melissa.diary.repository.TermRepository;
+import com.melissa.diary.repository.TermVersionRepository;
+import com.melissa.diary.repository.UserRepository;
+import com.melissa.diary.repository.UserTermAgreementRepository;
+import com.melissa.diary.web.dto.TermRequestDTO;
+import com.melissa.diary.web.dto.TermResponseDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TermAgreementServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private TermRepository termRepository;
+
+    @Mock
+    private TermVersionRepository termVersionRepository;
+
+    @Mock
+    private UserTermAgreementRepository userTermAgreementRepository;
+
+    private TermAgreementService termAgreementService;
+
+    private User user;
+    private Term serviceTerm;
+    private Term privacyTerm;
+    private Term marketingTerm;
+    private TermVersion serviceV1;
+    private TermVersion privacyV1;
+    private TermVersion marketingV1;
+
+    @BeforeEach
+    void setUp() {
+        termAgreementService = new TermAgreementService(
+                userRepository,
+                termRepository,
+                termVersionRepository,
+                userTermAgreementRepository
+        );
+
+        user = User.builder()
+                .id(1L)
+                .provider("GOOGLE")
+                .nickname("user")
+                .build();
+        serviceTerm = term(1L, "SERVICE_TERMS", TermCategory.SERVICE, 1);
+        privacyTerm = term(2L, "PRIVACY_POLICY", TermCategory.PRIVACY, 2);
+        marketingTerm = term(3L, "MARKETING", TermCategory.MARKETING, 3);
+        serviceV1 = version(101L, serviceTerm, "1.0", "서비스 이용약관", true, true);
+        privacyV1 = version(102L, privacyTerm, "1.0", "개인정보 처리방침", true, true);
+        marketingV1 = version(103L, marketingTerm, "1.0", "마케팅 정보 수신 동의", false, false);
+    }
+
+    @Test
+    void getAgreementStatusRequiresInitialRequiredTermsForNewUser() {
+        mockCurrentTerms(List.of(serviceV1, privacyV1, marketingV1));
+        when(userTermAgreementRepository.findByUserIdAndTermIdIn(eq(user.getId()), anyList()))
+                .thenReturn(List.of());
+
+        TermResponseDTO.AgreementStatusResponse response = termAgreementService.getAgreementStatus(user.getId());
+
+        assertThat(response.getAgreementRequired()).isTrue();
+        assertThat(response.getReason()).isEqualTo("INITIAL_REQUIRED_TERMS");
+        assertThat(response.getSubmitContext()).isEqualTo("SIGNUP");
+        assertThat(response.getTerms()).hasSize(3);
+        assertThat(response.getTerms().get(0).getAction()).isEqualTo("INITIAL_AGREEMENT_REQUIRED");
+        assertThat(response.getTerms().get(0).getBlocking()).isTrue();
+        assertThat(response.getTerms().get(1).getBlocking()).isTrue();
+        assertThat(response.getTerms().get(2).getAction()).isEqualTo("OPTIONAL_CONSENT_AVAILABLE");
+        assertThat(response.getTerms().get(2).getBlocking()).isFalse();
+        assertThat(response.getTerms().get(0).getContent()).isNull();
+        assertThat(response.getTerms().get(0).getContentUrl()).isEqualTo("/api/v1/terms/versions/101");
+    }
+
+    @Test
+    void getAgreementStatusRequiresReconsentForUpdatedRequiredTerm() {
+        TermVersion serviceV11 = version(111L, serviceTerm, "1.1", "서비스 이용약관", true, true);
+        UserTermAgreement serviceAgreementV1 = agreement(1L, serviceV1, true);
+        UserTermAgreement privacyAgreementV1 = agreement(2L, privacyV1, true);
+
+        mockCurrentTerms(List.of(serviceV11, privacyV1, marketingV1));
+        when(userTermAgreementRepository.findByUserIdAndTermIdIn(eq(user.getId()), anyList()))
+                .thenReturn(List.of(serviceAgreementV1, privacyAgreementV1));
+
+        TermResponseDTO.AgreementStatusResponse response = termAgreementService.getAgreementStatus(user.getId());
+
+        assertThat(response.getAgreementRequired()).isTrue();
+        assertThat(response.getReason()).isEqualTo("UPDATED_REQUIRED_TERMS");
+        assertThat(response.getSubmitContext()).isEqualTo("RECONSENT");
+        assertThat(response.getTerms().get(0).getCurrentVersion()).isEqualTo("1.1");
+        assertThat(response.getTerms().get(0).getPreviousVersion()).isEqualTo("1.0");
+        assertThat(response.getTerms().get(0).getUpdated()).isTrue();
+        assertThat(response.getTerms().get(0).getAction()).isEqualTo("RECONSENT_REQUIRED");
+        assertThat(response.getTerms().get(0).getBlocking()).isTrue();
+    }
+
+    @Test
+    void submitAgreementsRejectsMissingBlockingRequiredTerm() {
+        mockCurrentTerms(List.of(serviceV1, privacyV1, marketingV1));
+        when(userTermAgreementRepository.findByUserIdAndTermIdIn(eq(user.getId()), anyList()))
+                .thenReturn(List.of());
+
+        TermRequestDTO.SubmitAgreementsRequest request = new TermRequestDTO.SubmitAgreementsRequest(
+                AgreementContext.SIGNUP,
+                List.of(new TermRequestDTO.AgreementDecisionRequest(marketingV1.getId(), false))
+        );
+
+        ErrorHandler error = assertThrows(
+                ErrorHandler.class,
+                () -> termAgreementService.submitAgreements(user.getId(), request)
+        );
+
+        assertThat(error.getErrorCode()).isEqualTo(ErrorStatus.TERM_REQUIRED_AGREEMENT_MISSING);
+    }
+
+    @Test
+    void submitAgreementsStoresDecisionsAndReturnsNoBlockingStatus() {
+        mockCurrentTerms(List.of(serviceV1, privacyV1, marketingV1));
+        when(termVersionRepository.findByIdWithTerm(serviceV1.getId())).thenReturn(Optional.of(serviceV1));
+        when(termVersionRepository.findByIdWithTerm(privacyV1.getId())).thenReturn(Optional.of(privacyV1));
+        when(termVersionRepository.findByIdWithTerm(marketingV1.getId())).thenReturn(Optional.of(marketingV1));
+
+        UserTermAgreement serviceAgreement = agreement(1L, serviceV1, true);
+        UserTermAgreement privacyAgreement = agreement(2L, privacyV1, true);
+        UserTermAgreement marketingAgreement = agreement(3L, marketingV1, false);
+        when(userTermAgreementRepository.findByUserIdAndTermIdIn(eq(user.getId()), anyList()))
+                .thenReturn(List.of())
+                .thenReturn(List.of(serviceAgreement, privacyAgreement, marketingAgreement));
+        when(userTermAgreementRepository.save(any(UserTermAgreement.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        TermRequestDTO.SubmitAgreementsRequest request = new TermRequestDTO.SubmitAgreementsRequest(
+                AgreementContext.SIGNUP,
+                List.of(
+                        new TermRequestDTO.AgreementDecisionRequest(serviceV1.getId(), true),
+                        new TermRequestDTO.AgreementDecisionRequest(privacyV1.getId(), true),
+                        new TermRequestDTO.AgreementDecisionRequest(marketingV1.getId(), false)
+                )
+        );
+
+        TermResponseDTO.SubmitAgreementsResponse response = termAgreementService.submitAgreements(user.getId(), request);
+
+        assertThat(response.getAgreementRequired()).isFalse();
+        assertThat(response.getReason()).isEqualTo("NONE");
+        verify(userTermAgreementRepository, times(3)).save(any(UserTermAgreement.class));
+    }
+
+    private void mockCurrentTerms(List<TermVersion> versions) {
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(termRepository.findByActiveTrueOrderByDisplayOrderAsc())
+                .thenReturn(List.of(serviceTerm, privacyTerm, marketingTerm));
+        when(termVersionRepository.findByTermIdInAndStatusAndEffectiveFromLessThanEqual(
+                anyList(),
+                eq(TermVersionStatus.PUBLISHED),
+                any(LocalDateTime.class)
+        )).thenReturn(versions);
+    }
+
+    private Term term(Long id, String termCode, TermCategory category, Integer displayOrder) {
+        return Term.builder()
+                .id(id)
+                .termCode(termCode)
+                .category(category)
+                .displayOrder(displayOrder)
+                .active(true)
+                .build();
+    }
+
+    private TermVersion version(
+            Long id,
+            Term term,
+            String versionLabel,
+            String title,
+            Boolean required,
+            Boolean requiresReconsent
+    ) {
+        return TermVersion.builder()
+                .id(id)
+                .term(term)
+                .versionLabel(versionLabel)
+                .title(title)
+                .required(required)
+                .content(title + " " + versionLabel + " 내용")
+                .contentFormat(TermContentFormat.TEXT)
+                .status(TermVersionStatus.PUBLISHED)
+                .requiresReconsent(requiresReconsent)
+                .effectiveFrom(LocalDateTime.now().minusDays(1))
+                .publishedAt(LocalDateTime.now().minusDays(1))
+                .build();
+    }
+
+    private UserTermAgreement agreement(Long id, TermVersion termVersion, Boolean agreed) {
+        return UserTermAgreement.builder()
+                .id(id)
+                .user(user)
+                .term(termVersion.getTerm())
+                .termVersion(termVersion)
+                .termCodeSnapshot(termVersion.getTerm().getTermCode())
+                .versionLabelSnapshot(termVersion.getVersionLabel())
+                .titleSnapshot(termVersion.getTitle())
+                .requiredSnapshot(termVersion.getRequired())
+                .agreed(agreed)
+                .agreementContext(AgreementContext.SIGNUP)
+                .decidedAt(LocalDateTime.now().minusHours(1).plusMinutes(id))
+                .build();
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
약관 버전 관리와 사용자 약관 동의 API를 신규 구현했습니다.  
프론트가 약관 동의 필요 여부, 변경 약관 여부, 필수 약관 재동의 필요 여부를 서버 응답 기준으로 판단할 수 있도록 구성했습니다.

## 📋 변경 사항
- 약관/약관 버전/사용자 약관 동의 이력 엔티티 추가
- 약관 상태 조회, 약관 동의 화면 조회, 약관 버전 상세 조회, 약관 동의/거절 제출 API 추가
- 약관 종류/버전 상태/동의 액션/동의 컨텍스트 enum 추가
- 약관 초기 데이터 및 적용/롤백용 manual SQL 추가
- 약관 API Swagger 설명 및 enum 후보값 보강
- 결제/권한/푸시 토큰/사용자 응답 API Swagger 설명 보강
  - 결제 플랫폼: `GOOGLE`, `APPLE`
  - 결제 상태: `PENDING`, `PURCHASED`, `FAILED`, `REFUNDED`, `REVOKED`
  - 푸시 플랫폼: `ANDROID`, `IOS`
  - OAuth provider: `GOOGLE`, `KAKAO`, `APPLE`

## 🔍 Code Review
- 약관 본문은 DB 평문 저장 기준으로 구현했습니다.
- 사용자 동의 이력은 버전별 스냅샷 성격으로 저장되며, 최신 약관과 이전 동의 버전을 비교해 재동의 필요 여부를 계산합니다.
- 신규 환경변수 추가는 없습니다.
- SQL은 자동 migration이 아니라 `src/main/resources/db/migration/manual` 경로의 수동 적용 스크립트입니다.
- 기존 API 동작 변경 없이 Swagger 명세 보강은 별도 커밋으로 분리했습니다.

## 📸 ScreenShot
백엔드 API 작업으로 별도 스크린샷은 없습니다.

테스트:
- `./gradlew.bat compileJava`
- `./gradlew.bat test --tests com.melissa.diary.service.TermAgreementServiceTest`