### PR TITLE
Feat: 사용자 약관 동의 이력 삭제 API 추가

### DIFF
--- a/src/main/java/com/melissa/diary/repository/UserTermAgreementRepository.java
+++ b/src/main/java/com/melissa/diary/repository/UserTermAgreementRepository.java
@@ -3,6 +3,9 @@ package com.melissa.diary.repository;
 import com.melissa.diary.domain.UserTermAgreement;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,4 +13,8 @@ public interface UserTermAgreementRepository extends JpaRepository<UserTermAgree
 
     @EntityGraph(attributePaths = {"term", "termVersion"})
     List<UserTermAgreement> findByUserIdAndTermIdIn(Long userId, List<Long> termIds);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM UserTermAgreement agreement WHERE agreement.user.id = :userId")
+    int deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/melissa/diary/service/TermAgreementService.java
+++ b/src/main/java/com/melissa/diary/service/TermAgreementService.java
@@ -111,6 +111,21 @@ public class TermAgreementService {
                 .build();
     }
 
+    @Transactional
+    public TermResponseDTO.DeleteAgreementHistoryResponse deleteAgreementHistory(Long userId) {
+        findUser(userId);
+        long deletedCount = userTermAgreementRepository.deleteByUserId(userId);
+
+        List<ComputedTermStatus> updatedStatuses = loadTermStatuses(userId, LocalDateTime.now());
+        AgreementStatusReason reason = calculateReason(updatedStatuses);
+
+        return TermResponseDTO.DeleteAgreementHistoryResponse.builder()
+                .deletedCount(deletedCount)
+                .agreementRequired(hasBlockingTerm(updatedStatuses))
+                .reason(reason.name())
+                .build();
+    }
+
     private User findUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new ErrorHandler(ErrorStatus.USER_NOT_FOUND));

--- a/src/main/java/com/melissa/diary/web/controller/TermController.java
+++ b/src/main/java/com/melissa/diary/web/controller/TermController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -100,5 +101,24 @@ public class TermController {
     ) {
         Long userId = Long.parseLong(principal.getName());
         return ApiResponse.onSuccess(termAgreementService.submitAgreements(userId, request));
+    }
+
+    @Operation(
+            summary = "사용자 약관 동의 이력 삭제",
+            description = """
+                    현재 로그인한 사용자의 약관 동의 이력을 삭제합니다.
+                    - 인증 필요 (Bearer JWT)
+                    - 삭제 대상은 user_term_agreement 이력만입니다.
+                    - term, term_version 데이터는 삭제하지 않습니다.
+                    - 프론트 약관 동의 플로우 반복 테스트용 API입니다.
+                    - 정식 약관 철회 기능은 별도 정책 검토 후 분리 구현합니다.
+                    """
+    )
+    @DeleteMapping("/agreements/me")
+    public ApiResponse<TermResponseDTO.DeleteAgreementHistoryResponse> deleteAgreementHistory(
+            Principal principal
+    ) {
+        Long userId = Long.parseLong(principal.getName());
+        return ApiResponse.onSuccess(termAgreementService.deleteAgreementHistory(userId));
     }
 }

--- a/src/main/java/com/melissa/diary/web/dto/EntitlementResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/EntitlementResponseDTO.java
@@ -14,10 +14,10 @@ public class EntitlementResponseDTO {
     @Schema(description = "현재 사용자의 활성 권한 응답")
     public static class EntitlementsResponse {
 
-        @Schema(description = "활성 권한 목록")
+        @Schema(description = "활성 권한 목록", requiredMode = Schema.RequiredMode.REQUIRED)
         private List<EntitlementSummary> entitlements;
 
-        @Schema(description = "활성 권한 기반 프론트 기능 플래그")
+        @Schema(description = "활성 권한 기반 프론트 기능 플래그", requiredMode = Schema.RequiredMode.REQUIRED)
         private FeatureSummary features;
     }
 
@@ -29,25 +29,27 @@ public class EntitlementResponseDTO {
         @Schema(
                 description = "권한 타입. enum 후보: REMOVE_ADS(광고 제거), PREMIUM, EXTRA_STORAGE, AI_CREDIT. 현재 결제 상품은 REMOVE_ADS만 사용",
                 example = "REMOVE_ADS",
-                allowableValues = {"REMOVE_ADS", "PREMIUM", "EXTRA_STORAGE", "AI_CREDIT"}
+                allowableValues = {"REMOVE_ADS", "PREMIUM", "EXTRA_STORAGE", "AI_CREDIT"},
+                requiredMode = Schema.RequiredMode.REQUIRED
         )
         private String type;
 
-        @Schema(description = "권한 활성 여부", example = "true")
+        @Schema(description = "권한 활성 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean active;
 
         @Schema(
                 description = "권한이 부여된 결제 플랫폼. 후보: GOOGLE, APPLE. 결제 외 수동 부여 등 플랫폼이 없으면 null",
                 example = "GOOGLE",
                 allowableValues = {"GOOGLE", "APPLE"},
+                requiredMode = Schema.RequiredMode.REQUIRED,
                 nullable = true
         )
         private String sourcePlatform;
 
-        @Schema(description = "권한 부여 시각")
+        @Schema(description = "권한 부여 시각", requiredMode = Schema.RequiredMode.REQUIRED)
         private LocalDateTime grantedAt;
 
-        @Schema(description = "권한 회수 시각", nullable = true)
+        @Schema(description = "권한 회수 시각", requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
         private LocalDateTime revokedAt;
     }
 
@@ -56,7 +58,7 @@ public class EntitlementResponseDTO {
     @Schema(description = "프론트 기능 플래그")
     public static class FeatureSummary {
 
-        @Schema(description = "광고 제거 적용 여부. 프론트는 이 값을 기준으로 광고 표시 여부를 판단", example = "true")
+        @Schema(description = "광고 제거 적용 여부. 프론트는 이 값을 기준으로 광고 표시 여부를 판단", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean adRemoved;
     }
 }

--- a/src/main/java/com/melissa/diary/web/dto/PaymentRequestDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/PaymentRequestDTO.java
@@ -35,7 +35,7 @@ public class PaymentRequestDTO {
         @Schema(description = "Google Play Billing purchaseToken", requiredMode = Schema.RequiredMode.REQUIRED)
         private String purchaseToken;
 
-        @Schema(description = "Google 주문 ID. 없으면 생략 가능", example = "GPA.1234-5678-9012-34567", nullable = true)
+        @Schema(description = "Google 주문 ID. 없으면 생략 가능", example = "GPA.1234-5678-9012-34567", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String orderId;
     }
 
@@ -68,7 +68,7 @@ public class PaymentRequestDTO {
         @Schema(description = "Apple transactionId", example = "2000000123456789", requiredMode = Schema.RequiredMode.REQUIRED)
         private String transactionId;
 
-        @Schema(description = "Apple originalTransactionId. 없으면 생략 가능", example = "2000000123456789", nullable = true)
+        @Schema(description = "Apple originalTransactionId. 없으면 생략 가능", example = "2000000123456789", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private String originalTransactionId;
 
         @NotBlank
@@ -105,7 +105,7 @@ public class PaymentRequestDTO {
         @Schema(description = "수동 환불 반영 사유", example = "Google Play Console 환불 처리 확인", requiredMode = Schema.RequiredMode.REQUIRED)
         private String reason;
 
-        @Schema(description = "스토어 환불 처리 시각. 생략하면 서버 처리 시각 사용", nullable = true)
+        @Schema(description = "스토어 환불 처리 시각. 생략하면 서버 처리 시각 사용", requiredMode = Schema.RequiredMode.NOT_REQUIRED, nullable = true)
         private LocalDateTime refundedAt;
     }
 }

--- a/src/main/java/com/melissa/diary/web/dto/PaymentResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/PaymentResponseDTO.java
@@ -17,34 +17,34 @@ public class PaymentResponseDTO {
     @AllArgsConstructor
     @Schema(description = "스토어 구매 검증 응답")
     public static class VerifyResponse {
-        @Schema(description = "백엔드 결제 내역 ID", example = "1")
+        @Schema(description = "백엔드 결제 내역 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long paymentId;
 
-        @Schema(description = "결제 플랫폼. 후보: GOOGLE, APPLE", example = "GOOGLE", allowableValues = {"GOOGLE", "APPLE"})
+        @Schema(description = "결제 플랫폼. 후보: GOOGLE, APPLE", example = "GOOGLE", allowableValues = {"GOOGLE", "APPLE"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String platform;
 
-        @Schema(description = "백엔드 내부 상품 ID. 현재 후보: remove_ads(광고 제거). 스토어 상품 ID가 아니라 내부 상품 ID로 반환", example = "remove_ads", allowableValues = {"remove_ads"})
+        @Schema(description = "백엔드 내부 상품 ID. 현재 후보: remove_ads(광고 제거). 스토어 상품 ID가 아니라 내부 상품 ID로 반환", example = "remove_ads", allowableValues = {"remove_ads"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String productId;
 
-        @Schema(description = "결제 상태. 후보: PENDING, PURCHASED, FAILED, REFUNDED, REVOKED", example = "PURCHASED", allowableValues = {"PENDING", "PURCHASED", "FAILED", "REFUNDED", "REVOKED"})
+        @Schema(description = "결제 상태. 후보: PENDING, PURCHASED, FAILED, REFUNDED, REVOKED", example = "PURCHASED", allowableValues = {"PENDING", "PURCHASED", "FAILED", "REFUNDED", "REVOKED"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String status;
 
-        @Schema(description = "검증 성공으로 부여된 권한 요약")
+        @Schema(description = "검증 성공으로 부여된 권한 요약", requiredMode = Schema.RequiredMode.REQUIRED)
         private EntitlementSummary entitlement;
 
-        @Schema(description = "Google 구매 acknowledge 완료 여부. Apple은 null", example = "true", nullable = true)
+        @Schema(description = "Google 구매 acknowledge 완료 여부. Apple은 null", example = "true", requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
         private Boolean acknowledged;
 
-        @Schema(description = "프론트의 구매 완료 처리 필요 여부. Apple 검증 성공 시 true", example = "true", nullable = true)
+        @Schema(description = "프론트의 구매 완료 처리 필요 여부. Apple 검증 성공 시 true", example = "true", requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
         private Boolean finishRequired;
 
-        @Schema(description = "이미 처리된 같은 구매를 다시 검증했는지 여부", example = "false")
+        @Schema(description = "이미 처리된 같은 구매를 다시 검증했는지 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean alreadyProcessed;
 
-        @Schema(description = "스토어 구매 시각")
+        @Schema(description = "스토어 구매 시각", requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
         private LocalDateTime purchasedAt;
 
-        @Schema(description = "백엔드 검증 시각")
+        @Schema(description = "백엔드 검증 시각", requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
         private LocalDateTime verifiedAt;
     }
 
@@ -54,10 +54,10 @@ public class PaymentResponseDTO {
     @AllArgsConstructor
     @Schema(description = "결제 권한 요약")
     public static class EntitlementSummary {
-        @Schema(description = "권한 타입. enum 후보: REMOVE_ADS(광고 제거), PREMIUM, EXTRA_STORAGE, AI_CREDIT. 현재 결제 상품은 REMOVE_ADS만 사용", example = "REMOVE_ADS", allowableValues = {"REMOVE_ADS", "PREMIUM", "EXTRA_STORAGE", "AI_CREDIT"})
+        @Schema(description = "권한 타입. enum 후보: REMOVE_ADS(광고 제거), PREMIUM, EXTRA_STORAGE, AI_CREDIT. 현재 결제 상품은 REMOVE_ADS만 사용", example = "REMOVE_ADS", allowableValues = {"REMOVE_ADS", "PREMIUM", "EXTRA_STORAGE", "AI_CREDIT"}, requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
         private String type;
 
-        @Schema(description = "권한 활성 여부. true면 광고 제거 적용 가능", example = "true")
+        @Schema(description = "권한 활성 여부. true면 광고 제거 적용 가능", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean active;
     }
 
@@ -67,13 +67,13 @@ public class PaymentResponseDTO {
     @AllArgsConstructor
     @Schema(description = "스토어 구매 복원 응답")
     public static class RestoreResponse {
-        @Schema(description = "복원에 성공한 구매 목록")
+        @Schema(description = "복원에 성공한 구매 목록", requiredMode = Schema.RequiredMode.REQUIRED)
         private List<RestoredPurchase> restored;
 
-        @Schema(description = "검증에 실패한 구매 목록. 일부 실패가 있어도 API 자체는 성공할 수 있음")
+        @Schema(description = "검증에 실패한 구매 목록. 일부 실패가 있어도 API 자체는 성공할 수 있음", requiredMode = Schema.RequiredMode.REQUIRED)
         private List<FailedPurchase> failed;
 
-        @Schema(description = "현재 사용자의 기능 플래그. 광고 제거 여부는 `adRemoved`로 판단")
+        @Schema(description = "현재 사용자의 기능 플래그. 광고 제거 여부는 `adRemoved`로 판단", requiredMode = Schema.RequiredMode.REQUIRED)
         private EntitlementResponseDTO.FeatureSummary features;
     }
 
@@ -83,19 +83,19 @@ public class PaymentResponseDTO {
     @AllArgsConstructor
     @Schema(description = "복원 성공 구매 요약")
     public static class RestoredPurchase {
-        @Schema(description = "백엔드 결제 내역 ID", example = "1")
+        @Schema(description = "백엔드 결제 내역 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long paymentId;
 
-        @Schema(description = "결제 플랫폼. 후보: GOOGLE, APPLE", example = "APPLE", allowableValues = {"GOOGLE", "APPLE"})
+        @Schema(description = "결제 플랫폼. 후보: GOOGLE, APPLE", example = "APPLE", allowableValues = {"GOOGLE", "APPLE"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String platform;
 
-        @Schema(description = "백엔드 내부 상품 ID. 현재 후보: remove_ads(광고 제거)", example = "remove_ads", allowableValues = {"remove_ads"})
+        @Schema(description = "백엔드 내부 상품 ID. 현재 후보: remove_ads(광고 제거)", example = "remove_ads", allowableValues = {"remove_ads"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String productId;
 
-        @Schema(description = "결제 상태. 후보: PENDING, PURCHASED, FAILED, REFUNDED, REVOKED", example = "PURCHASED", allowableValues = {"PENDING", "PURCHASED", "FAILED", "REFUNDED", "REVOKED"})
+        @Schema(description = "결제 상태. 후보: PENDING, PURCHASED, FAILED, REFUNDED, REVOKED", example = "PURCHASED", allowableValues = {"PENDING", "PURCHASED", "FAILED", "REFUNDED", "REVOKED"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String status;
 
-        @Schema(description = "복원된 권한 타입. enum 후보: REMOVE_ADS(광고 제거), PREMIUM, EXTRA_STORAGE, AI_CREDIT. 현재 결제 상품은 REMOVE_ADS만 사용", example = "REMOVE_ADS", allowableValues = {"REMOVE_ADS", "PREMIUM", "EXTRA_STORAGE", "AI_CREDIT"})
+        @Schema(description = "복원된 권한 타입. enum 후보: REMOVE_ADS(광고 제거), PREMIUM, EXTRA_STORAGE, AI_CREDIT. 현재 결제 상품은 REMOVE_ADS만 사용", example = "REMOVE_ADS", allowableValues = {"REMOVE_ADS", "PREMIUM", "EXTRA_STORAGE", "AI_CREDIT"}, requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
         private String entitlementType;
     }
 
@@ -105,19 +105,19 @@ public class PaymentResponseDTO {
     @AllArgsConstructor
     @Schema(description = "복원 실패 구매 요약")
     public static class FailedPurchase {
-        @Schema(description = "결제 플랫폼. 후보: GOOGLE, APPLE", example = "GOOGLE", allowableValues = {"GOOGLE", "APPLE"})
+        @Schema(description = "결제 플랫폼. 후보: GOOGLE, APPLE", example = "GOOGLE", allowableValues = {"GOOGLE", "APPLE"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String platform;
 
-        @Schema(description = "요청으로 전달된 스토어 상품 ID", example = "premium")
+        @Schema(description = "요청으로 전달된 스토어 상품 ID", example = "premium", requiredMode = Schema.RequiredMode.REQUIRED)
         private String productId;
 
-        @Schema(description = "실패 항목 식별자. Google은 orderId 또는 purchaseToken, Apple은 transactionId", example = "GPA.1234-5678-9012-34567")
+        @Schema(description = "실패 항목 식별자. Google은 orderId 또는 purchaseToken, Apple은 transactionId", example = "GPA.1234-5678-9012-34567", requiredMode = Schema.RequiredMode.REQUIRED)
         private String identifier;
 
-        @Schema(description = "실패 코드", example = "PAYMENT4004")
+        @Schema(description = "실패 코드", example = "PAYMENT4004", requiredMode = Schema.RequiredMode.REQUIRED)
         private String code;
 
-        @Schema(description = "실패 메시지", example = "스토어 구매 검증에 실패했습니다.")
+        @Schema(description = "실패 메시지", example = "스토어 구매 검증에 실패했습니다.", requiredMode = Schema.RequiredMode.REQUIRED)
         private String message;
     }
 
@@ -127,37 +127,37 @@ public class PaymentResponseDTO {
     @AllArgsConstructor
     @Schema(description = "관리자 수동 환불 반영 응답")
     public static class AdminManualRefundResponse {
-        @Schema(description = "백엔드 결제 내역 ID", example = "1")
+        @Schema(description = "백엔드 결제 내역 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long paymentId;
 
-        @Schema(description = "환불 처리 대상 사용자 ID", example = "10")
+        @Schema(description = "환불 처리 대상 사용자 ID", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long userId;
 
-        @Schema(description = "결제 플랫폼. 후보: GOOGLE, APPLE", example = "GOOGLE", allowableValues = {"GOOGLE", "APPLE"})
+        @Schema(description = "결제 플랫폼. 후보: GOOGLE, APPLE", example = "GOOGLE", allowableValues = {"GOOGLE", "APPLE"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String platform;
 
-        @Schema(description = "백엔드 내부 상품 ID. 현재 후보: remove_ads(광고 제거)", example = "remove_ads", allowableValues = {"remove_ads"})
+        @Schema(description = "백엔드 내부 상품 ID. 현재 후보: remove_ads(광고 제거)", example = "remove_ads", allowableValues = {"remove_ads"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String productId;
 
-        @Schema(description = "결제 상태. 후보: PENDING, PURCHASED, FAILED, REFUNDED, REVOKED", example = "REFUNDED", allowableValues = {"PENDING", "PURCHASED", "FAILED", "REFUNDED", "REVOKED"})
+        @Schema(description = "결제 상태. 후보: PENDING, PURCHASED, FAILED, REFUNDED, REVOKED", example = "REFUNDED", allowableValues = {"PENDING", "PURCHASED", "FAILED", "REFUNDED", "REVOKED"}, requiredMode = Schema.RequiredMode.REQUIRED)
         private String status;
 
-        @Schema(description = "회수 대상 권한 타입. enum 후보: REMOVE_ADS(광고 제거), PREMIUM, EXTRA_STORAGE, AI_CREDIT. 회수 대상 권한이 없으면 null", example = "REMOVE_ADS", allowableValues = {"REMOVE_ADS", "PREMIUM", "EXTRA_STORAGE", "AI_CREDIT"}, nullable = true)
+        @Schema(description = "회수 대상 권한 타입. enum 후보: REMOVE_ADS(광고 제거), PREMIUM, EXTRA_STORAGE, AI_CREDIT. 회수 대상 권한이 없으면 null", example = "REMOVE_ADS", allowableValues = {"REMOVE_ADS", "PREMIUM", "EXTRA_STORAGE", "AI_CREDIT"}, requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
         private String entitlementType;
 
-        @Schema(description = "권한 회수 완료 여부", example = "true")
+        @Schema(description = "권한 회수 완료 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean entitlementRevoked;
 
-        @Schema(description = "권한 활성 여부", example = "false", nullable = true)
+        @Schema(description = "권한 활성 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
         private Boolean entitlementActive;
 
-        @Schema(description = "이미 환불 처리된 결제였는지 여부", example = "false")
+        @Schema(description = "이미 환불 처리된 결제였는지 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean alreadyProcessed;
 
-        @Schema(description = "환불 반영 시각")
+        @Schema(description = "환불 반영 시각", requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
         private LocalDateTime refundedAt;
 
-        @Schema(description = "관리자 fallback 처리 시각")
+        @Schema(description = "관리자 fallback 처리 시각", requiredMode = Schema.RequiredMode.REQUIRED)
         private LocalDateTime processedAt;
     }
 }

--- a/src/main/java/com/melissa/diary/web/dto/TermResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/TermResponseDTO.java
@@ -154,4 +154,25 @@ public class TermResponseDTO {
         )
         private String reason;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "약관 동의 이력 삭제 응답")
+    public static class DeleteAgreementHistoryResponse {
+
+        @Schema(description = "삭제된 사용자 약관 동의 이력 수", example = "3")
+        private Long deletedCount;
+
+        @Schema(description = "삭제 후 서비스 진입 전 약관 동의 화면이 필요한지 여부", example = "true")
+        private Boolean agreementRequired;
+
+        @Schema(
+                description = "삭제 후 약관 동의 상태 사유. 후보: NONE(필요 없음), INITIAL_REQUIRED_TERMS(최초 필수 약관 동의 필요), UPDATED_REQUIRED_TERMS(개정된 필수 약관 재동의 필요), OPTIONAL_TERMS_AVAILABLE(선택 약관 동의/변경 가능)",
+                example = "INITIAL_REQUIRED_TERMS",
+                allowableValues = {"NONE", "INITIAL_REQUIRED_TERMS", "UPDATED_REQUIRED_TERMS", "OPTIONAL_TERMS_AVAILABLE"}
+        )
+        private String reason;
+    }
 }

--- a/src/main/java/com/melissa/diary/web/dto/TermResponseDTO.java
+++ b/src/main/java/com/melissa/diary/web/dto/TermResponseDTO.java
@@ -18,24 +18,26 @@ public class TermResponseDTO {
     @Schema(description = "약관 동의 상태 응답")
     public static class AgreementStatusResponse {
 
-        @Schema(description = "서비스 진입 전 약관 동의 화면이 필요한지 여부. true면 서비스 진입 전 약관 동의 화면으로 이동", example = "true")
+        @Schema(description = "서비스 진입 전 약관 동의 화면이 필요한지 여부. true면 서비스 진입 전 약관 동의 화면으로 이동", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean agreementRequired;
 
         @Schema(
                 description = "약관 동의 상태 사유. 후보: NONE(필요 없음), INITIAL_REQUIRED_TERMS(최초 필수 약관 동의 필요), UPDATED_REQUIRED_TERMS(개정된 필수 약관 재동의 필요), OPTIONAL_TERMS_AVAILABLE(선택 약관 동의/변경 가능)",
                 example = "INITIAL_REQUIRED_TERMS",
-                allowableValues = {"NONE", "INITIAL_REQUIRED_TERMS", "UPDATED_REQUIRED_TERMS", "OPTIONAL_TERMS_AVAILABLE"}
+                allowableValues = {"NONE", "INITIAL_REQUIRED_TERMS", "UPDATED_REQUIRED_TERMS", "OPTIONAL_TERMS_AVAILABLE"},
+                requiredMode = Schema.RequiredMode.REQUIRED
         )
         private String reason;
 
         @Schema(
                 description = "프론트가 POST /api/v1/terms/agreements 호출 시 context로 사용할 값. 후보: NONE, SIGNUP, RECONSENT, OPTIONAL_UPDATE",
                 example = "SIGNUP",
-                allowableValues = {"NONE", "SIGNUP", "RECONSENT", "OPTIONAL_UPDATE"}
+                allowableValues = {"NONE", "SIGNUP", "RECONSENT", "OPTIONAL_UPDATE"},
+                requiredMode = Schema.RequiredMode.REQUIRED
         )
         private String submitContext;
 
-        @Schema(description = "현재 사용자 기준 약관 항목 목록")
+        @Schema(description = "현재 사용자 기준 약관 항목 목록", requiredMode = Schema.RequiredMode.REQUIRED)
         private List<TermItemResponse> terms;
     }
 
@@ -49,51 +51,53 @@ public class TermResponseDTO {
         @Schema(
                 description = "약관 코드. 초기 후보: SERVICE_TERMS(서비스 이용약관), PRIVACY_POLICY(개인정보 처리방침), MARKETING(마케팅 정보 수신 동의)",
                 example = "SERVICE_TERMS",
-                allowableValues = {"SERVICE_TERMS", "PRIVACY_POLICY", "MARKETING"}
+                allowableValues = {"SERVICE_TERMS", "PRIVACY_POLICY", "MARKETING"},
+                requiredMode = Schema.RequiredMode.REQUIRED
         )
         private String termCode;
 
-        @Schema(description = "약관 제목", example = "서비스 이용약관")
+        @Schema(description = "약관 제목", example = "서비스 이용약관", requiredMode = Schema.RequiredMode.REQUIRED)
         private String title;
 
-        @Schema(description = "필수 약관 여부. true면 동의해야 서비스 이용 가능", example = "true")
+        @Schema(description = "필수 약관 여부. true면 동의해야 서비스 이용 가능", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean required;
 
-        @Schema(description = "현재 최신 약관 버전 ID", example = "1")
+        @Schema(description = "현재 최신 약관 버전 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long currentTermVersionId;
 
-        @Schema(description = "현재 최신 약관 버전", example = "1.0")
+        @Schema(description = "현재 최신 약관 버전", example = "1.0", requiredMode = Schema.RequiredMode.REQUIRED)
         private String currentVersion;
 
-        @Schema(description = "사용자가 이전에 결정한 약관 버전. 최초 동의 전이면 null", example = "1.0", nullable = true)
+        @Schema(description = "사용자가 이전에 결정한 약관 버전. 최초 동의 전이면 null", example = "1.0", requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
         private String previousVersion;
 
-        @Schema(description = "현재 최신 버전에 동의한 상태인지 여부. true면 해당 currentTermVersionId에 이미 동의한 상태", example = "false")
+        @Schema(description = "현재 최신 버전에 동의한 상태인지 여부. true면 해당 currentTermVersionId에 이미 동의한 상태", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean agreed;
 
-        @Schema(description = "이번 화면에서 사용자에게 새 동의/거절 결정을 받아야 하는지 여부", example = "true")
+        @Schema(description = "이번 화면에서 사용자에게 새 동의/거절 결정을 받아야 하는지 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean needsAgreement;
 
-        @Schema(description = "사용자 이전 결정 버전과 현재 최신 버전이 다른지 여부", example = "false")
+        @Schema(description = "사용자 이전 결정 버전과 현재 최신 버전이 다른지 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean updated;
 
-        @Schema(description = "현재 최신 버전이 재동의를 요구하는지 여부", example = "true")
+        @Schema(description = "현재 최신 버전이 재동의를 요구하는지 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean requiresReconsent;
 
-        @Schema(description = "동의 전 서비스 진입 차단 여부. true면 해당 약관 동의 전 서비스 진입 차단", example = "true")
+        @Schema(description = "동의 전 서비스 진입 차단 여부. true면 해당 약관 동의 전 서비스 진입 차단", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean blocking;
 
         @Schema(
                 description = "프론트 화면 분기용 서버 계산 액션. 후보: NONE(처리 없음), INITIAL_AGREEMENT_REQUIRED(최초 동의 필요), RECONSENT_REQUIRED(필수 약관 재동의 필요), OPTIONAL_CONSENT_AVAILABLE(선택 약관 동의 가능), OPTIONAL_RECONSENT_AVAILABLE(선택 약관 재동의 가능)",
                 example = "INITIAL_AGREEMENT_REQUIRED",
-                allowableValues = {"NONE", "INITIAL_AGREEMENT_REQUIRED", "RECONSENT_REQUIRED", "OPTIONAL_CONSENT_AVAILABLE", "OPTIONAL_RECONSENT_AVAILABLE"}
+                allowableValues = {"NONE", "INITIAL_AGREEMENT_REQUIRED", "RECONSENT_REQUIRED", "OPTIONAL_CONSENT_AVAILABLE", "OPTIONAL_RECONSENT_AVAILABLE"},
+                requiredMode = Schema.RequiredMode.REQUIRED
         )
         private String action;
 
-        @Schema(description = "약관 본문 상세 조회 URL", example = "/api/v1/terms/versions/1", nullable = true)
+        @Schema(description = "약관 본문 상세 조회 URL", example = "/api/v1/terms/versions/1", requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
         private String contentUrl;
 
-        @Schema(description = "약관 본문. agreement-screen 응답에서만 포함", nullable = true)
+        @Schema(description = "약관 본문. agreement-screen 응답에서만 포함", requiredMode = Schema.RequiredMode.REQUIRED, nullable = true)
         private String content;
     }
 
@@ -107,33 +111,35 @@ public class TermResponseDTO {
         @Schema(
                 description = "약관 코드. 초기 후보: SERVICE_TERMS(서비스 이용약관), PRIVACY_POLICY(개인정보 처리방침), MARKETING(마케팅 정보 수신 동의)",
                 example = "SERVICE_TERMS",
-                allowableValues = {"SERVICE_TERMS", "PRIVACY_POLICY", "MARKETING"}
+                allowableValues = {"SERVICE_TERMS", "PRIVACY_POLICY", "MARKETING"},
+                requiredMode = Schema.RequiredMode.REQUIRED
         )
         private String termCode;
 
-        @Schema(description = "약관 제목", example = "서비스 이용약관")
+        @Schema(description = "약관 제목", example = "서비스 이용약관", requiredMode = Schema.RequiredMode.REQUIRED)
         private String title;
 
-        @Schema(description = "필수 약관 여부. true면 동의해야 서비스 이용 가능", example = "true")
+        @Schema(description = "필수 약관 여부. true면 동의해야 서비스 이용 가능", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean required;
 
-        @Schema(description = "약관 버전 ID", example = "1")
+        @Schema(description = "약관 버전 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long termVersionId;
 
-        @Schema(description = "약관 버전", example = "1.0")
+        @Schema(description = "약관 버전", example = "1.0", requiredMode = Schema.RequiredMode.REQUIRED)
         private String version;
 
-        @Schema(description = "약관 효력 발생 시각")
+        @Schema(description = "약관 효력 발생 시각", requiredMode = Schema.RequiredMode.REQUIRED)
         private LocalDateTime effectiveFrom;
 
         @Schema(
                 description = "약관 본문 형식. 후보: TEXT(일반 텍스트), HTML(HTML), MARKDOWN(마크다운)",
                 example = "TEXT",
-                allowableValues = {"TEXT", "HTML", "MARKDOWN"}
+                allowableValues = {"TEXT", "HTML", "MARKDOWN"},
+                requiredMode = Schema.RequiredMode.REQUIRED
         )
         private String contentFormat;
 
-        @Schema(description = "약관 본문")
+        @Schema(description = "약관 본문", requiredMode = Schema.RequiredMode.REQUIRED)
         private String content;
     }
 
@@ -144,13 +150,14 @@ public class TermResponseDTO {
     @Schema(description = "약관 동의 제출 응답")
     public static class SubmitAgreementsResponse {
 
-        @Schema(description = "서비스 진입 전 약관 동의 화면이 필요한지 여부. false면 필수 약관 기준 서비스 진입 가능", example = "false")
+        @Schema(description = "서비스 진입 전 약관 동의 화면이 필요한지 여부. false면 필수 약관 기준 서비스 진입 가능", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean agreementRequired;
 
         @Schema(
                 description = "약관 동의 상태 사유. 후보: NONE(필요 없음), INITIAL_REQUIRED_TERMS(최초 필수 약관 동의 필요), UPDATED_REQUIRED_TERMS(개정된 필수 약관 재동의 필요), OPTIONAL_TERMS_AVAILABLE(선택 약관 동의/변경 가능)",
                 example = "NONE",
-                allowableValues = {"NONE", "INITIAL_REQUIRED_TERMS", "UPDATED_REQUIRED_TERMS", "OPTIONAL_TERMS_AVAILABLE"}
+                allowableValues = {"NONE", "INITIAL_REQUIRED_TERMS", "UPDATED_REQUIRED_TERMS", "OPTIONAL_TERMS_AVAILABLE"},
+                requiredMode = Schema.RequiredMode.REQUIRED
         )
         private String reason;
     }
@@ -162,16 +169,17 @@ public class TermResponseDTO {
     @Schema(description = "약관 동의 이력 삭제 응답")
     public static class DeleteAgreementHistoryResponse {
 
-        @Schema(description = "삭제된 사용자 약관 동의 이력 수", example = "3")
+        @Schema(description = "삭제된 사용자 약관 동의 이력 수", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long deletedCount;
 
-        @Schema(description = "삭제 후 서비스 진입 전 약관 동의 화면이 필요한지 여부", example = "true")
+        @Schema(description = "삭제 후 서비스 진입 전 약관 동의 화면이 필요한지 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         private Boolean agreementRequired;
 
         @Schema(
                 description = "삭제 후 약관 동의 상태 사유. 후보: NONE(필요 없음), INITIAL_REQUIRED_TERMS(최초 필수 약관 동의 필요), UPDATED_REQUIRED_TERMS(개정된 필수 약관 재동의 필요), OPTIONAL_TERMS_AVAILABLE(선택 약관 동의/변경 가능)",
                 example = "INITIAL_REQUIRED_TERMS",
-                allowableValues = {"NONE", "INITIAL_REQUIRED_TERMS", "UPDATED_REQUIRED_TERMS", "OPTIONAL_TERMS_AVAILABLE"}
+                allowableValues = {"NONE", "INITIAL_REQUIRED_TERMS", "UPDATED_REQUIRED_TERMS", "OPTIONAL_TERMS_AVAILABLE"},
+                requiredMode = Schema.RequiredMode.REQUIRED
         )
         private String reason;
     }

--- a/src/test/java/com/melissa/diary/service/TermAgreementServiceTest.java
+++ b/src/test/java/com/melissa/diary/service/TermAgreementServiceTest.java
@@ -174,6 +174,38 @@ class TermAgreementServiceTest {
         verify(userTermAgreementRepository, times(3)).save(any(UserTermAgreement.class));
     }
 
+    @Test
+    void deleteAgreementHistoryDeletesUserHistoryAndReturnsInitialRequiredStatus() {
+        mockCurrentTerms(List.of(serviceV1, privacyV1, marketingV1));
+        when(userTermAgreementRepository.deleteByUserId(user.getId())).thenReturn(3);
+        when(userTermAgreementRepository.findByUserIdAndTermIdIn(eq(user.getId()), anyList()))
+                .thenReturn(List.of());
+
+        TermResponseDTO.DeleteAgreementHistoryResponse response =
+                termAgreementService.deleteAgreementHistory(user.getId());
+
+        assertThat(response.getDeletedCount()).isEqualTo(3L);
+        assertThat(response.getAgreementRequired()).isTrue();
+        assertThat(response.getReason()).isEqualTo("INITIAL_REQUIRED_TERMS");
+        verify(userTermAgreementRepository).deleteByUserId(user.getId());
+    }
+
+    @Test
+    void deleteAgreementHistoryReturnsZeroWhenNoHistoryExists() {
+        mockCurrentTerms(List.of(serviceV1, privacyV1, marketingV1));
+        when(userTermAgreementRepository.deleteByUserId(user.getId())).thenReturn(0);
+        when(userTermAgreementRepository.findByUserIdAndTermIdIn(eq(user.getId()), anyList()))
+                .thenReturn(List.of());
+
+        TermResponseDTO.DeleteAgreementHistoryResponse response =
+                termAgreementService.deleteAgreementHistory(user.getId());
+
+        assertThat(response.getDeletedCount()).isZero();
+        assertThat(response.getAgreementRequired()).isTrue();
+        assertThat(response.getReason()).isEqualTo("INITIAL_REQUIRED_TERMS");
+        verify(userTermAgreementRepository).deleteByUserId(user.getId());
+    }
+
     private void mockCurrentTerms(List<TermVersion> versions) {
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
         when(termRepository.findByActiveTrueOrderByDisplayOrderAsc())


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
사용자 본인의 약관 동의 이력을 삭제하고, 삭제 직후 약관 동의 상태를 다시 계산해 반환하는 API를 추가했습니다.

프론트 generated type이 서버 응답 스펙과 맞도록 결제/약관 관련 OpenAPI DTO의 `requiredMode`와 `nullable`도 정리했습니다.

## 📋 변경 사항
- `DELETE /api/v1/terms/agreements/me` 엔드포인트 추가
- `user_term_agreement` 이력만 사용자 기준으로 삭제하는 repository 쿼리 추가
- 삭제 결과 응답 DTO 추가: `deletedCount`, `agreementRequired`, `reason`
- 삭제 후 `agreement-status`와 동일한 상태 계산 로직을 재사용하도록 service 로직 추가
- 동의 이력이 있는 경우와 없는 경우의 서비스 테스트 추가
- 약관 응답 DTO의 항상 내려오는 필드에 `requiredMode = REQUIRED` 명시
- 약관 응답 DTO의 null 가능 필드는 `requiredMode = REQUIRED, nullable = true`로 명시
- 결제/권한 응답 DTO의 항상 내려오는 필드에 `requiredMode = REQUIRED` 명시
- 결제 요청 DTO의 생략 가능 필드에 `requiredMode = NOT_REQUIRED, nullable = true` 명시

## 🔍 Code Review
- 삭제 대상은 `term`, `term_version`이 아니라 `user_term_agreement`로만 제한했습니다.
- 인증된 사용자 본인의 이력만 삭제하도록 `Principal`의 userId를 사용했습니다.
- 정식 약관 철회 기능과 섞이지 않도록 API 설명에 테스트/초기화 목적을 명시했습니다.
- OpenAPI 스펙 정리는 런타임 응답 형태를 바꾸지 않고, generated type 정확도만 보정하는 변경입니다.
- 검증:
  - `./gradlew.bat test --tests "com.melissa.diary.service.TermAgreementServiceTest"` 통과
  - `./gradlew.bat test --tests "com.melissa.diary.service.TermAgreementServiceTest" --tests "com.melissa.diary.service.payment.PaymentVerificationServiceTest" --tests "com.melissa.diary.service.EntitlementServiceTest" --tests "com.melissa.diary.service.payment.PaymentAdminRefundServiceTest"` 통과
  - `./gradlew.bat test`는 기존 `MelissaDiaryAssistantApplicationTests.contextLoads()`에서 `ENC_SECRET_KEY` placeholder 누락으로 실패

## 📸 ScreenShot
해당 없음

Closes #296